### PR TITLE
deactivate marker when timeline is in the top

### DIFF
--- a/packages/layer-composer/src/generators/vessel-events/vessel-events.ts
+++ b/packages/layer-composer/src/generators/vessel-events/vessel-events.ts
@@ -48,9 +48,7 @@ class VesselsEventsGenerator {
     }
 
     const geojson = memoizeCache[config.id].getVesselEventsGeojson(data) as FeatureCollection
-
-    let newData: FeatureCollection = { ...geojson }
-    newData = this._setActiveEvent(newData, config.currentEventId || null)
+    const newData: FeatureCollection = this._setActiveEvent(geojson, config.currentEventId || null)
 
     if (config.start && config.end) {
       const startMs = new Date(config.start).getTime()


### PR DESCRIPTION
Ticket: https://trello.com/c/N69cGbkn/161-highlighted-event-in-map-keep-selected-on-scroll-up

when I go down:
![image](https://user-images.githubusercontent.com/1672451/87705604-87ff2300-c774-11ea-8e5c-2105201aae3e.png)

When I go to the top again:
![image](https://user-images.githubusercontent.com/1672451/87705646-9c432000-c774-11ea-80b5-1c2de0fd8ed8.png)
