### PR TITLE
Polish 🇵🇱

### DIFF
--- a/.changeset/serious-insects-return.md
+++ b/.changeset/serious-insects-return.md
@@ -1,0 +1,6 @@
+---
+"@globalfishingwatch/ui-components": patch
+"@globalfishingwatchapp/fishing-map": patch
+---
+
+[WIP] Polish 🇵🇱

--- a/applications/fishing-map/public/locales/source/translations.json
+++ b/applications/fishing-map/public/locales/source/translations.json
@@ -8,12 +8,12 @@
     "copiedToClipboard": "The link to share this view has been copied to your clipboard",
     "hour": "Hour",
     "hour_plural": "Hours",
-    "login": "Log in",
     "logout": "Log Out",
     "more": "More",
-    "open_menu": "Open Menu",
     "share": "Click to share the current view",
     "vessel_plural": "Vessels",
+    "login": "Log in",
+    "open_menu": "Open Menu",
     "dismiss": "Dismiss",
     "save": "Save",
     "events": "Events",
@@ -24,6 +24,7 @@
   },
   "layer": {
     "add": "Add layer",
+    "addDisabled": "Adding layers is disabled when layers are combined",
     "color_change": "Change color",
     "filter_close": "Close filters",
     "filter_open": "Open filters",
@@ -50,11 +51,13 @@
     "loading": "Map loading",
     "rulers_add": "Add rulers",
     "rulers_remove": "Remove all rulers",
+    "search": "Search areas",
     "zoom_in": "Zoom in",
     "zoom_out": "Zoom out",
     "screenshot": "Map screenshot"
   },
   "search": {
+    "close": "Close search",
     "suggestion": "Did you mean"
   },
   "selects": {

--- a/applications/fishing-map/public/locales/source/translations.json
+++ b/applications/fishing-map/public/locales/source/translations.json
@@ -24,7 +24,6 @@
   },
   "layer": {
     "add": "Add layer",
-    "addDisabled": "Adding layers is disabled when layers are combined",
     "color_change": "Change color",
     "filter_close": "Close filters",
     "filter_open": "Open filters",
@@ -67,7 +66,11 @@
   "timebar": {
     "graph": "Graph",
     "settings_close": "Close timebar settings",
-    "settings_open": "Open timebar settings"
+    "settings_open": "Open timebar settings",
+    "showTracks": "Show tracks graph",
+    "showFishingEffort": "Show fishing hours graph",
+    "tracksDisabled": "Select at least one vessel",
+    "fishingEffortDisabled": "Select at least one apparent fishing effort layer"
   },
   "vessel": {
     "callsign": "Callsign",

--- a/applications/fishing-map/src/features/app/app.slice.ts
+++ b/applications/fishing-map/src/features/app/app.slice.ts
@@ -4,6 +4,7 @@ import { RootState } from 'store'
 type MapState = {
   screenshotMode: boolean
   screenshotLoading: boolean
+  heatmapSublayersAddedIndex?: number
 }
 
 const initialState: MapState = {
@@ -21,11 +22,20 @@ const slice = createSlice({
     setScreenshotLoading: (state, action: PayloadAction<boolean>) => {
       state.screenshotLoading = action.payload
     },
+    setHeatmapSublayersAddedIndex: (state, action: PayloadAction<number>) => {
+      state.heatmapSublayersAddedIndex = action.payload
+    },
   },
 })
 
 export const selectScreenshotMode = (state: RootState) => state.app.screenshotMode
 export const selectScreenshotLoading = (state: RootState) => state.app.screenshotLoading
+export const selectHeatmapSublayersAddedIndex = (state: RootState) =>
+  state.app.heatmapSublayersAddedIndex
 
-export const { setScreenshotMode, setScreenshotLoading } = slice.actions
+export const {
+  setScreenshotMode,
+  setScreenshotLoading,
+  setHeatmapSublayersAddedIndex,
+} = slice.actions
 export default slice.reducer

--- a/applications/fishing-map/src/features/app/app.slice.ts
+++ b/applications/fishing-map/src/features/app/app.slice.ts
@@ -4,7 +4,6 @@ import { RootState } from 'store'
 type MapState = {
   screenshotMode: boolean
   screenshotLoading: boolean
-  heatmapSublayersAddedIndex?: number
 }
 
 const initialState: MapState = {
@@ -22,20 +21,11 @@ const slice = createSlice({
     setScreenshotLoading: (state, action: PayloadAction<boolean>) => {
       state.screenshotLoading = action.payload
     },
-    setHeatmapSublayersAddedIndex: (state, action: PayloadAction<number>) => {
-      state.heatmapSublayersAddedIndex = action.payload
-    },
   },
 })
 
 export const selectScreenshotMode = (state: RootState) => state.app.screenshotMode
 export const selectScreenshotLoading = (state: RootState) => state.app.screenshotLoading
-export const selectHeatmapSublayersAddedIndex = (state: RootState) =>
-  state.app.heatmapSublayersAddedIndex
 
-export const {
-  setScreenshotMode,
-  setScreenshotLoading,
-  setHeatmapSublayersAddedIndex,
-} = slice.actions
+export const { setScreenshotMode, setScreenshotLoading } = slice.actions
 export default slice.reducer

--- a/applications/fishing-map/src/features/dataviews/dataviews.utils.ts
+++ b/applications/fishing-map/src/features/dataviews/dataviews.utils.ts
@@ -44,7 +44,7 @@ export const getHeatmapDataviewInstance = (
 ): DataviewInstance<Generators.Type> => {
   const notUsedOptions = HeatmapColorBarOptions.filter((option) => !usedRamps.includes(option.id))
   const colorOption = notUsedOptions?.length > 0 ? notUsedOptions[0] : HeatmapColorBarOptions[0]
-  const vesselDataviewInstance = {
+  const heatmapDataviewInstance = {
     id: `fishing-${Date.now()}`,
     config: {
       color: colorOption.value,
@@ -52,5 +52,5 @@ export const getHeatmapDataviewInstance = (
     },
     dataviewId: DEFAULT_FISHING_DATAVIEW_ID,
   }
-  return vesselDataviewInstance
+  return heatmapDataviewInstance
 }

--- a/applications/fishing-map/src/features/timebar/TimebarSettings.tsx
+++ b/applications/fishing-map/src/features/timebar/TimebarSettings.tsx
@@ -53,8 +53,6 @@ const TimebarSettings = () => {
   }
   const expandedContainerRef = useClickedOutside(closeOptions)
 
-  if (!timebarVisualisation) return null
-
   const timebarGraphEnabled = activeVesselDataviews && activeVesselDataviews?.length <= 2
   return (
     <div className={cx('print-hidden', styles.container)} ref={expandedContainerRef}>
@@ -70,21 +68,30 @@ const TimebarSettings = () => {
       />
       {optionsPanelOpen && (
         <div className={styles.optionsContainer}>
-          {activeHeatmapDataviews && activeHeatmapDataviews.length > 0 && (
+          <Radio
+            label={t('common.apparentFishing', 'Apparent Fishing Effort')}
+            active={timebarVisualisation === TimebarVisualisations.Heatmap}
+            disabled={!activeHeatmapDataviews?.length}
+            tooltip={
+              !activeHeatmapDataviews?.length
+                ? 'Select at least one apparent fishing effort layer'
+                : 'Show fishing hours graph'
+            }
+            onClick={setHeatmapActive}
+          />
+          <Fragment>
             <Radio
-              label={t('common.apparentFishing', 'Apparent Fishing Effort')}
-              active={timebarVisualisation === TimebarVisualisations.Heatmap}
-              onClick={setHeatmapActive}
+              label={t('vessel.tracks', 'Vessel Tracks')}
+              active={timebarVisualisation === TimebarVisualisations.Vessel}
+              disabled={!activeVesselDataviews?.length}
+              tooltip={
+                !activeVesselDataviews?.length ? 'Select at least one vessel' : 'Show tracks graph'
+              }
+              onClick={setVesselActive}
             />
-          )}
-          {activeVesselDataviews && activeVesselDataviews.length > 0 && (
-            <Fragment>
-              <Radio
-                label={t('vessel.tracks', 'Vessel Tracks')}
-                active={timebarVisualisation === TimebarVisualisations.Vessel}
-                onClick={setVesselActive}
-              />
-              {timebarVisualisation === TimebarVisualisations.Vessel && (
+            {timebarVisualisation === TimebarVisualisations.Vessel &&
+              activeVesselDataviews &&
+              activeVesselDataviews.length > 0 && (
                 <div className={styles.vesselTrackOptions}>
                   <Select
                     // label={t('common.events', 'Events')}
@@ -108,8 +115,7 @@ const TimebarSettings = () => {
                   )}
                 </div>
               )}
-            </Fragment>
-          )}
+          </Fragment>
         </div>
       )}
     </div>

--- a/applications/fishing-map/src/features/timebar/TimebarSettings.tsx
+++ b/applications/fishing-map/src/features/timebar/TimebarSettings.tsx
@@ -2,7 +2,9 @@ import React, { Fragment, useState } from 'react'
 import cx from 'classnames'
 import { useSelector } from 'react-redux'
 import { useTranslation } from 'react-i18next'
-import { IconButton, Radio, Select, SelectOption } from '@globalfishingwatch/ui-components/dist'
+import IconButton from '@globalfishingwatch/ui-components/dist/icon-button'
+import Radio from '@globalfishingwatch/ui-components/dist/radio'
+import Select, { SelectOption } from '@globalfishingwatch/ui-components/dist/select'
 import useClickedOutside from 'hooks/use-clicked-outside'
 import { TimebarEvents, TimebarGraphs, TimebarVisualisations } from 'types'
 import {
@@ -74,8 +76,11 @@ const TimebarSettings = () => {
             disabled={!activeHeatmapDataviews?.length}
             tooltip={
               !activeHeatmapDataviews?.length
-                ? 'Select at least one apparent fishing effort layer'
-                : 'Show fishing hours graph'
+                ? t(
+                    'timebar.fishingEffortDisabled',
+                    'Select at least one apparent fishing effort layer'
+                  )
+                : t('timebar.showFishingEffort', 'Show fishing hours graph')
             }
             onClick={setHeatmapActive}
           />
@@ -85,7 +90,9 @@ const TimebarSettings = () => {
               active={timebarVisualisation === TimebarVisualisations.Vessel}
               disabled={!activeVesselDataviews?.length}
               tooltip={
-                !activeVesselDataviews?.length ? 'Select at least one vessel' : 'Show tracks graph'
+                !activeVesselDataviews?.length
+                  ? t('timebar.tracksDisabled', 'Select at least one apparent fishing effort layer')
+                  : t('timebar.showTracks', 'Show tracks graph')
               }
               onClick={setVesselActive}
             />

--- a/applications/fishing-map/src/features/timebar/timebar.slice.ts
+++ b/applications/fishing-map/src/features/timebar/timebar.slice.ts
@@ -9,11 +9,13 @@ type Range = {
 type TimebarSlice = {
   highlightedTime: Range | null
   staticTime: Range | null
+  hasChangedSettingsOnce: boolean
 }
 
 const initialState: TimebarSlice = {
   highlightedTime: null,
   staticTime: null,
+  hasChangedSettingsOnce: false,
 }
 
 const slice = createSlice({
@@ -29,11 +31,21 @@ const slice = createSlice({
     setStaticTime: (state, action: PayloadAction<Range>) => {
       state.staticTime = action.payload
     },
+    changeSettings: (state) => {
+      state.hasChangedSettingsOnce = true
+    },
   },
 })
 
-export const { setHighlightedTime, disableHighlightedTime, setStaticTime } = slice.actions
+export const {
+  setHighlightedTime,
+  disableHighlightedTime,
+  setStaticTime,
+  changeSettings,
+} = slice.actions
 export default slice.reducer
 
 export const selectHighlightedTime = (state: RootState) => state.timebar.highlightedTime
 export const selectStaticTime = (state: RootState) => state.timebar.staticTime
+export const selectHasChangedSettingsOnce = (state: RootState) =>
+  state.timebar.hasChangedSettingsOnce

--- a/applications/fishing-map/src/features/workspace/heatmaps/HeatmapLayerPanel.tsx
+++ b/applications/fishing-map/src/features/workspace/heatmaps/HeatmapLayerPanel.tsx
@@ -16,11 +16,12 @@ import HeatmapInfoModal from './HeatmapInfoModal'
 
 type LayerPanelProps = {
   dataview: UrlDataviewInstance
+  isAdded: boolean
 }
 
-function LayerPanel({ dataview }: LayerPanelProps): React.ReactElement {
+function LayerPanel({ dataview, isAdded }: LayerPanelProps): React.ReactElement {
   const { t } = useTranslation()
-  const [filterOpen, setFiltersOpen] = useState(false)
+  const [filterOpen, setFiltersOpen] = useState(isAdded === undefined ? false : isAdded)
   const [modalInfoOpen, setModalInfoOpen] = useState(false)
   const sourcesOptions = getSourcesSelectedInDataview(dataview)
   const fishingFiltersOptions = getFlagsByIds(dataview.config?.filters || [])

--- a/applications/fishing-map/src/features/workspace/heatmaps/HeatmapLayerPanel.tsx
+++ b/applications/fishing-map/src/features/workspace/heatmaps/HeatmapLayerPanel.tsx
@@ -15,13 +15,14 @@ import { getSourcesSelectedInDataview } from './heatmaps.utils'
 import HeatmapInfoModal from './HeatmapInfoModal'
 
 type LayerPanelProps = {
+  index: number
+  isOpen: boolean
   dataview: UrlDataviewInstance
-  isAdded: boolean
 }
 
-function LayerPanel({ dataview, isAdded }: LayerPanelProps): React.ReactElement {
+function LayerPanel({ dataview, index, isOpen }: LayerPanelProps): React.ReactElement {
   const { t } = useTranslation()
-  const [filterOpen, setFiltersOpen] = useState(isAdded === undefined ? false : isAdded)
+  const [filterOpen, setFiltersOpen] = useState(isOpen === undefined ? false : isOpen)
   const [modalInfoOpen, setModalInfoOpen] = useState(false)
   const sourcesOptions = getSourcesSelectedInDataview(dataview)
   const fishingFiltersOptions = getFlagsByIds(dataview.config?.filters || [])
@@ -29,7 +30,7 @@ function LayerPanel({ dataview, isAdded }: LayerPanelProps): React.ReactElement 
   const { dispatchQueryParams } = useLocationConnect()
   const bivariate = useSelector(selectBivariate)
 
-  const layerActive = bivariate ? true : dataview?.config?.visible ?? true
+  const layerActive = dataview?.config?.visible ?? true
   const onToggleLayerActive = () => {
     upsertDataviewInstance({
       id: dataview.id,
@@ -38,8 +39,11 @@ function LayerPanel({ dataview, isAdded }: LayerPanelProps): React.ReactElement 
       },
     })
   }
+
   const onRemoveLayerClick = () => {
-    dispatchQueryParams({ bivariate: false })
+    if (index < 2) {
+      dispatchQueryParams({ bivariate: false })
+    }
     deleteDataviewInstance(dataview.id)
   }
 

--- a/applications/fishing-map/src/features/workspace/heatmaps/HeatmapsSection.tsx
+++ b/applications/fishing-map/src/features/workspace/heatmaps/HeatmapsSection.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback } from 'react'
 import cx from 'classnames'
-import { useSelector } from 'react-redux'
+import { useDispatch, useSelector } from 'react-redux'
 import { useTranslation } from 'react-i18next'
 import { IconButton } from '@globalfishingwatch/ui-components'
 import { Generators } from '@globalfishingwatch/layer-composer'
@@ -10,20 +10,28 @@ import { useDataviewInstancesConnect } from 'features/workspace/workspace.hook'
 import { useLocationConnect } from 'routes/routes.hook'
 import { selectBivariate } from 'features/app/app.selectors'
 import { getHeatmapDataviewInstance } from 'features/dataviews/dataviews.utils'
+import {
+  selectHeatmapSublayersAddedIndex,
+  setHeatmapSublayersAddedIndex,
+} from 'features/app/app.slice'
 import LayerPanel from './HeatmapLayerPanel'
 
 function HeatmapsSection(): React.ReactElement {
   const { t } = useTranslation()
+  const dispatch = useDispatch()
   const dataviews = useSelector(selectTemporalgridDataviews)
   const { upsertDataviewInstance } = useDataviewInstancesConnect()
   const { dispatchQueryParams } = useLocationConnect()
   const bivariate = useSelector(selectBivariate)
 
+  const heatmapSublayersAddedIndex = useSelector(selectHeatmapSublayersAddedIndex)
+
   const onAddClick = useCallback(() => {
     const usedRamps = dataviews?.flatMap((dataview) => dataview.config?.colorRamp || [])
     const dataviewInstance = getHeatmapDataviewInstance(usedRamps)
+    dispatch(setHeatmapSublayersAddedIndex(dataviews ? dataviews.length : 0))
     upsertDataviewInstance(dataviewInstance)
-  }, [dataviews, upsertDataviewInstance])
+  }, [dispatch, dataviews, upsertDataviewInstance])
 
   const onToggleCombinationMode = useCallback(() => {
     const newBivariateValue = !bivariate
@@ -79,8 +87,12 @@ function HeatmapsSection(): React.ReactElement {
           />
         </div>
       </div>
-      {dataviews?.map((dataview) => (
-        <LayerPanel key={dataview.id} dataview={dataview} />
+      {dataviews?.map((dataview, index) => (
+        <LayerPanel
+          key={dataview.id}
+          dataview={dataview}
+          isAdded={index === heatmapSublayersAddedIndex}
+        />
       ))}
     </div>
   )

--- a/applications/fishing-map/src/features/workspace/heatmaps/HeatmapsSection.tsx
+++ b/applications/fishing-map/src/features/workspace/heatmaps/HeatmapsSection.tsx
@@ -23,7 +23,6 @@ function HeatmapsSection(): React.ReactElement {
   const { upsertDataviewInstance } = useDataviewInstancesConnect()
   const { dispatchQueryParams } = useLocationConnect()
   const bivariate = useSelector(selectBivariate)
-
   const heatmapSublayersAddedIndex = useSelector(selectHeatmapSublayersAddedIndex)
 
   const onAddClick = useCallback(() => {
@@ -60,9 +59,13 @@ function HeatmapsSection(): React.ReactElement {
   if (dataviews?.length !== 2) {
     bivariateTooltip = t(
       'layer.toggleCombinationMode.disabled',
-      'Combine mode is only availabe with two activity layers'
+      'Combine mode is only available with two activity layers'
     )
   }
+
+  const addTooltip = bivariate
+    ? t('layer.addDisabled', 'Adding layers is disabled when layers are combined')
+    : t('layer.add', 'Add layer')
   return (
     <div className={styles.container}>
       <div className={styles.header}>
@@ -81,7 +84,8 @@ function HeatmapsSection(): React.ReactElement {
             icon="plus"
             type="border"
             size="medium"
-            tooltip={t('layer.add', 'Add layer')}
+            disabled={bivariate}
+            tooltip={addTooltip}
             tooltipPlacement="top"
             onClick={onAddClick}
           />

--- a/packages/ui-components/src/map-legend/Bivariate.tsx
+++ b/packages/ui-components/src/map-legend/Bivariate.tsx
@@ -141,12 +141,12 @@ function BivariateLegend({
                   <g className={styles.labels}>
                     <BivariateArrows />
                     {valuesPositions.map((positions, xIndex) =>
-                      positions.map(({ x, y }, yIndex) => {
+                      positions?.map(({ x, y }, yIndex) => {
                         if (xIndex === 1 && yIndex === 0) return null
-                        const value = layer.sublayersBreaks[xIndex][yIndex]
+                        const value = layer.sublayersBreaks?.[xIndex]?.[yIndex]
                         const roundedValue = roundValues ? roundLegendNumber(value) : value
                         return (
-                          <text>
+                          <text key={value}>
                             <tspan x={x} y={y}>
                               {formatLegendValue(roundedValue)}
                             </tspan>
@@ -157,7 +157,7 @@ function BivariateLegend({
                   </g>
                   <g transform="translate(81, 62) scale(1, -1) rotate(45) translate(-81, -62) translate(41, 22)">
                     {layer.bivariateRamp.map((color: string, i: number) => (
-                      <BivariateRect color={color} i={i} key={i} />
+                      <BivariateRect color={color} i={i} key={color} />
                     ))}
                     {bivariateBucketIndex && bivariateBucketIndex > 0 && (
                       <BivariateRect

--- a/packages/ui-components/src/radio/Radio.module.css
+++ b/packages/ui-components/src/radio/Radio.module.css
@@ -3,6 +3,10 @@
   align-items: center;
 }
 
+.container.disabled {
+  cursor: not-allowed;
+}
+
 .inline {
   display: inline-flex;
 }
@@ -20,10 +24,6 @@
 
 .Radio:focus {
   box-shadow: var(--box-shadow-highlight);
-}
-
-.Radio:disabled {
-  cursor: not-allowed;
 }
 
 .Radio .nib {
@@ -62,6 +62,10 @@
   opacity: var(--opacity-secondary);
   color: var(--color-primary-blue);
   text-transform: none;
+}
+
+.disabled .Label {
+  pointer-events: none;
 }
 
 .active {

--- a/packages/ui-components/src/radio/Radio.tsx
+++ b/packages/ui-components/src/radio/Radio.tsx
@@ -2,6 +2,7 @@ import React, { memo } from 'react'
 import cx from 'classnames'
 import { Placement } from 'tippy.js'
 import Tooltip from '../tooltip'
+import { TooltipTypes } from '../types/types'
 import styles from './Radio.module.css'
 
 interface RadioProps {
@@ -9,7 +10,7 @@ interface RadioProps {
   label?: string
   disabled?: boolean
   onClick: (event: React.MouseEvent) => void
-  tooltip?: React.ReactChild | React.ReactChild[] | string
+  tooltip?: TooltipTypes
   tooltipPlacement?: Placement
   className?: string
   labelClassname?: string

--- a/packages/ui-components/src/radio/Radio.tsx
+++ b/packages/ui-components/src/radio/Radio.tsx
@@ -28,7 +28,9 @@ function Radio(props: RadioProps) {
   } = props
   return (
     <Tooltip content={tooltip} placement={tooltipPlacement}>
-      <div className={cx(styles.container, { [styles.inline]: !label })}>
+      <div
+        className={cx(styles.container, { [styles.inline]: !label, [styles.disabled]: disabled })}
+      >
         <button
           type="button"
           role="radio"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2708,11 +2708,11 @@
   integrity sha512-Es6WcD0nO5l+2BOQS4uLfNPYQaNDfbot3X1XUoloz+x0mPDS3eeORZJl06HXjwBG1fOGwCRnzK88LMdxKRrd6Q==
 
 "@math.gl/web-mercator@^3.1.3":
-  version "3.3.2"
-  resolved "https://registry.yarnpkg.com/@math.gl/web-mercator/-/web-mercator-3.3.2.tgz#e85e4efab8c74edd549f20121ba680b0f466e9cd"
-  integrity sha512-84NNnwP97Xwm1ynZzat1BuEU2uLyIw0gzG5uvGMrAzezny2P38+E2cUK8t9eptKa8gjk2MaC7hhcO0saFCZTHw==
+  version "3.3.3"
+  resolved "https://registry.yarnpkg.com/@math.gl/web-mercator/-/web-mercator-3.3.3.tgz#636b79b0470f309c618920bccfd689cff30ff02c"
+  integrity sha512-1EKxoP2jDlY9Imb3KAJjQIcl3J8A7hhsHdYXpQcSdi6imvw/9JvixnE+qMlkUd49jDGZusw9VQtC0EMpBtg7fw==
   dependencies:
-    "@babel/runtime" "^7.0.0"
+    "@babel/runtime" "^7.12.0"
     gl-matrix "^3.0.0"
 
 "@mrmlnc/readdir-enhanced@^2.2.1":
@@ -3212,9 +3212,9 @@
     loader-utils "^2.0.0"
 
 "@testing-library/dom@*", "@testing-library/dom@^7.28.1":
-  version "7.29.1"
-  resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-7.29.1.tgz#a08ebeb26b2ea859b1621ff9642d114c1f04fe3a"
-  integrity sha512-6BU7vAjKuMspCy9QQEtbWgmkuXi/yOSZo3ANdvZmNQW8N/WQGjO9cvlcA5EFJaPtp2hL1RAaPGpCXxumijUxCg==
+  version "7.29.2"
+  resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-7.29.2.tgz#6cba65d961d8b36d621a98caa8537444075fb42e"
+  integrity sha512-CBMELfyY1jKdtLcSRmEnZWRzRkCRVSNPTzhzrn8wY8OnzUo7Pe/W+HgLzt4TDnWIPYeusHBodf9wUjJF48kPmA==
   dependencies:
     "@babel/code-frame" "^7.10.4"
     "@babel/runtime" "^7.12.5"
@@ -4896,9 +4896,9 @@
     "@types/istanbul-lib-report" "*"
 
 "@types/jest@*", "@types/jest@^26.0.14":
-  version "26.0.19"
-  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-26.0.19.tgz#e6fa1e3def5842ec85045bd5210e9bb8289de790"
-  integrity sha512-jqHoirTG61fee6v6rwbnEuKhpSKih0tuhqeFbCmMmErhtu3BYlOZaXWjffgOstMM4S/3iQD31lI5bGLTrs97yQ==
+  version "26.0.20"
+  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-26.0.20.tgz#cd2f2702ecf69e86b586e1f5223a60e454056307"
+  integrity sha512-9zi2Y+5USJRxd0FsahERhBwlcvFh6D2GLQnY2FH2BzK8J9s9omvNHIbvABwIluXa0fD8XVKMLTO0aOEuUfACAA==
   dependencies:
     jest-diff "^26.0.0"
     pretty-format "^26.0.0"
@@ -4944,9 +4944,9 @@
   integrity sha512-iIJp2CP6C32gVqI08HIYnzqj55tlLnodIBMCcMf28q9ckqMfMzocCmIzd9JWI/ALLPMUiTkCu1JGv3FFtu6t3g==
 
 "@types/mapbox-gl@*":
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/@types/mapbox-gl/-/mapbox-gl-2.0.1.tgz#dc0734ba6bcd459e69f14ac8fc0368349c685a6f"
-  integrity sha512-0bHvAoDt5Cpz1GQeXjamLnSbNDLX/wAa8KelK02KW+prvjtSKVuirQayJZkaKa/JMb/WmVtEhfMjvH3sDEOUOw==
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/@types/mapbox-gl/-/mapbox-gl-2.0.2.tgz#79dc50459b61bbcfd053ea93867a8b365f8f32dd"
+  integrity sha512-vHEa8Xk3ukdiLxccMJOUxeDo3WeKPB8AmdSbnI9jDFQfGHLV1uGn6eXdYcJ/yozo3iATjan2Rb9+69LPhVTnEQ==
   dependencies:
     "@types/geojson" "*"
 
@@ -10452,12 +10452,19 @@ find-up@^5.0.0:
     locate-path "^6.0.0"
     path-exists "^4.0.0"
 
-find-versions@^3.0.0, find-versions@^3.2.0:
+find-versions@^3.0.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/find-versions/-/find-versions-3.2.0.tgz#10297f98030a786829681690545ef659ed1d254e"
   integrity sha512-P8WRou2S+oe222TOCHitLy8zj+SIsVJh52VP4lvXkaFVnOFFdoWv1H1Jjvel1aI6NCFOAaeAVm8qrI0odiLcww==
   dependencies:
     semver-regex "^2.0.0"
+
+find-versions@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/find-versions/-/find-versions-4.0.0.tgz#3c57e573bf97769b8cb8df16934b627915da4965"
+  integrity sha512-wgpWy002tA+wgmO27buH/9KzyEOQnKsG/R0yrcjPT9BOFm0zRBVQbZ95nRGXWMywS8YR5knRbpohio0bcJABxQ==
+  dependencies:
+    semver-regex "^3.1.2"
 
 find-yarn-workspace-root2@1.2.16:
   version "1.2.16"
@@ -10547,6 +10554,13 @@ follow-redirects@^1.0.0:
   version "1.13.1"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.13.1.tgz#5f69b813376cee4fd0474a3aba835df04ab763b7"
   integrity sha512-SSG5xmZh1mkPGyKzjZP8zLjltIfpW32Y5QpdNJyjcfGxK3qo3NDDkZOZSFiGn1A6SclQxY9GzEwAHQ3dmYRWpg==
+
+for-each@^0.3.3:
+  version "0.3.3"
+  resolved "https://registry.yarnpkg.com/for-each/-/for-each-0.3.3.tgz#69b447e88a0a5d32c3e7084f3f1710034b21376e"
+  integrity sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==
+  dependencies:
+    is-callable "^1.1.3"
 
 for-in@^1.0.1, for-in@^1.0.2:
   version "1.0.2"
@@ -11792,17 +11806,17 @@ humanize-url@^1.0.0:
     strip-url-auth "^1.0.0"
 
 husky@^4.2.5, husky@^4.3.0:
-  version "4.3.6"
-  resolved "https://registry.yarnpkg.com/husky/-/husky-4.3.6.tgz#ebd9dd8b9324aa851f1587318db4cccb7665a13c"
-  integrity sha512-o6UjVI8xtlWRL5395iWq9LKDyp/9TE7XMOTvIpEVzW638UcGxTmV5cfel6fsk/jbZSTlvfGVJf2svFtybcIZag==
+  version "4.3.7"
+  resolved "https://registry.yarnpkg.com/husky/-/husky-4.3.7.tgz#ca47bbe6213c1aa8b16bbd504530d9600de91e88"
+  integrity sha512-0fQlcCDq/xypoyYSJvEuzbDPHFf8ZF9IXKJxlrnvxABTSzK1VPT2RKYQKrcgJ+YD39swgoB6sbzywUqFxUiqjw==
   dependencies:
     chalk "^4.0.0"
     ci-info "^2.0.0"
     compare-versions "^3.6.0"
     cosmiconfig "^7.0.0"
-    find-versions "^3.2.0"
+    find-versions "^4.0.0"
     opencollective-postinstall "^2.0.2"
-    pkg-dir "^4.2.0"
+    pkg-dir "^5.0.0"
     please-upgrade-node "^3.2.0"
     slash "^3.0.0"
     which-pm-runs "^1.0.0"
@@ -12310,7 +12324,7 @@ is-buffer@^2.0.0:
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-2.0.5.tgz#ebc252e400d22ff8d77fa09888821a24a658c191"
   integrity sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==
 
-is-callable@^1.1.4, is-callable@^1.2.2:
+is-callable@^1.1.3, is-callable@^1.1.4, is-callable@^1.2.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.2.2.tgz#c7c6715cd22d4ddb48d3e19970223aceabb080d9"
   integrity sha512-dnMqspv5nU3LoewK2N/y7KLtxtakvTuaCsU9FU50/QDmdbHNy/4/JuRtMHqRU22o3q+W89YQndQEeCVwK+3qrA==
@@ -14819,9 +14833,9 @@ meow@^6.0.0:
     yargs-parser "^18.1.3"
 
 meow@^8.0.0:
-  version "8.1.0"
-  resolved "https://registry.yarnpkg.com/meow/-/meow-8.1.0.tgz#0fcaa267e35e4d58584b8205923df6021ddcc7ba"
-  integrity sha512-fNWkgM1UVMey2kf24yLiccxLihc5W+6zVus3/N0b+VfnJgxV99E9u04X6NAiKdg6ED7DAQBX5sy36NM0QJZkWA==
+  version "8.1.2"
+  resolved "https://registry.yarnpkg.com/meow/-/meow-8.1.2.tgz#bcbe45bda0ee1729d350c03cffc8395a36c4e897"
+  integrity sha512-r85E3NdZ+mpYk1C6RjPFEMSE+s1iZMuHtsHAqY0DT3jZczl0diWUZ8g6oU7h0M9cD2EL+PzaYghhCLzR0ZNn5Q==
   dependencies:
     "@types/minimist" "^1.2.0"
     camelcase-keys "^6.2.2"
@@ -15706,7 +15720,7 @@ object.fromentries@^2.0.2:
     es-abstract "^1.18.0-next.1"
     has "^1.0.3"
 
-object.getownpropertydescriptors@^2.0.3, object.getownpropertydescriptors@^2.1.0:
+object.getownpropertydescriptors@^2.0.3, object.getownpropertydescriptors@^2.1.0, object.getownpropertydescriptors@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.1.1.tgz#0dfda8d108074d9c563e80490c883b6661091544"
   integrity sha512-6DtXgZ/lIZ9hqx4GtZETobXLR/ZLaa0aqV0kzbn80Rf8Z2e/XFnhA0I7p07N2wH8bBBltr2xQPi6sbKWAY2Eng==
@@ -15796,9 +15810,9 @@ only@~0.0.2:
   integrity sha1-Kv3oTQPlC5qO3EROMGEKcCle37Q=
 
 open@^7.0.2:
-  version "7.3.0"
-  resolved "https://registry.yarnpkg.com/open/-/open-7.3.0.tgz#45461fdee46444f3645b6e14eb3ca94b82e1be69"
-  integrity sha512-mgLwQIx2F/ye9SmbrUkurZCnkoXyXyu9EbHtJZrICjVAJfyMArdHp3KkixGdZx1ZHFPNIwl0DDM1dFFqXbTLZw==
+  version "7.3.1"
+  resolved "https://registry.yarnpkg.com/open/-/open-7.3.1.tgz#111119cb919ca1acd988f49685c4fdd0f4755356"
+  integrity sha512-f2wt9DCBKKjlFbjzGb8MOAW8LH8F0mrs1zc7KTjAJ9PZNQbfenzWbNP1VZJvw6ICMG9r14Ah6yfwPn7T7i646A==
   dependencies:
     is-docker "^2.0.0"
     is-wsl "^2.1.1"
@@ -16559,6 +16573,13 @@ pkg-dir@^4.1.0, pkg-dir@^4.2.0:
   integrity sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==
   dependencies:
     find-up "^4.0.0"
+
+pkg-dir@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/pkg-dir/-/pkg-dir-5.0.0.tgz#a02d6aebe6ba133a928f74aec20bafdfe6b8e760"
+  integrity sha512-NPE8TDbzl/3YQYY7CSS228s3g2ollTFnc+Qi3tqmqJp9Vg2ovUpixcJEo2HJScN2Ez+kEaal6y70c0ehqJBJeA==
+  dependencies:
+    find-up "^5.0.0"
 
 pkg-up@3.1.0:
   version "3.1.0"
@@ -19284,9 +19305,9 @@ sass-loader@8.0.2:
     semver "^6.3.0"
 
 sass@^1.26.5:
-  version "1.32.0"
-  resolved "https://registry.yarnpkg.com/sass/-/sass-1.32.0.tgz#10101a026c13080b14e2b374d4e15ee24400a4d3"
-  integrity sha512-fhyqEbMIycQA4blrz/C0pYhv2o4x2y6FYYAH0CshBw3DXh5D5wyERgxw0ptdau1orc/GhNrhF7DFN2etyOCEng==
+  version "1.32.2"
+  resolved "https://registry.yarnpkg.com/sass/-/sass-1.32.2.tgz#66dc0250bc86c15d19ddee7135e93d0cf3d3257b"
+  integrity sha512-u1pUuzqwz3SAgvHSWp1k0mRhX82b2DdlVnP6UIetQPZtYbuJUDaPQhZE12jyjB7vYeOScfz9WPsZJB6Rpk7heA==
   dependencies:
     chokidar ">=2.0.0 <4.0.0"
 
@@ -19385,6 +19406,11 @@ semver-regex@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/semver-regex/-/semver-regex-2.0.0.tgz#a93c2c5844539a770233379107b38c7b4ac9d338"
   integrity sha512-mUdIBBvdn0PLOeP3TEkMH7HHeUP3GjsXCwKarjv/kGmUFOYg1VqEemKhoQpWMu6X2I8kHeuVdGibLGkVK+/5Qw==
+
+semver-regex@^3.1.2:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/semver-regex/-/semver-regex-3.1.2.tgz#34b4c0d361eef262e07199dbef316d0f2ab11807"
+  integrity sha512-bXWyL6EAKOJa81XG1OZ/Yyuq+oT0b2YLlxx7c+mrdYPaPbnj6WgVULXhinMIeZGufuUBu/eVRqXEhiv4imfwxA==
 
 semver-truncate@^1.1.2:
   version "1.1.2"
@@ -21125,9 +21151,9 @@ tsscmp@1.0.6, tsscmp@^1.0.6:
   integrity sha512-LxhtAkPDTkVCMQjt2h6eBVY28KCjikZqZfMcC15YBeNjkgUpdCfBu5HoiOTDu86v6smE8yOjyEktJ8hlbANHQA==
 
 tsutils@^3.17.1:
-  version "3.18.0"
-  resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-3.18.0.tgz#38add50a28ec97e988cb43c5b32e55d1ff4a222a"
-  integrity sha512-D9Tu8nE3E7D1Bsf/V29oMHceMf+gnVO+pDguk/A5YRo1cLpkiQ48ZnbbS57pvvHeY+OIeNQx1vf4ASPlEtRpcA==
+  version "3.19.0"
+  resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-3.19.0.tgz#9387cb5fcb71579aa0909c509604f8a7fbe1cff1"
+  integrity sha512-A7BaLUPvcQ1cxVu72YfD+UMI3SQPTDv/w4ol6TOwLyI0hwfG9EC+cYlhdflJTmtYTgZ3KqdPSe/otxU4K3kArg==
   dependencies:
     tslib "^1.8.1"
 
@@ -21581,7 +21607,17 @@ util.promisify@1.0.0:
     define-properties "^1.1.2"
     object.getownpropertydescriptors "^2.0.3"
 
-util.promisify@^1.0.0, util.promisify@~1.0.0:
+util.promisify@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/util.promisify/-/util.promisify-1.1.0.tgz#aa0a043eb73f5ff5cbb3ae44819cd0f3e7a5322f"
+  integrity sha512-KXdwUwahiTMGAA2NE3NVKSyabmckHljc99p1E9neqltHxT+7KsomX6yGGWSmbWRMf7wTpeG/CQMDgbLN8AahsQ==
+  dependencies:
+    call-bind "^1.0.0"
+    define-properties "^1.1.3"
+    for-each "^0.3.3"
+    object.getownpropertydescriptors "^2.1.1"
+
+util.promisify@~1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/util.promisify/-/util.promisify-1.0.1.tgz#6baf7774b80eeb0f7520d8b81d07982a59abbaee"
   integrity sha512-g9JpC/3He3bm38zsLupWryXHoEcS22YHthuPQSJdMy6KNrzIRzWqcsHzD/WUnqe45whVou4VIsPew37DoXWNrA==


### PR DESCRIPTION
- [x] Always show all timebar settings options even when heatmap/vessels unavailable (but disabled)
- [x] Switch automatically to timebar track view when vessel is loaded for the 1st time
- [x] Fixed a bug where an empty timebar settings panel would show when using certain workspaces
- [x] Fixed a bug where a disabled radio button label would still be interactive
- [x] Show filters panels open by default when adding heatmap layer
- ~[ ] Let user activate bivariate when 3rd 4th layers etc are disabled~
- [x] prevent adding layers in combined/bivriate mode
- ~[ ] Some form of static graph to show *something* by default in timebar~

Later: Bivariate PR
- [ ] 5 colors bivariates
- [ ] add hover button _in between_ heatmap layers 
- [ ] move from `bivariate: true` to `bivariateStartIndex: 2`