### PR TITLE
restore pow scale for cvp use case

### DIFF
--- a/.changeset/popular-zebras-tickle.md
+++ b/.changeset/popular-zebras-tickle.md
@@ -1,0 +1,5 @@
+---
+'@globalfishingwatch/layer-composer': minor
+---
+
+pow scale exponent option to heatmap generator

--- a/packages/layer-composer/src/generators/heatmap/heatmap.ts
+++ b/packages/layer-composer/src/generators/heatmap/heatmap.ts
@@ -1,6 +1,6 @@
 import flatten from 'lodash/flatten'
 import zip from 'lodash/zip'
-import { scaleLinear } from 'd3-scale'
+import { scalePow } from 'd3-scale'
 import memoizeOne from 'memoize-one'
 import { Group } from '../../types'
 import { Type, HeatmapGeneratorConfig, GlobalGeneratorConfig } from '../types'
@@ -62,6 +62,7 @@ class HeatmapGenerator {
   _getHeatmapLayers = (config: GlobalHeatmapGeneratorConfig) => {
     const geomType = config.geomType || HEATMAP_GEOM_TYPES.GRIDDED
     const colorRampType = config.colorRamp || 'presence'
+    const scalePowExponent = config.scalePowExponent || 1
 
     let stops: number[] = []
     const zoom = Math.min(Math.floor(config.zoom), config.maxZoom || HEATMAP_DEFAULT_MAX_ZOOM)
@@ -72,7 +73,10 @@ class HeatmapGenerator {
       const { min, max, avg } = statsByZoom
       if (min && max && avg) {
         const roundedMax = this._roundNumber(max)
-        const scale = scaleLinear().domain([0, 0.5, 1]).range([min, avg, roundedMax])
+        const scale = scalePow()
+          .exponent(scalePowExponent)
+          .domain([0, 0.5, 1])
+          .range([min, avg, roundedMax])
 
         stops = [0, min, scale(0.25), scale(0.5), scale(0.75), roundedMax]
 

--- a/packages/layer-composer/src/generators/types.ts
+++ b/packages/layer-composer/src/generators/types.ts
@@ -165,6 +165,7 @@ export interface HeatmapGeneratorConfig extends GeneratorConfig {
   steps?: number[]
   tilesUrl: string
   statsUrl?: string
+  scalePowExponent?: number
   fetchStats?: boolean
   statsFilter?: string
   geomType?: Geoms


### PR DESCRIPTION
Restore use case for carrier portal when pow scale is needed, to keep compatibility with both use cases the exponent by default is 1