### PR TITLE
Use MGL worker breaks in layer-composer animated heatmap generator 

### DIFF
--- a/packages/layer-composer/src/generators/heatmap/heatmap-layers-paint.ts
+++ b/packages/layer-composer/src/generators/heatmap/heatmap-layers-paint.ts
@@ -1,4 +1,4 @@
-const baseBlobIntensity = 0.0003
+const baseBlobIntensity = 0.5
 
 // TODO this must vary *within* on zoom level
 // TODO also depends on grid size

--- a/packages/layer-composer/src/generators/heatmap/util/time-chunks.ts
+++ b/packages/layer-composer/src/generators/heatmap/util/time-chunks.ts
@@ -160,8 +160,6 @@ export const getActiveTimeChunks = (
   const delta = +toDT(activeEnd) - +toDT(activeStart)
   const interval = getInterval(delta)
 
-  console.log(interval)
-
   // ignore any start/end time chunk calculation as for the '10 days' interval the entire tileset is loaded
   if (interval === '10days') {
     return [


### PR DESCRIPTION
- sends value breaks to MGL worker --> see https://github.com/GlobalFishingWatch/mapbox-gl-js/pull/77
- use a `step` expression instead of `interpolate`ing values
- use a `coalesce` expression instead of `to-number`, which more elegantly sets the default value in case of nulls