### PR TITLE
Resources slice

### DIFF
--- a/applications/fishing-map/src/App.tsx
+++ b/applications/fishing-map/src/App.tsx
@@ -6,6 +6,8 @@ import Spinner from '@globalfishingwatch/ui-components/dist/spinner'
 import Menu from '@globalfishingwatch/ui-components/dist/menu'
 import { MapboxRefProvider } from 'features/map/map.context'
 import { fetchWorkspaceThunk, selectWorkspaceStatus } from 'features/workspace/workspace.slice'
+import { selectDataviewsResourceQueries } from 'features/workspace/workspace.selectors'
+import { fetchResourceThunk } from 'features/resources/resources.slice'
 import menuBgImage from 'assets/images/menubg.jpg'
 import Login from './features/user/Login'
 import Map from './features/map/Map'
@@ -43,6 +45,15 @@ function App(): React.ReactElement {
       dispatch(fetchWorkspaceThunk())
     }
   }, [dispatch, logged])
+
+  const resourceQueries = useSelector(selectDataviewsResourceQueries)
+  useEffect(() => {
+    if (workspaceStatus === AsyncReducerStatus.Finished) {
+      resourceQueries.forEach((resourceQuery) => {
+        dispatch(fetchResourceThunk(resourceQuery))
+      })
+    }
+  }, [dispatch, workspaceStatus, resourceQueries])
 
   return (
     <Fragment>

--- a/applications/fishing-map/src/App.tsx
+++ b/applications/fishing-map/src/App.tsx
@@ -1,5 +1,6 @@
 import React, { memo, useState, Fragment, useEffect, useCallback } from 'react'
 import { useSelector, useDispatch } from 'react-redux'
+import { AsyncReducerStatus } from 'types'
 import SplitView from '@globalfishingwatch/ui-components/dist/split-view'
 import Spinner from '@globalfishingwatch/ui-components/dist/spinner'
 import Menu from '@globalfishingwatch/ui-components/dist/menu'
@@ -46,7 +47,7 @@ function App(): React.ReactElement {
   return (
     <Fragment>
       <Login />
-      {!logged || workspaceStatus !== 'finished' ? (
+      {!logged || workspaceStatus !== AsyncReducerStatus.Finished ? (
         <div className={styles.placeholder}>
           <Spinner />
         </div>

--- a/applications/fishing-map/src/features/map/Map.tsx
+++ b/applications/fishing-map/src/features/map/Map.tsx
@@ -1,13 +1,8 @@
-import React, { useCallback, useEffect, useState, useMemo } from 'react'
+import React, { useCallback, useEffect, useState } from 'react'
 import { MiniGlobe, IconButton, MiniglobeBounds } from '@globalfishingwatch/ui-components'
 import { InteractiveMap, ScaleControl, MapRequest } from '@globalfishingwatch/react-map-gl'
 import GFWAPI from '@globalfishingwatch/api-client'
 import useLayerComposer from '@globalfishingwatch/react-hooks/dist/use-layer-composer'
-import {
-  AnyGeneratorConfig,
-  TrackGeneratorConfig,
-} from '@globalfishingwatch/layer-composer/dist/generators/types'
-import { trackValueArrayToSegments, Field, Segment } from '@globalfishingwatch/data-transforms'
 import { useGeneratorsConnect, useViewport } from './map.hooks'
 import { useMapboxRef } from './map.context'
 import styles from './Map.module.css'
@@ -67,35 +62,9 @@ const Map = (): React.ReactElement => {
     [token]
   )
 
-  const [track, setTrack] = useState<Segment[] | null>(null)
-  useEffect(() => {
-    const fields = [Field.lonlat, Field.timestamp, Field.speed, Field.fishing]
-    GFWAPI.fetch(
-      `https://gateway.api.dev.globalfishingwatch.org/datasets/fishing/vessels/00ba29183-3b86-9e36-cf20-ee340e409521/tracks?startDate=2017-01-01T00:00:00.000Z&endDate=2020-09-14T18:31:59.567Z&fields=${fields}&wrapLongitudes=false&format=valueArray`
-      // &binary=true &format=valueArray
-    )
-      // .then((r) => r.json())
-      .then((data) => {
-        const segments = trackValueArrayToSegments(data as any, fields)
-        setTrack(segments)
-      })
-  }, [])
-
-  const generatorsConfigWithTrack = useMemo<AnyGeneratorConfig[]>(() => {
-    const genConfigs = [...generatorsConfig]
-    const trackAt = genConfigs.findIndex((generator) => generator.id === 'TRACK_2_SOME_UNIQUE_ID')
-    const oldTrackGenerator = genConfigs[trackAt] as TrackGeneratorConfig
-    const trackGenerator: TrackGeneratorConfig = {
-      ...oldTrackGenerator,
-      data: track,
-    }
-    genConfigs[trackAt] = trackGenerator
-    return genConfigs
-  }, [track, generatorsConfig])
-
   // useLayerComposer is a convenience hook to easily generate a Mapbox GL style (see https://docs.mapbox.com/mapbox-gl-js/style-spec/) from
   // the generatorsConfig (ie the map "layers") and the global configuration
-  const { style } = useLayerComposer(generatorsConfigWithTrack, globalConfig)
+  const { style } = useLayerComposer(generatorsConfig, globalConfig)
 
   return (
     <div className={styles.container}>

--- a/applications/fishing-map/src/features/resources/resources.slice.ts
+++ b/applications/fishing-map/src/features/resources/resources.slice.ts
@@ -1,0 +1,69 @@
+import { createSlice, createAsyncThunk } from '@reduxjs/toolkit'
+import { AsyncReducerStatus } from 'types'
+import { RootState } from 'store'
+import { trackValueArrayToSegments, Field } from '@globalfishingwatch/data-transforms'
+import GFWAPI from '@globalfishingwatch/api-client'
+import { DataviewDatasetConfig, DatasetTypes } from '@globalfishingwatch/dataviews-client'
+
+export interface ResourceQuery {
+  url: string
+  dataviewId: number
+  datasetConfig: DataviewDatasetConfig
+  datasetType: DatasetTypes
+}
+
+export interface Resource extends ResourceQuery {
+  data: unknown
+}
+
+interface ResourcesState {
+  status: AsyncReducerStatus
+  resources: Record<string, Resource>
+}
+
+const initialState: ResourcesState = {
+  status: AsyncReducerStatus.Idle,
+  resources: {},
+}
+
+export const fetchResourceThunk = createAsyncThunk(
+  'resources/fetch',
+  async (resource: ResourceQuery) => {
+    const data = await GFWAPI.fetch(resource.url).then((data) => {
+      // TODO Replace with enum?
+      if (resource.datasetType === 'carriers-tracks:v1') {
+        const fields = (resource.datasetConfig.query?.find((q) => q.id === 'fields')
+          ?.value as string).split(',') as Field[]
+        const segments = trackValueArrayToSegments(data as any, fields)
+        return segments
+      }
+      return data
+    })
+    return {
+      ...resource,
+      data,
+    }
+  }
+)
+
+const resourcesSlice = createSlice({
+  name: 'resources',
+  initialState,
+  reducers: {},
+  extraReducers: (builder) => {
+    builder.addCase(fetchResourceThunk.pending, (state) => {
+      state.status = AsyncReducerStatus.Loading
+    })
+    builder.addCase(fetchResourceThunk.fulfilled, (state, action) => {
+      state.status = AsyncReducerStatus.Finished
+      state.resources[action.payload.url] = action.payload
+    })
+    builder.addCase(fetchResourceThunk.rejected, (state) => {
+      state.status = AsyncReducerStatus.Error
+    })
+  },
+})
+
+export const selectResources = (state: RootState) => state.resources.resources
+
+export default resourcesSlice.reducer

--- a/applications/fishing-map/src/features/search/search.slice.ts
+++ b/applications/fishing-map/src/features/search/search.slice.ts
@@ -9,7 +9,7 @@ interface UserState {
 }
 
 const initialState: UserState = {
-  status: 'idle',
+  status: AsyncReducerStatus.Idle,
   data: null,
 }
 
@@ -30,14 +30,14 @@ const searchSlice = createSlice({
   },
   extraReducers: (builder) => {
     builder.addCase(fetchVesselSearchThunk.pending, (state) => {
-      state.status = 'loading'
+      state.status = AsyncReducerStatus.Loading
     })
     builder.addCase(fetchVesselSearchThunk.fulfilled, (state, action) => {
-      state.status = 'finished'
+      state.status = AsyncReducerStatus.Finished
       state.data = action.payload
     })
     builder.addCase(fetchVesselSearchThunk.rejected, (state) => {
-      state.status = 'error'
+      state.status = AsyncReducerStatus.Error
     })
   },
 })

--- a/applications/fishing-map/src/features/user/user.slice.ts
+++ b/applications/fishing-map/src/features/user/user.slice.ts
@@ -15,7 +15,7 @@ interface UserState {
 
 const initialState: UserState = {
   logged: false,
-  status: 'idle',
+  status: AsyncReducerStatus.Idle,
   data: null,
 }
 
@@ -39,15 +39,15 @@ const userSlice = createSlice({
   reducers: {},
   extraReducers: (builder) => {
     builder.addCase(fetchUserThunk.pending, (state) => {
-      state.status = 'loading'
+      state.status = AsyncReducerStatus.Loading
     })
     builder.addCase(fetchUserThunk.fulfilled, (state, action) => {
-      state.status = 'finished'
+      state.status = AsyncReducerStatus.Finished
       state.logged = true
       state.data = action.payload
     })
     builder.addCase(fetchUserThunk.rejected, (state) => {
-      state.status = 'error'
+      state.status = AsyncReducerStatus.Error
     })
     builder.addCase(logoutUserThunk.fulfilled, (state) => {
       state.logged = false

--- a/applications/fishing-map/src/features/workspace/workspace.mock.ts
+++ b/applications/fishing-map/src/features/workspace/workspace.mock.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/camelcase */
 import { Workspace } from '@globalfishingwatch/dataviews-client'
 import { Generators } from '@globalfishingwatch/layer-composer'
+import { Field } from '@globalfishingwatch/data-transforms'
 
 const workspace: Workspace = {
   id: 1,
@@ -527,6 +528,71 @@ const workspace: Workspace = {
         type: Generators.Type.Track,
         color: 'red',
       },
+      datasetsConfig: {
+        'carriers-tracks:v20200507': {
+          params: [{ id: 'vesselId', value: 'TODO set that correctly' }],
+          query: [
+            // { id: 'binary', value: false },
+            { id: 'wrapLongitudes', value: false },
+            {
+              id: 'fields',
+              value: [Field.lonlat, Field.timestamp, Field.speed, Field.fishing].join(','),
+            },
+            {
+              id: 'format',
+              value: 'valueArray',
+            },
+          ],
+          endpoint: 'carriers-tracks',
+        },
+      },
+      datasets: [
+        {
+          alias: null,
+          id: 'carriers-tracks:v20200507',
+          name: 'carriers-tracks:v20200507',
+          type: 'carriers-tracks:v1',
+          description: 'test dataset',
+          status: 'done',
+          ownerId: 46,
+          ownerType: 'user',
+          configuration: { table: 'carriers_v20200507_tracks' },
+          createdAt: '2020-09-25T14:40:24.004Z',
+          relatedDatasets: null,
+          endpoints: [
+            {
+              id: 'carriers-tracks',
+              description: 'Endpoint to retrieve vessel track',
+              downloadable: true,
+              // TODO Why is it {{id}} in pathTemplate and then 'vesselId' in params???
+              pathTemplate: '/v1/vessels/{{id}}/tracks',
+              params: [{ label: 'vessel id', id: 'vesselId', type: 'string' }],
+              query: [
+                { label: 'Datasets', id: 'datasets', type: 'string', required: true },
+                { label: 'start date', id: 'startDate', type: 'Date ISO', required: false },
+                { label: 'end date', id: 'endDate', type: 'Date ISO', required: false },
+                { label: 'binary', id: 'binary', type: 'boolean', default: true },
+                { label: 'wrapLongitudes', id: 'wrapLongitudes', type: 'boolean', default: false },
+                {
+                  label: 'fields',
+                  id: 'fields',
+                  type: 'enum',
+                  enum: ['lat', 'lon', 'timestamp', 'speed', 'course'],
+                },
+                {
+                  label: 'format',
+                  id: 'format',
+                  type: 'enum',
+                  values: ['point', 'lines', 'valueArray'],
+                  default: 'lines',
+                  description:
+                    'Specific encoding format to use for the track. Possible values lines, points or valueArray. valueArray: is a custom compact format, an array with all the fields serialized. The format is further explained in this issue: valueArray format. lines: Geojson with a single LineString feature containing all the points in the track points: Geojson with a FeatureCollection containing a Point feature for every point in the track',
+                },
+              ],
+            },
+          ],
+        },
+      ],
     },
   ],
   dataviewsConfig: {

--- a/applications/fishing-map/src/features/workspace/workspace.mock.ts
+++ b/applications/fishing-map/src/features/workspace/workspace.mock.ts
@@ -530,7 +530,7 @@ const workspace: Workspace = {
       },
       datasetsConfig: {
         'carriers-tracks:v20200507': {
-          params: [{ id: 'vesselId', value: 'TODO set that correctly' }],
+          params: [{ id: 'vesselId', value: '00ba29183-3b86-9e36-cf20-ee340e409521' }],
           query: [
             // { id: 'binary', value: false },
             { id: 'wrapLongitudes', value: false },
@@ -565,7 +565,8 @@ const workspace: Workspace = {
               description: 'Endpoint to retrieve vessel track',
               downloadable: true,
               // TODO Why is it {{id}} in pathTemplate and then 'vesselId' in params???
-              pathTemplate: '/v1/vessels/{{id}}/tracks',
+              // pathTemplate: '/v1/vessels/{{id}}/tracks',
+              pathTemplate: '/datasets/fishing/vessels/{{vesselId}}/tracks',
               params: [{ label: 'vessel id', id: 'vesselId', type: 'string' }],
               query: [
                 { label: 'Datasets', id: 'datasets', type: 'string', required: true },

--- a/applications/fishing-map/src/features/workspace/workspace.selectors.ts
+++ b/applications/fishing-map/src/features/workspace/workspace.selectors.ts
@@ -2,6 +2,7 @@ import { createSelector } from '@reduxjs/toolkit'
 import { Generators } from '@globalfishingwatch/layer-composer'
 import { Dataview } from '@globalfishingwatch/dataviews-client'
 import { selectWorkspace } from 'features/workspace/workspace.slice'
+import { ResourceQuery } from 'features/resources/resources.slice'
 
 export const getDatasetsByDataview = (dataview: Dataview) =>
   Object.entries(dataview.datasetsConfig || {}).flatMap(([id, value]) => {
@@ -34,3 +35,50 @@ export const selectFishingDatasets = createSelector([selectFishingDataviews], (d
 
   return dataviews.flatMap((dataview) => getDatasetsByDataview(dataview))
 })
+
+export const selectDataviewsResourceQueries = createSelector(
+  [selectWorkspaceDataviews],
+  (dataviews) => {
+    if (!dataviews) return []
+    const resourceQueries: ResourceQuery[] = dataviews.flatMap((dataview) => {
+      if (dataview.config.type !== Generators.Type.Track) return []
+
+      // TODO should come from search or 4wings cell - not sure how to get that when set in a workspace?
+      const DATASET_ID = 'carriers-tracks:v20200507'
+      const dataset = dataview.datasets?.find((dataset) => dataset.id === DATASET_ID)
+      const datasetConfig = dataview.datasetsConfig && dataview.datasetsConfig[DATASET_ID]
+      if (!dataset || !datasetConfig) return []
+
+      const endpoint = dataset.endpoints?.find((endpoint) => endpoint.id === datasetConfig.endpoint)
+
+      if (!endpoint) return []
+
+      const template = endpoint.pathTemplate
+
+      // TODO SET PARAMS This is adhoc for tracks, we need something more generic
+      const param = datasetConfig.params.find((param) => param.id === 'vesselId')
+      let url = template.replace('{{id}}', param!.value as string)
+
+      if (datasetConfig.query) {
+        const resolvedQuery = new URLSearchParams()
+        datasetConfig.query.forEach((query) => {
+          resolvedQuery.set(query.id, query.value.toString())
+        })
+        // TODO Stop using hardcoded value
+        url = `/datasets/fishing/vessels/00ba29183-3b86-9e36-cf20-ee340e409521/tracks?${decodeURI(
+          resolvedQuery.toString()
+        )}`
+        // url = `${url}/${resolvedQuery.toString()}`
+      }
+
+      return {
+        dataviewId: dataview.id,
+        datasetType: dataset.type,
+        datasetConfig,
+        url,
+      }
+    })
+
+    return resourceQueries
+  }
+)

--- a/applications/fishing-map/src/features/workspace/workspace.selectors.ts
+++ b/applications/fishing-map/src/features/workspace/workspace.selectors.ts
@@ -1,6 +1,6 @@
 import { createSelector } from '@reduxjs/toolkit'
 import { Generators } from '@globalfishingwatch/layer-composer'
-import { Dataview } from '@globalfishingwatch/dataviews-client'
+import { Dataview, resolveEndpoint } from '@globalfishingwatch/dataviews-client'
 import { selectWorkspace } from 'features/workspace/workspace.slice'
 import { ResourceQuery } from 'features/resources/resources.slice'
 
@@ -46,30 +46,11 @@ export const selectDataviewsResourceQueries = createSelector(
       // TODO should come from search or 4wings cell - not sure how to get that when set in a workspace?
       const DATASET_ID = 'carriers-tracks:v20200507'
       const dataset = dataview.datasets?.find((dataset) => dataset.id === DATASET_ID)
-      const datasetConfig = dataview.datasetsConfig && dataview.datasetsConfig[DATASET_ID]
-      if (!dataset || !datasetConfig) return []
-
-      const endpoint = dataset.endpoints?.find((endpoint) => endpoint.id === datasetConfig.endpoint)
-
-      if (!endpoint) return []
-
-      const template = endpoint.pathTemplate
-
-      // TODO SET PARAMS This is adhoc for tracks, we need something more generic
-      const param = datasetConfig.params.find((param) => param.id === 'vesselId')
-      let url = template.replace('{{id}}', param!.value as string)
-
-      if (datasetConfig.query) {
-        const resolvedQuery = new URLSearchParams()
-        datasetConfig.query.forEach((query) => {
-          resolvedQuery.set(query.id, query.value.toString())
-        })
-        // TODO Stop using hardcoded value
-        url = `/datasets/fishing/vessels/00ba29183-3b86-9e36-cf20-ee340e409521/tracks?${decodeURI(
-          resolvedQuery.toString()
-        )}`
-        // url = `${url}/${resolvedQuery.toString()}`
-      }
+      if (!dataset) return []
+      const datasetConfig = dataview.datasetsConfig && dataview.datasetsConfig[dataset.id]
+      if (!datasetConfig) return []
+      const url = resolveEndpoint(dataset, datasetConfig)
+      if (!url) return []
 
       return {
         dataviewId: dataview.id,

--- a/applications/fishing-map/src/features/workspace/workspace.slice.ts
+++ b/applications/fishing-map/src/features/workspace/workspace.slice.ts
@@ -11,7 +11,7 @@ interface UserState {
 }
 
 const initialState: UserState = {
-  status: 'idle',
+  status: AsyncReducerStatus.Idle,
   data: null,
 }
 
@@ -26,14 +26,14 @@ const workspaceSlice = createSlice({
   reducers: {},
   extraReducers: (builder) => {
     builder.addCase(fetchWorkspaceThunk.pending, (state) => {
-      state.status = 'loading'
+      state.status = AsyncReducerStatus.Loading
     })
     builder.addCase(fetchWorkspaceThunk.fulfilled, (state, action) => {
-      state.status = 'finished'
+      state.status = AsyncReducerStatus.Finished
       state.data = action.payload
     })
     builder.addCase(fetchWorkspaceThunk.rejected, (state) => {
-      state.status = 'error'
+      state.status = AsyncReducerStatus.Error
     })
   },
 })

--- a/applications/fishing-map/src/store.ts
+++ b/applications/fishing-map/src/store.ts
@@ -41,6 +41,22 @@ const defaultMiddlewareOptions: any = {
 }
 
 const store = configureStore({
+  devTools: {
+    stateSanitizer: (state: any) => {
+      if (!state.resources?.resources) return state
+      const serializedResources = Object.entries(
+        state.resources.resources
+      ).map(([key, value]: any) => [key, { ...value, data: 'NOT_SERIALIZED' }])
+
+      return {
+        ...state,
+        resources: {
+          ...state.resources,
+          resources: Object.fromEntries(serializedResources),
+        },
+      }
+    },
+  },
   reducer: rootReducer,
   middleware: [
     ...getDefaultMiddleware(defaultMiddlewareOptions),

--- a/applications/fishing-map/src/store.ts
+++ b/applications/fishing-map/src/store.ts
@@ -8,7 +8,7 @@ import {
 import connectedRoutes, { routerQueryMiddleware } from './routes/routes'
 import userReducer from './features/user/user.slice'
 import workspaceReducer from './features/workspace/workspace.slice'
-// import resourcesReducer from './features/resources/resources.slice'
+import resourcesReducer from './features/resources/resources.slice'
 import searchReducer from './features/search/search.slice'
 import timebarReducer from './features/timebar/timebar.slice'
 
@@ -23,7 +23,7 @@ const rootReducer = combineReducers({
   user: userReducer,
   search: searchReducer,
   workspace: workspaceReducer,
-  // resources: resourcesReducer,
+  resources: resourcesReducer,
   timebar: timebarReducer,
   location: location,
 })
@@ -32,7 +32,12 @@ const rootReducer = combineReducers({
 const defaultMiddlewareOptions: any = {
   // Fix issue with Redux-first-router and RTK (https://stackoverflow.com/questions/59773345/react-toolkit-and-redux-first-router)
   serializableCheck: false,
-  immutableCheck: {},
+  immutableCheck: {
+    ignoredPaths: [
+      // Too big to check for immutability:
+      'resources',
+    ],
+  },
 }
 
 const store = configureStore({

--- a/applications/fishing-map/src/store.ts
+++ b/applications/fishing-map/src/store.ts
@@ -8,6 +8,7 @@ import {
 import connectedRoutes, { routerQueryMiddleware } from './routes/routes'
 import userReducer from './features/user/user.slice'
 import workspaceReducer from './features/workspace/workspace.slice'
+// import resourcesReducer from './features/resources/resources.slice'
 import searchReducer from './features/search/search.slice'
 import timebarReducer from './features/timebar/timebar.slice'
 
@@ -22,6 +23,7 @@ const rootReducer = combineReducers({
   user: userReducer,
   search: searchReducer,
   workspace: workspaceReducer,
+  // resources: resourcesReducer,
   timebar: timebarReducer,
   location: location,
 })

--- a/applications/fishing-map/src/types/index.ts
+++ b/applications/fishing-map/src/types/index.ts
@@ -25,4 +25,9 @@ export type MapCoordinates = {
   zoom: number
 }
 
-export type AsyncReducerStatus = 'idle' | 'loading' | 'finished' | 'error'
+export enum AsyncReducerStatus {
+  Idle = 'idle',
+  Loading = 'loading',
+  Finished = 'finished',
+  Error = 'error',
+}

--- a/packages/dataviews-client/src/index.ts
+++ b/packages/dataviews-client/src/index.ts
@@ -1,5 +1,6 @@
 export { default } from './dataviews-client'
 export { default as resolveDataviews } from './resolve-dataviews'
+export { default as resolveEndpoint } from './resolve-endpoint'
 export type {
   Endpoint,
   EndpointParam,

--- a/packages/dataviews-client/src/resolve-endpoint.ts
+++ b/packages/dataviews-client/src/resolve-endpoint.ts
@@ -1,0 +1,25 @@
+import { Dataset, DataviewDatasetConfig } from './types'
+
+// Generates an URL by interpolating a dataset endpoint template with a dataview datasetConfig
+export default (dataset: Dataset, datasetConfig: DataviewDatasetConfig) => {
+  const endpoint = dataset.endpoints?.find((endpoint) => endpoint.id === datasetConfig.endpoint)
+
+  if (!endpoint) return null
+
+  const template = endpoint.pathTemplate
+
+  let url = template
+  datasetConfig.params.forEach((param) => {
+    url = template.replace(`{{${param.id}}}`, param.value as string)
+  })
+
+  if (datasetConfig.query) {
+    const resolvedQuery = new URLSearchParams()
+    datasetConfig.query.forEach((query) => {
+      resolvedQuery.set(query.id, query.value.toString())
+    })
+    url = `${url}?${resolvedQuery.toString()}`
+  }
+
+  return url
+}

--- a/packages/dataviews-client/src/types.ts
+++ b/packages/dataviews-client/src/types.ts
@@ -10,6 +10,7 @@ export interface EndpointParam {
   enum?: string[]
   default?: string | boolean | number
   required?: boolean
+  values?: any
 }
 
 export interface Endpoint {
@@ -48,16 +49,16 @@ export interface Dataset {
   alias: string[] | null
   name: string
   description: string
-  category: string
-  subcategory: string
-  source: string
+  category?: string
+  subcategory?: string
+  source?: string
   status: DatasetStatus
-  importLogs: string
-  unit: string
+  importLogs?: string
+  unit?: string
   ownerType: string
   ownerId: number
-  startDate: string
-  endDate: string
+  startDate?: string
+  endDate?: string
   createdAt: string
   endpoints?: Endpoint[]
   configuration: DatasetConfiguration | null


### PR DESCRIPTION
Adds a simple Resources slice where resources are indexed by URL.
The URLs of resources are resolved by the `selectDataviewsResourceQueries` selector using the dataview, its dataset and its datasetParams.
 
Nevertheless, ATM the track URL is still hardcoded because I have no dataset id and no vessel id yet to use.

Also, I have changed AsyncReducerStatus to a TS enum, which I think which should start to use by default rather than loose `'foo' | 'bar'` string types.