### PR TITLE
Workspace id path

### DIFF
--- a/applications/fishing-map/src/App.tsx
+++ b/applications/fishing-map/src/App.tsx
@@ -9,9 +9,10 @@ import { MapboxRefProvider } from 'features/map/map.context'
 import { fetchWorkspaceThunk, selectWorkspaceStatus } from 'features/workspace/workspace.slice'
 import { selectDataviewsResourceQueries } from 'features/workspace/workspace.selectors'
 import { fetchResourceThunk } from 'features/resources/resources.slice'
-import { selectWorkspaceId } from 'routes/routes.selectors'
+import { selectWorkspaceId, selectSidebarOpen } from 'routes/routes.selectors'
 import menuBgImage from 'assets/images/menubg.jpg'
 import { selectActive, toggleDebugMenu } from 'features/debug/debug.slice'
+import { useLocationConnect } from 'routes/routes.hook'
 import DebugMenu from './features/debug/DebugMenu'
 import Login from './features/user/Login'
 import Map from './features/map/Map'
@@ -30,7 +31,8 @@ const Main = memo(() => (
 
 function App(): React.ReactElement {
   const dispatch = useDispatch()
-  const [sidebarOpen, setSidebarOpen] = useState(true)
+  const sidebarOpen = useSelector(selectSidebarOpen)
+  const { dispatchQueryParams } = useLocationConnect()
   const [menuOpen, setMenuOpen] = useState(false)
   const logged = useSelector(isUserLogged)
   const workspaceId = useSelector(selectWorkspaceId)
@@ -50,7 +52,7 @@ function App(): React.ReactElement {
   const debugActive = useSelector(selectActive)
 
   const onToggle = () => {
-    setSidebarOpen(!sidebarOpen)
+    dispatchQueryParams({ sidebarOpen: !sidebarOpen })
   }
 
   const onMenuClick = useCallback(() => {

--- a/applications/fishing-map/src/App.tsx
+++ b/applications/fishing-map/src/App.tsx
@@ -9,6 +9,7 @@ import { MapboxRefProvider } from 'features/map/map.context'
 import { fetchWorkspaceThunk, selectWorkspaceStatus } from 'features/workspace/workspace.slice'
 import { selectDataviewsResourceQueries } from 'features/workspace/workspace.selectors'
 import { fetchResourceThunk } from 'features/resources/resources.slice'
+import { selectWorkspaceId } from 'routes/routes.selectors'
 import menuBgImage from 'assets/images/menubg.jpg'
 import { selectActive, toggleDebugMenu } from 'features/debug/debug.slice'
 import DebugMenu from './features/debug/DebugMenu'
@@ -32,6 +33,7 @@ function App(): React.ReactElement {
   const [sidebarOpen, setSidebarOpen] = useState(true)
   const [menuOpen, setMenuOpen] = useState(false)
   const logged = useSelector(isUserLogged)
+  const workspaceId = useSelector(selectWorkspaceId)
   const workspaceStatus = useSelector(selectWorkspaceStatus)
 
   useEffect(() => {
@@ -57,9 +59,9 @@ function App(): React.ReactElement {
 
   useEffect(() => {
     if (logged) {
-      dispatch(fetchWorkspaceThunk())
+      dispatch(fetchWorkspaceThunk(workspaceId))
     }
-  }, [dispatch, logged])
+  }, [dispatch, logged, workspaceId])
 
   const resourceQueries = useSelector(selectDataviewsResourceQueries)
   useEffect(() => {

--- a/applications/fishing-map/src/data/config.ts
+++ b/applications/fishing-map/src/data/config.ts
@@ -7,10 +7,13 @@ export const FALLBACK_VIEWPORT = {
   zoom: 3,
 }
 
+export const DEFAULT_WERSION = 'v1'
+
 export const DEFAULT_WORKSPACE = {
   latitude: undefined,
   longitude: undefined,
   zoom: undefined,
+  query: undefined,
   start: new Date(2019, 0, 1).toISOString(),
   end: new Date(2019, 1, 1).toISOString(),
   availableStart: new Date(2012, 0, 1).toISOString(),

--- a/applications/fishing-map/src/data/config.ts
+++ b/applications/fishing-map/src/data/config.ts
@@ -14,6 +14,7 @@ export const DEFAULT_WORKSPACE = {
   longitude: undefined,
   zoom: undefined,
   query: undefined,
+  sidebarOpen: true,
   start: new Date(2019, 0, 1).toISOString(),
   end: new Date(2019, 1, 1).toISOString(),
   availableStart: new Date(2012, 0, 1).toISOString(),

--- a/applications/fishing-map/src/features/sidebar/Sidebar.tsx
+++ b/applications/fishing-map/src/features/sidebar/Sidebar.tsx
@@ -3,9 +3,8 @@ import { useSelector, useDispatch } from 'react-redux'
 import { IconButton, Logo } from '@globalfishingwatch/ui-components'
 import { selectUserData, logoutUserThunk } from 'features/user/user.slice'
 import { selectWorkspaceStatus } from 'features/workspace/workspace.slice'
-import { useLocationConnect } from 'routes/routes.hook'
-import { SEARCH } from 'routes/routes'
 import Search from 'features/search/Search'
+import { selectSearchQuery } from 'routes/routes.selectors'
 import styles from './Sidebar.module.css'
 import HeatmapsSection from './heatmaps/HeatmapsSection'
 import VesselsSection from './vessels/VesselsSection'
@@ -54,9 +53,9 @@ function SidebarHeader({ onMenuClick }: SidebarProps) {
 
 function Sidebar({ onMenuClick }: SidebarProps) {
   const workspaceStatus = useSelector(selectWorkspaceStatus)
-  const { location } = useLocationConnect()
+  const searchQuery = useSelector(selectSearchQuery)
 
-  if (location.type === SEARCH) {
+  if (searchQuery !== undefined) {
     return <Search />
   }
 

--- a/applications/fishing-map/src/features/sidebar/vessels/VesselLayerPanel.tsx
+++ b/applications/fishing-map/src/features/sidebar/vessels/VesselLayerPanel.tsx
@@ -74,14 +74,6 @@ function LayerPanel({ dataview }: LayerPanelProps): React.ReactElement {
   }
   const expandedContainerRef = useClickedOutside(closeExpandedContainer)
 
-  if (resource?.status === AsyncReducerStatus.Loading) {
-    return (
-      <div className={cx(styles.LayerPanel)}>
-        <Spinner size="small" />
-      </div>
-    )
-  }
-
   const vesselId = datasetConfig?.params.find((p: any) => p.id === 'vesselId')?.value as string
   const title = vesselName || vesselId || dataview.name
 
@@ -112,6 +104,7 @@ function LayerPanel({ dataview }: LayerPanelProps): React.ReactElement {
           <IconButton
             icon="info"
             size="small"
+            loading={resource?.status === AsyncReducerStatus.Loading}
             className={styles.actionButton}
             tooltip="info"
             onClick={onToggleInfoOpen}

--- a/applications/fishing-map/src/features/sidebar/vessels/VesselLayerPanel.tsx
+++ b/applications/fishing-map/src/features/sidebar/vessels/VesselLayerPanel.tsx
@@ -4,7 +4,7 @@ import { UrlDataviewInstance, AsyncReducerStatus } from 'types'
 import { useSelector } from 'react-redux'
 import useClickedOutside from 'hooks/useClickedOutside'
 import { formatInfoField, formatInfoLabel } from 'utils/info'
-import { Switch, IconButton, Tooltip, Spinner, ColorBar } from '@globalfishingwatch/ui-components'
+import { Switch, IconButton, Tooltip, ColorBar } from '@globalfishingwatch/ui-components'
 import {
   ColorBarOption,
   TrackColorBarOptions,

--- a/applications/fishing-map/src/features/sidebar/vessels/VesselsSection.tsx
+++ b/applications/fishing-map/src/features/sidebar/vessels/VesselsSection.tsx
@@ -2,17 +2,16 @@ import React, { useCallback } from 'react'
 import { useSelector } from 'react-redux'
 import { IconButton } from '@globalfishingwatch/ui-components'
 import { useLocationConnect } from 'routes/routes.hook'
-import { SEARCH } from 'routes/routes'
 import { selectVesselsDataviews } from 'features/workspace/workspace.selectors'
 import styles from 'features/sidebar/common/Sections.module.css'
 import LayerPanel from './VesselLayerPanel'
 
 function VesselsSection(): React.ReactElement {
-  const { dispatchLocation } = useLocationConnect()
+  const { dispatchQueryParams } = useLocationConnect()
   const dataviews = useSelector(selectVesselsDataviews)
   const onSearchClick = useCallback(() => {
-    dispatchLocation(SEARCH)
-  }, [dispatchLocation])
+    dispatchQueryParams({ query: '' })
+  }, [dispatchQueryParams])
   return (
     <div className={styles.container}>
       <div className={styles.header}>

--- a/applications/fishing-map/src/features/workspace/workspace.slice.ts
+++ b/applications/fishing-map/src/features/workspace/workspace.slice.ts
@@ -5,6 +5,8 @@ import { Workspace } from '@globalfishingwatch/dataviews-client'
 import { fetchDatasetsByIdsThunk } from 'features/datasets/datasets.slice'
 import { fetchDataviewsByIdsThunk } from 'features/dataviews/dataviews.slice'
 import workspaceMock from './workspace.mock'
+
+// import { selectVersion } from 'routes/routes.selectors'
 // import GFWAPI from '@globalfishingwatch/api-client'
 
 interface WorkspaceState {
@@ -19,8 +21,9 @@ const initialState: WorkspaceState = {
 
 export const fetchWorkspaceThunk = createAsyncThunk(
   'workspace/fetch',
-  async (arg, { dispatch }) => {
-    // const workspace = await GFWAPI.fetch<Workspace>(`/v1/workspaces${id}`)
+  async (workspaceId: string, { dispatch, getState }) => {
+    // const version = selectVersion(getState() as RootState)
+    // const workspace = await GFWAPI.fetch<Workspace>(`/${version}/workspaces/${workspaceId}`)
     const workspace = workspaceMock
     const datasets = workspace.datasets?.map((dataset) => dataset.id as string)
     if (datasets) {
@@ -44,7 +47,9 @@ const workspaceSlice = createSlice({
     })
     builder.addCase(fetchWorkspaceThunk.fulfilled, (state, action) => {
       state.status = AsyncReducerStatus.Finished
-      state.data = action.payload
+      if (action.payload) {
+        state.data = action.payload
+      }
     })
     builder.addCase(fetchWorkspaceThunk.rejected, (state) => {
       state.status = AsyncReducerStatus.Error

--- a/applications/fishing-map/src/routes/routes.hook.ts
+++ b/applications/fishing-map/src/routes/routes.hook.ts
@@ -11,9 +11,9 @@ export const useLocationConnect = () => {
   const payload = useSelector(selectLocationPayload)
   const dispatchLocation = useCallback(
     (type: ROUTE_TYPES, customPayload: any = {}) => {
-      dispatch({ type, payload: customPayload })
+      dispatch({ type, payload: { ...payload, ...customPayload } })
     },
-    [dispatch]
+    [dispatch, payload]
   )
   const dispatchQueryParams = useCallback(
     (query: QueryParams) => {

--- a/applications/fishing-map/src/routes/routes.selectors.ts
+++ b/applications/fishing-map/src/routes/routes.selectors.ts
@@ -2,7 +2,7 @@ import { createSelector } from 'reselect'
 import { Query, RouteObject } from 'redux-first-router'
 import { RootState } from 'store'
 import { WorkspaceParam, UrlDataviewInstance } from 'types'
-import { DEFAULT_WORKSPACE } from 'data/config'
+import { DEFAULT_WORKSPACE, DEFAULT_WERSION } from 'data/config'
 import { ROUTE_TYPES } from './routes'
 
 const selectLocation = (state: RootState) => state.location
@@ -17,6 +17,14 @@ export const selectLocationQuery = createSelector(
 )
 
 export const selectLocationPayload = createSelector([selectLocation], ({ payload }) => payload)
+export const selectVersion = createSelector(
+  [selectLocationPayload],
+  (payload) => payload.version || DEFAULT_WERSION
+)
+export const selectWorkspaceId = createSelector(
+  [selectLocationPayload],
+  (payload) => payload.workspaceId
+)
 
 const selectQueryParam = <T = any>(param: WorkspaceParam) =>
   createSelector<RootState, Query, T>([selectLocationQuery], (query: any) => {
@@ -31,6 +39,7 @@ export const selectMapLatitudeQuery = selectQueryParam<number>('latitude')
 export const selectMapLongitudeQuery = selectQueryParam<number>('longitude')
 export const selectStartQuery = selectQueryParam<string>('start')
 export const selectEndQuery = selectQueryParam<string>('end')
+export const selectSearchQuery = selectQueryParam<string>('query')
 export const selectDataviewInstances = selectQueryParam<UrlDataviewInstance[]>('dataviewInstances')
 
 export const selectTimerange = createSelector([selectStartQuery, selectEndQuery], (start, end) => ({

--- a/applications/fishing-map/src/routes/routes.selectors.ts
+++ b/applications/fishing-map/src/routes/routes.selectors.ts
@@ -40,6 +40,7 @@ export const selectMapLongitudeQuery = selectQueryParam<number>('longitude')
 export const selectStartQuery = selectQueryParam<string>('start')
 export const selectEndQuery = selectQueryParam<string>('end')
 export const selectSearchQuery = selectQueryParam<string>('query')
+export const selectSidebarOpen = selectQueryParam<boolean>('sidebarOpen')
 export const selectDataviewInstances = selectQueryParam<UrlDataviewInstance[]>('dataviewInstances')
 
 export const selectTimerange = createSelector([selectStartQuery, selectEndQuery], (start, end) => ({

--- a/applications/fishing-map/src/routes/routes.ts
+++ b/applications/fishing-map/src/routes/routes.ts
@@ -8,15 +8,11 @@ import { REPLACE_URL_PARAMS } from 'data/config'
 import { UpdateQueryParamsAction } from './routes.actions'
 
 export const HOME = 'HOME'
-export const SEARCH = 'SEARCH'
-export type ROUTE_TYPES = typeof HOME | typeof SEARCH
+export type ROUTE_TYPES = typeof HOME
 
 const routesMap: RoutesMap = {
   [HOME]: {
-    path: '/',
-  },
-  [SEARCH]: {
-    path: '/search/:query?',
+    path: '/:workspaceId?/:version?',
   },
   [NOT_FOUND]: {
     path: '',

--- a/applications/fishing-map/src/store.ts
+++ b/applications/fishing-map/src/store.ts
@@ -73,6 +73,7 @@ const store = configureStore({
 })
 
 export type RootState = ReturnType<typeof store.getState>
+export type AppDispatch = typeof store.dispatch
 export type AppThunk<ReturnType = void> = ThunkAction<
   ReturnType,
   RootState,

--- a/applications/fishing-map/src/types/index.ts
+++ b/applications/fishing-map/src/types/index.ts
@@ -13,6 +13,7 @@ export type WorkspaceParam =
   | 'start'
   | 'end'
   | 'query'
+  | 'sidebarOpen'
   | 'dataviewInstances'
   | 'fishingFilters' // TODO embed in dataviewInstances config
 
@@ -23,6 +24,7 @@ export type QueryParams = {
   start?: string
   end?: string
   query?: string
+  sidebarOpen?: boolean
   dataviewInstances?: any[]
 }
 

--- a/applications/fishing-map/src/types/index.ts
+++ b/applications/fishing-map/src/types/index.ts
@@ -12,6 +12,7 @@ export type WorkspaceParam =
   | 'longitude'
   | 'start'
   | 'end'
+  | 'query'
   | 'dataviewInstances'
   | 'fishingFilters' // TODO embed in dataviewInstances config
 
@@ -21,6 +22,7 @@ export type QueryParams = {
   longitude?: number
   start?: string
   end?: string
+  query?: string
   dataviewInstances?: any[]
 }
 


### PR DESCRIPTION
Prepare routes path to support, for example, `/indonesia` using indonesia as workspace id.
Also supports API version path with `/:workspaceId/v1|v2...`

I had to remove the `/search` path as was hard to make it compatible with the workspaceId and version optional params, now is used with the `query` queryParam and also moved the sidebarOpen state to URL too

Something to notice is an easy improvement using [redux-toolkit batch](https://react-redux.js.org/api/batch) [here](https://github.com/GlobalFishingWatch/frontend/compare/workspace-id-path?expand=1#diff-0fc787fc5bdbf9885682179d3112abad8749adc32b96fd9b5f511b878b7c089eR38) to group actions dispatch and avoid multiple re-renders