### PR TITLE
Fishingmap/other context layers

### DIFF
--- a/applications/fishing-map/public/locales/en/datasets.json
+++ b/applications/fishing-map/public/locales/en/datasets.json
@@ -10,5 +10,13 @@
   "eez-areas": {
     "name": "EEZ (Marine Regions)",
     "description": "Flanders Marine Institute (2019). Maritime Boundaries Geodatabase: Maritime Boundaries and Exclusive Economic Zones (200NM), version 11"
+  },
+  "tuna-rfmo": {
+    "name": "Tuna RFMO",
+    "description": "RFMO stands for Regional Fishery Management Organization. These organizations are international organizations formed by countries with a shared interest in managing or conserving an area’s fish stock. Some RFMOs manage all the fish stocks found in a specific area, while others focus on particular highly migratory species, notably tuna, throughout vast geographical areas. The RFMO Layer on the Global Fishing Watch map currently includes the five tuna RFMOs."
+  },
+  "wpp-nri": {
+    "name": "WPP NRI",
+    "description": "The WPP-NRI (Wilayah Pengelolaan Perikanan Negara Republik Indonesia) are fisheries management areas for fishing, conservation, research, and fisheries development which covers inland waters, archipelagic waters, territorial sea, within and outside the exclusive economic zone of Indonesia."
   }
 }

--- a/applications/fishing-map/public/locales/source/datasets.json
+++ b/applications/fishing-map/public/locales/source/datasets.json
@@ -10,5 +10,13 @@
   "eez-areas": {
     "name": "EEZ",
     "description": "Flanders Marine Institute (2019). Maritime Boundaries Geodatabase: Maritime Boundaries and Exclusive Economic Zones (200NM), version 11"
+  },
+  "tuna-rfmo": {
+    "name": "Tuna RFMO",
+    "description": "RFMO stands for Regional Fishery Management Organization. These organizations are international organizations formed by countries with a shared interest in managing or conserving an area’s fish stock. Some RFMOs manage all the fish stocks found in a specific area, while others focus on particular highly migratory species, notably tuna, throughout vast geographical areas. The RFMO Layer on the Global Fishing Watch map currently includes the five tuna RFMOs."
+  },
+  "wpp-nri": {
+    "name": "WPP NRI",
+    "description": "The WPP-NRI (Wilayah Pengelolaan Perikanan Negara Republik Indonesia) are fisheries management areas for fishing, conservation, research, and fisheries development which covers inland waters, archipelagic waters, territorial sea, within and outside the exclusive economic zone of Indonesia."
   }
 }

