### PR TITLE
use ocean-areas library to create user friendly workspace names

### DIFF
--- a/applications/fishing-map/src/features/app/app.selectors.ts
+++ b/applications/fishing-map/src/features/app/app.selectors.ts
@@ -135,7 +135,6 @@ export const selectCustomWorkspace = createSelector(
   ): WorkspaceUpsert<WorkspaceState> => {
     return {
       ...workspace,
-      name: `user_${user?.id}_${Date.now()}`,
       app: APP_NAME,
       aoi: undefined,
       dataviews: workspace?.dataviews?.map(({ id }) => id as number),

--- a/applications/fishing-map/src/features/i18n/i18nDate.tsx
+++ b/applications/fishing-map/src/features/i18n/i18nDate.tsx
@@ -1,13 +1,20 @@
 import React, { Fragment } from 'react'
 import { DateTime, DateTimeFormatOptions } from 'luxon'
 import { useTranslation } from 'react-i18next'
+import { Locale } from 'types'
+import i18n from './i18n'
 
 type Dates = {
   date: string
   format?: DateTimeFormatOptions
 }
 
-export const formatI18nDate = (date: string, locale: string, format = DateTime.DATE_MED) => {
+type formatI18DateParams = { format?: DateTimeFormatOptions; locale?: Locale }
+
+export const formatI18nDate = (
+  date: string,
+  { format = DateTime.DATE_MED, locale = i18n.language as Locale }: formatI18DateParams = {}
+) => {
   return `${DateTime.fromISO(date).toUTC().setLocale(locale).toLocaleString(format)}${
     format === DateTime.DATETIME_MED ? ' UTC' : ''
   }`
@@ -15,7 +22,7 @@ export const formatI18nDate = (date: string, locale: string, format = DateTime.D
 
 export const useI18nDate = (date: string, format = DateTime.DATE_MED) => {
   const { i18n } = useTranslation()
-  return formatI18nDate(date, i18n.language, format)
+  return formatI18nDate(date, { format, locale: i18n.language as Locale })
 }
 
 const I18nDate = ({ date, format = DateTime.DATE_MED }: Dates) => {

--- a/applications/fishing-map/src/features/map/controls/MapInfo.tsx
+++ b/applications/fishing-map/src/features/map/controls/MapInfo.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { DateTime } from 'luxon'
+import { DateTime, DateTimeFormatOptions } from 'luxon'
 import { ScaleControl } from '@globalfishingwatch/react-map-gl'
 import { InteractionEvent } from '@globalfishingwatch/react-hooks'
 import toFixed from 'utils/toFixed'
@@ -8,12 +8,15 @@ import useViewport from 'features/map/map-viewport.hooks'
 import I18nDate from 'features/i18n/i18nDate'
 import styles from './MapInfo.module.css'
 
-const A_DAY = 1000 * 60 * 60 * 24
+export const pickDateFormatByRange = (start: string, end: string): DateTimeFormatOptions => {
+  const A_DAY = 1000 * 60 * 60 * 24
+  const timeΔ = start && end ? new Date(end).getTime() - new Date(start).getTime() : 0
+  return timeΔ < A_DAY ? DateTime.DATETIME_MED : DateTime.DATE_MED
+}
 
 export const TimelineDatesRange = () => {
   const { start, end } = useTimerangeConnect()
-  const timeΔ = start && end ? new Date(end).getTime() - new Date(start).getTime() : 0
-  const dateFormat = timeΔ < A_DAY ? DateTime.DATETIME_MED : DateTime.DATE_MED
+  const dateFormat = pickDateFormatByRange(start, end)
   if (!start || !end) return null
   return (
     <div>

--- a/packages/api-types/src/workspaces.ts
+++ b/packages/api-types/src/workspaces.ts
@@ -2,17 +2,19 @@ import { AOI, Dataview, DataviewInstance } from '.'
 
 export type ApiAppName = 'fishing-map' | 'marine-reserves'
 
+export interface WorkspaceViewport {
+  zoom: number
+  latitude: number
+  longitude: number
+}
+
 export interface Workspace<T = unknown> {
   id: string
   name: string
   app: ApiAppName
   description: string
   aoi?: AOI
-  viewport: {
-    zoom: number
-    latitude: number
-    longitude: number
-  }
+  viewport: WorkspaceViewport
   startAt: string
   endAt: string
   state?: T


### PR DESCRIPTION
from ugly `${userId}-${Date.now()}` to shiny `from_${start}_to_${end}_near_${your-area}` ✨ workspaces names