### PR TITLE
Fishingmap/bugfixes

### DIFF
--- a/.changeset/kind-snails-taste.md
+++ b/.changeset/kind-snails-taste.md
@@ -1,0 +1,7 @@
+---
+"@globalfishingwatch/layer-composer": patch
+"@globalfishingwatch/timebar": patch
+"@globalfishingwatchapp/fishing-map": patch
+---
+
+Fishingmap/bugfixes

--- a/applications/fishing-map/src/features/map/Map.tsx
+++ b/applications/fishing-map/src/features/map/Map.tsx
@@ -178,6 +178,7 @@ const MapWrapper = (): React.ReactElement | null => {
     <div className={styles.container}>
       {style && (
         <InteractiveMap
+          disableTokenWarning={true}
           ref={mapRef}
           width="100%"
           height="100%"

--- a/applications/fishing-map/src/features/sidebar/heatmaps/HeatmapLayerPanel.tsx
+++ b/applications/fishing-map/src/features/sidebar/heatmaps/HeatmapLayerPanel.tsx
@@ -23,12 +23,12 @@ function LayerPanel({ dataview }: LayerPanelProps): React.ReactElement {
   const { upsertDataviewInstance, deleteDataviewInstance } = useDataviewInstancesConnect()
   const bivariate = useSelector(selectBivariate)
 
-  const layerActive = dataview?.config?.visible ?? true
+  const layerActive = bivariate ? true : dataview?.config?.visible ?? true
   const onToggleLayerActive = () => {
     upsertDataviewInstance({
       id: dataview.id,
       config: {
-        visible: !layerActive,
+        visible: bivariate ? true : !layerActive,
       },
     })
   }
@@ -67,6 +67,7 @@ function LayerPanel({ dataview }: LayerPanelProps): React.ReactElement {
           tooltip={t('layer.toggle_visibility', 'Toggle layer visibility')}
           tooltipPlacement="top"
           color={dataview.config?.color}
+          disabled={bivariate}
         />
         {datasetName.length > 24 ? (
           <Tooltip content={datasetName}>{TitleComponent}</Tooltip>

--- a/applications/fishing-map/src/features/sidebar/heatmaps/HeatmapsSection.tsx
+++ b/applications/fishing-map/src/features/sidebar/heatmaps/HeatmapsSection.tsx
@@ -2,6 +2,7 @@ import React, { useCallback } from 'react'
 import { useSelector } from 'react-redux'
 import { useTranslation } from 'react-i18next'
 import { IconButton } from '@globalfishingwatch/ui-components'
+import { Generators } from '@globalfishingwatch/layer-composer'
 import { selectTemporalgridDataviews } from 'features/workspace/workspace.selectors'
 import styles from 'features/sidebar/Sections.module.css'
 import { useDataviewInstancesConnect } from 'features/workspace/workspace.hook'
@@ -12,7 +13,7 @@ import LayerPanel from './HeatmapLayerPanel'
 function HeatmapsSection(): React.ReactElement {
   const { t } = useTranslation()
   const dataviews = useSelector(selectTemporalgridDataviews)
-  const { removeDataviewInstance } = useDataviewInstancesConnect()
+  const { removeDataviewInstance, upsertDataviewInstance } = useDataviewInstancesConnect()
   const onAddClick = useCallback(() => {
     removeDataviewInstance('fishing-1')
   }, [removeDataviewInstance])
@@ -20,7 +21,24 @@ function HeatmapsSection(): React.ReactElement {
   const { dispatchQueryParams } = useLocationConnect()
   const bivariate = useSelector(selectBivariate)
   const onToggleCombinationMode = () => {
-    dispatchQueryParams({ bivariate: !bivariate })
+    const newBivariateValue = !bivariate
+    dispatchQueryParams({ bivariate: newBivariateValue })
+    // automatically set 2 first animated heatmaps to visible
+    if (newBivariateValue) {
+      let heatmapAnimatedIndex = 0
+      dataviews?.forEach((dataview) => {
+        if (dataview.config?.type === Generators.Type.HeatmapAnimated) {
+          const visible = heatmapAnimatedIndex < 2
+          upsertDataviewInstance({
+            id: dataview.id,
+            config: {
+              visible,
+            },
+          })
+          heatmapAnimatedIndex++
+        }
+      })
+    }
   }
 
   return (

--- a/packages/layer-composer/src/generators/heatmap/util/get-legends.ts
+++ b/packages/layer-composer/src/generators/heatmap/util/get-legends.ts
@@ -57,6 +57,9 @@ export const getSublayersBreaks = (
   // TODO - generate this using updated stats API ?
   // TODO - For each sublayer a different set of breaks should be produced depending on filters
   const ramps = getSublayersColorRamps(config)
+
+  const multiplier = intervalInDays * Math.pow(1 / 4, config.zoom) * 250
+
   return config.sublayers.map((_, sublayerIndex) => {
     const sublayerColorRamp = ramps[sublayerIndex]
     const numBreaks =
@@ -65,7 +68,7 @@ export const getSublayersBreaks = (
         : sublayerColorRamp
         ? sublayerColorRamp.length
         : 6
-    return getBreaks(STATS_MIN, STATS_MAX, STATS_AVG, SCALEPOWEXPONENT, numBreaks, intervalInDays)
+    return getBreaks(STATS_MIN, STATS_MAX, STATS_AVG, SCALEPOWEXPONENT, numBreaks, multiplier)
   })
 }
 

--- a/packages/layer-composer/src/generators/heatmap/util/get-legends.ts
+++ b/packages/layer-composer/src/generators/heatmap/util/get-legends.ts
@@ -13,7 +13,7 @@ export const getSublayersColorRamps = (config: GlobalHeatmapAnimatedGeneratorCon
   // TODO We might need more flexibility on that
   if (config.mode === HeatmapAnimatedMode.Bivariate) {
     colorRampIds = ['bivariate']
-  } else if (numVisibleSublayers === 1) {
+  } else if (numVisibleSublayers === 1 && config.sublayers[0].visible) {
     colorRampIds = ['presence']
   }
   const colorRamps = colorRampIds.map((colorRampId) => {

--- a/packages/layer-composer/src/generators/heatmap/util/get-legends.ts
+++ b/packages/layer-composer/src/generators/heatmap/util/get-legends.ts
@@ -28,14 +28,12 @@ export const getColorRampBaseExpression = (config: GlobalHeatmapAnimatedGenerato
   const colorRamps = getSublayersColorRamps(config)
 
   const expressions = colorRamps.map((originalColorRamp, colorRampIndex) => {
-    const legend = [...Array(originalColorRamp.length)].map((_, bucketIndex) => [
+    const legend = [...Array(originalColorRamp.length)].flatMap((_, bucketIndex) => [
       // offset each dataset by 10 + add actual bucket value
       colorRampIndex * 10 + bucketIndex,
       originalColorRamp[bucketIndex],
     ])
-    // TODO use flatMap
-    const expr = legend.flat()
-    return expr
+    return legend
   })
 
   if (config.mode === HeatmapAnimatedMode.Compare) {

--- a/packages/timebar/src/components/timeline.js
+++ b/packages/timebar/src/components/timeline.js
@@ -63,7 +63,6 @@ class Timeline extends PureComponent {
       dragging: null,
     }
     this.graphContainer = null
-    this.isMovingInside = false
   }
 
   componentDidMount() {
@@ -204,7 +203,7 @@ class Timeline extends PureComponent {
   }
 
   onMouseMove = (event) => {
-    const { start, end, absoluteStart, absoluteEnd, onChange, onMouseLeave } = this.props
+    const { start, end, absoluteStart, absoluteEnd, onChange } = this.props
     const { dragging, outerX, innerStartPx, innerEndPx } = this.state
     const clientX = event.clientX || (event.changedTouches && event.changedTouches[0].clientX)
     if (clientX === undefined) {
@@ -213,13 +212,8 @@ class Timeline extends PureComponent {
     const x = clientX - outerX
     const isMovingInside = this.node.contains(event.target) && x > innerStartPx && x < innerEndPx
     if (isMovingInside) {
-      this.isMovingInside = true
       const isDay = !isMoreThanADay(start, end)
       this.throttledMouseMove(x, this.outerScale.invert, isDay)
-    } else if (this.isMovingInside === true) {
-      this.isMovingInside = false
-      onMouseLeave()
-      this.notifyMouseLeave()
     }
 
     const isDraggingInner = dragging === DRAG_INNER


### PR DESCRIPTION
- fixed Timebar flicker when dragging
- hide mapbox token warning
- static stats: take zoom into account
- force always have 2 sublayers in bivariate mode
- auto switch to presence ramp should not happen when 1st sublayer is not visible