--- a/applications/fishing-map/src/features/map/Map.tsx
+++ b/applications/fishing-map/src/features/map/Map.tsx
@@ -115,7 +115,7 @@ const MapWrapper = (): React.ReactElement | null => {
 
   // useLayerComposer is a convenience hook to easily generate a Mapbox GL style (see https://docs.mapbox.com/mapbox-gl-js/style-spec/) from
   // the generatorsConfig (ie the map "layers") and the global configuration
-  const { style } = useLayerComposer(generatorsConfig as AnyGeneratorConfig[], globalConfig)
+  const { style } = useLayerComposer(generatorsConfig, globalConfig)
 
   const { clickedEvent, clickedEventStatus, dispatchClickedEvent } = useClickedEventConnect()
   const onMapClick = useMapClick(dispatchClickedEvent, style?.metadata as ExtendedStyleMeta)

--- a/applications/fishing-map/src/features/workspace/workspace.default.ts
+++ b/applications/fishing-map/src/features/workspace/workspace.default.ts
@@ -64,21 +64,36 @@ const workspace: Workspace = {
     //     },
     //   ],
     // },
-    // {
-    //   id: 'context-layer-1',
-    //   config: {
-    //     color: '#069688',
-    //     visible: false,
-    //   },
-    //   dataviewId: 93,
-    // },
     {
-      id: 'context-layer-1',
+      id: 'context-layer-mpa',
+      config: {
+        color: '#e5777c',
+        visible: true,
+      },
+      dataviewId: 93,
+    },
+    {
+      id: 'context-layer-rfmo',
+      config: {
+        color: '#6b67e5',
+        visible: false,
+      },
+      dataviewId: 95,
+    },
+    {
+      id: 'context-layer-eez',
       config: {
         color: '#069688',
         visible: true,
       },
       dataviewId: 94,
+    },
+    {
+      id: 'context-layer-wpp-nri',
+      config: {
+        visible: false,
+      },
+      dataviewId: 96,
     },
   ],
   dataviews: [],

--- a/packages/layer-composer/src/generators/carto-polygons/carto-polygons-layers.ts
+++ b/packages/layer-composer/src/generators/carto-polygons/carto-polygons-layers.ts
@@ -1,8 +1,7 @@
 /* eslint-disable @typescript-eslint/camelcase */
-
 import { Group } from '../../types'
 
-export default {
+const layers = {
   cp_rfmo: {
     source: {
       sql:
@@ -113,3 +112,5 @@ export default {
     ],
   },
 }
+
+export default layers

--- a/packages/layer-composer/src/generators/carto-polygons/carto-polygons.ts
+++ b/packages/layer-composer/src/generators/carto-polygons/carto-polygons.ts
@@ -141,6 +141,7 @@ class CartoPolygonsGenerator {
       }
 
       glLayer.metadata = {
+        ...config.metadata,
         interactive: true,
         generatorId: config.id,
       }

--- a/packages/layer-composer/src/generators/context/context-layers.ts
+++ b/packages/layer-composer/src/generators/context/context-layers.ts
@@ -11,49 +11,71 @@ const settledBoundaries = [
   'Unilateral claim (undisputed)',
 ]
 
+const getDefaultContexInteraction = (): Partial<Layer> => {
+  return {
+    type: 'fill',
+    paint: {
+      'fill-color': 'transparent',
+      'fill-outline-color': 'transparent',
+    },
+    layout: {},
+    metadata: {
+      interactive: true,
+      group: Group.OutlinePolygons,
+    },
+  }
+}
+
+const getDefaultContexLine = (color: string): Partial<Layer> => {
+  return {
+    type: 'line',
+    paint: {
+      'line-color': color,
+    },
+    layout: {
+      'line-cap': 'round',
+      'line-join': 'round',
+    },
+    metadata: {
+      interactive: false,
+      group: Group.OutlinePolygonsBackground,
+    },
+  }
+}
+
+const getDefaultContexLayersById = (id: string, color: string): Layer[] => {
+  return [
+    {
+      id: `${id}-interaction`,
+      ...getDefaultContexInteraction(),
+    },
+    {
+      id: `${id}-line`,
+      ...getDefaultContexLine(color),
+    },
+  ]
+}
+
 const CONTEXT_LAYERS: Record<ContextLayerType, Layer[]> = {
+  mpa: getDefaultContexLayersById('mpa', '#e5777c'),
+  'wpp-nri': getDefaultContexLayersById('wpp-nri', '#AD1457'),
+  'tuna-rfmo': getDefaultContexLayersById('tuna-rfmo', '#B39DDB'),
   'eez-areas': [
     {
       id: 'eez-base',
-      type: 'fill',
-      paint: {
-        'fill-color': 'transparent',
-        'fill-outline-color': 'transparent',
-      },
-      layout: {},
-      metadata: {
-        interactive: true,
-        group: Group.OutlinePolygonsBackground,
-      },
+      ...getDefaultContexInteraction(),
     },
   ],
   'eez-boundaries': [
     {
       id: 'eez_rest_lines',
-      type: 'line',
+      ...getDefaultContexLine('#33B679'),
       filter: ['match', ['get', 'line_type'], settledBoundaries, true, false],
-      layout: {},
-      paint: {
-        'line-color': '#93c96c',
-      },
-      metadata: {
-        interactive: false,
-        group: Group.OutlinePolygonsBackground,
-      },
     },
     {
       id: 'eez_special_lines',
-      type: 'line',
-      filter: ['match', ['get', 'line_type'], settledBoundaries, false, true],
-      layout: {},
-      paint: {
-        'line-color': '#93c96c',
-        'line-dasharray': [2, 4],
-      },
-      metadata: {
-        interactive: false,
-        group: Group.OutlinePolygonsBackground,
-      },
+      ...getDefaultContexLine('#33B679'),
+      filter: ['match', ['get', 'line_type'], settledBoundaries, true, false],
     },
   ],
 }

--- a/packages/layer-composer/src/generators/context/context-layers.ts
+++ b/packages/layer-composer/src/generators/context/context-layers.ts
@@ -11,7 +11,7 @@ const settledBoundaries = [
   'Unilateral claim (undisputed)',
 ]
 
-const getDefaultContexInteraction = (): Partial<Layer> => {
+const getDefaultContextInteraction = (): Partial<Layer> => {
   return {
     type: 'fill',
     paint: {
@@ -26,7 +26,7 @@ const getDefaultContexInteraction = (): Partial<Layer> => {
   }
 }
 
-const getDefaultContexLine = (color: string): Partial<Layer> => {
+const getDefaultContextLine = (color: string): Partial<Layer> => {
   return {
     type: 'line',
     paint: {
@@ -43,38 +43,38 @@ const getDefaultContexLine = (color: string): Partial<Layer> => {
   }
 }
 
-const getDefaultContexLayersById = (id: string, color: string): Layer[] => {
+const getDefaultContextLayersById = (id: string, color: string): Layer[] => {
   return [
     {
       id: `${id}-interaction`,
-      ...getDefaultContexInteraction(),
+      ...getDefaultContextInteraction(),
     },
     {
       id: `${id}-line`,
-      ...getDefaultContexLine(color),
+      ...getDefaultContextLine(color),
     },
   ]
 }
 
 const CONTEXT_LAYERS: Record<ContextLayerType, Layer[]> = {
-  mpa: getDefaultContexLayersById('mpa', '#e5777c'),
-  'wpp-nri': getDefaultContexLayersById('wpp-nri', '#AD1457'),
-  'tuna-rfmo': getDefaultContexLayersById('tuna-rfmo', '#B39DDB'),
+  mpa: getDefaultContextLayersById('mpa', '#e5777c'),
+  'wpp-nri': getDefaultContextLayersById('wpp-nri', '#AD1457'),
+  'tuna-rfmo': getDefaultContextLayersById('tuna-rfmo', '#B39DDB'),
   'eez-areas': [
     {
       id: 'eez-base',
-      ...getDefaultContexInteraction(),
+      ...getDefaultContextInteraction(),
     },
   ],
   'eez-boundaries': [
     {
       id: 'eez_rest_lines',
-      ...getDefaultContexLine('#33B679'),
+      ...getDefaultContextLine('#33B679'),
       filter: ['match', ['get', 'line_type'], settledBoundaries, true, false],
     },
     {
       id: 'eez_special_lines',
-      ...getDefaultContexLine('#33B679'),
+      ...getDefaultContextLine('#33B679'),
       filter: ['match', ['get', 'line_type'], settledBoundaries, true, false],
     },
   ],

--- a/packages/layer-composer/src/generators/context/context.ts
+++ b/packages/layer-composer/src/generators/context/context.ts
@@ -91,6 +91,7 @@ class ContextGenerator {
       },
     ]
   }
+
   _getStyleLayers = (config: ContextGeneratorConfig) => {
     const generatorId = `context-${config.layer}-${config.id}`
     const baseLayers = LAYERS[config.layer]

--- a/packages/layer-composer/src/generators/types.ts
+++ b/packages/layer-composer/src/generators/types.ts
@@ -255,6 +255,9 @@ export enum BasemapType {
 export enum ContextLayerType {
   EEZ = 'eez-areas',
   EEZBoundaries = 'eez-boundaries',
+  MPA = 'mpa',
+  TunaRfmo = 'tuna-rfmo',
+  WPPNRI = 'wpp-nri',
 }
 
 export type RawEvent = {

--- a/packages/layer-composer/src/transforms/sort/sort.ts
+++ b/packages/layer-composer/src/transforms/sort/sort.ts
@@ -43,16 +43,16 @@ export const convertLegacyGroups = (style: Style): ExtendedStyle => {
   return newStyle
 }
 
-const sort: StyleTransformation = (style) => {
-  const newStyle = { ...style }
-  newStyle.layers = newStyle.layers?.sort((a: ExtendedLayer, b: ExtendedLayer) => {
+const sort: StyleTransformation = (style, order = GROUP_ORDER) => {
+  const layers = style.layers ? [...style.layers] : []
+  const orderedLayers = layers.sort((a: ExtendedLayer, b: ExtendedLayer) => {
     const aGroup = a.metadata?.group || Group.Default
     const bGroup = b.metadata?.group || Group.Default
-    const aPos = GROUP_ORDER.indexOf(aGroup)
-    const bPos = GROUP_ORDER.indexOf(bGroup)
+    const aPos = order.indexOf(aGroup)
+    const bPos = order.indexOf(bGroup)
     return aPos - bPos
   })
-  return newStyle
+  return { ...style, layers: orderedLayers }
 }
 
 export default sort

--- a/packages/react-hooks/src/use-tiles-state/use-tiles-state.ts
+++ b/packages/react-hooks/src/use-tiles-state/use-tiles-state.ts
@@ -50,9 +50,10 @@ function useTilesState(map: Map) {
 
   const onLoadComplete = useCallback(
     (e: MapSourceDataEvent) => {
-      if (e.coord) {
+      // On error event coord is undefined so we nee to grab the key from the tileId
+      const key = e.coord?.canonical?.key || e.tile?.tileID?.canonical?.key
+      if (key !== undefined) {
         setTilesLoading((tilesLoading) => {
-          const { key } = e.coord.canonical
           const { [key]: currentTile, ...rest } = tilesLoading.tiles
 
           const otherTilesLoading = Object.keys(rest).length > 0
@@ -91,6 +92,7 @@ function useTilesState(map: Map) {
   useEffect(() => {
     if (map) {
       map.on('sourcedataloading', onLoad)
+      map.on('error', onLoadComplete)
       map.on('sourcedata', onLoadComplete)
       map.on('idle', onIdle)
     }


### PR DESCRIPTION
Refactor to share base config in context layers and include Tuna RFMOs and WPP NRI

Also:
- Handle error in use-tiles-state to remove the tile loading when a request fails
- Support custom order in style transformation to use if needed as for example in the labeler
