### PR TITLE
support fleet filters

### DIFF
--- a/applications/fishing-map/src/features/workspace/heatmaps/HeatmapFilters.tsx
+++ b/applications/fishing-map/src/features/workspace/heatmaps/HeatmapFilters.tsx
@@ -10,10 +10,11 @@ import { useDataviewInstancesConnect } from 'features/workspace/workspace.hook'
 import { getPlaceholderBySelections } from 'features/i18n/utils'
 import styles from './HeatmapFilters.module.css'
 import {
-  getCommonGearTypesInDataview,
-  getNotSupportedGearTypesDatasets,
+  getCommonSchemaFieldsInDataview,
+  getNotSupportedSchemaFieldsDatasets,
   getSourcesOptionsInDataview,
   getSourcesSelectedInDataview,
+  getSupportedSchemaFieldsDatasets,
 } from './heatmaps.utils'
 
 type FiltersProps = {
@@ -26,32 +27,60 @@ function Filters({ dataview }: FiltersProps): React.ReactElement {
 
   const sourceOptions = getSourcesOptionsInDataview(dataview)
   const sourcesSelected = getSourcesSelectedInDataview(dataview)
-  const gearTypeOptions = getCommonGearTypesInDataview(dataview)
+
+  const gearTypeOptions = getCommonSchemaFieldsInDataview(dataview, 'geartype')
   const gearTypeSelected = gearTypeOptions?.filter((geartype) =>
     dataview.config?.filters?.geartype?.includes(geartype.id)
   )
-  const fishingFiltersOptions = getFlagsByIds(dataview.config?.filters?.flag || [])
+  const fleetOptions = getCommonSchemaFieldsInDataview(dataview, 'fleet')
+  const fleetSelected = fleetOptions?.filter((fleet) =>
+    dataview.config?.filters?.fleet?.includes(fleet.id)
+  )
+
+  const flagOptions = getFlagsByIds(dataview.config?.filters?.flag || [])
   const flags = useMemo(getFlags, [])
 
-  const datasetsWithoutgGeartype = getNotSupportedGearTypesDatasets(dataview)
+  const datasetsWithoutGeartype = getNotSupportedSchemaFieldsDatasets(dataview, 'geartype')
+  const datasetsWithoutFleet = getNotSupportedSchemaFieldsDatasets(dataview, 'fleet')
+
+  const datasetsWithGeartype = getSupportedSchemaFieldsDatasets(dataview, 'geartype')
+  const datasetsWithFleet = getSupportedSchemaFieldsDatasets(dataview, 'fleet')
+
+  const supportsGearTypeSelection = datasetsWithGeartype && datasetsWithGeartype.length > 0
+  const supportsFleetSelection = datasetsWithFleet && datasetsWithFleet.length > 0
 
   const onSelectSourceClick: MultiSelectOnChange = (source) => {
     const datasets = [...(dataview.config?.datasets || []), source.id]
     const filters = dataview.config?.filters ? { ...dataview.config.filters } : {}
+
+    const newDataview = { ...dataview, config: { ...dataview.config, datasets } }
     if (filters['geartype']) {
-      const newDataview = { ...dataview, config: { ...dataview.config, datasets } }
-      const newGearTypeOptions = getCommonGearTypesInDataview(newDataview)
-      const supportGearTypeFilter = newGearTypeOptions.length > 0
-      const newGearTypeSelection = newGearTypeOptions?.filter((geartype) =>
+      const newGeartypeOptions = getCommonSchemaFieldsInDataview(newDataview, 'geartype')
+      const newGeartypeSelection = newGeartypeOptions?.filter((geartype) =>
         dataview.config?.filters?.geartype?.includes(geartype.id)
       )
 
       // We have to remove the geartype if it is not supported by the datasets selecion
-      if (!supportGearTypeFilter) {
+      if (newGeartypeOptions.length === 0) {
         delete filters['geartype']
         // or keep only the options that every dataset have in common
-      } else if (!newGearTypeSelection?.length !== dataview.config?.filters?.geartype?.length) {
-        filters.geartype = newGearTypeSelection.map(({ id }) => id)
+      } else if (!newGeartypeSelection?.length !== dataview.config?.filters?.geartype?.length) {
+        filters.geartype = newGeartypeSelection.map(({ id }) => id)
+      }
+    }
+
+    if (filters['fleet']) {
+      const newFleetOptions = getCommonSchemaFieldsInDataview(newDataview, 'fleet')
+      const newFleetSelection = newFleetOptions?.filter((geartype) =>
+        dataview.config?.filters?.geartype?.includes(geartype.id)
+      )
+
+      // We have to remove the geartype if it is not supported by the datasets selecion
+      if (newFleetOptions.length === 0) {
+        delete filters['fleet']
+        // or keep only the options that every dataset have in common
+      } else if (!newFleetSelection?.length !== dataview.config?.filters?.geartype?.length) {
+        filters.fleet = newFleetSelection.map(({ id }) => id)
       }
     }
     upsertDataviewInstance({
@@ -103,46 +132,71 @@ function Filters({ dataview }: FiltersProps): React.ReactElement {
     })
   }
 
-  const disabledGearType = datasetsWithoutgGeartype && datasetsWithoutgGeartype.length > 0
-  const disabledGearTypeTooltip = disabledGearType
+  const disabledGeartype = datasetsWithoutGeartype && datasetsWithoutGeartype.length > 0
+  const disabledGeartypeTooltip = disabledGeartype
     ? t('errors.notSupportedBy', {
-        list: datasetsWithoutgGeartype?.map((d) => d.name).join(','),
+        list: datasetsWithoutGeartype?.map((d) => d.name).join(','),
+        defaultValue: 'Not supported by {{list}}',
+      })
+    : ''
+  const disabledFleet = datasetsWithoutFleet && datasetsWithoutFleet.length > 0
+  const disabledFleetTooltip = disabledFleet
+    ? t('errors.notSupportedBy', {
+        list: datasetsWithoutFleet?.map((d) => d.name).join(','),
         defaultValue: 'Not supported by {{list}}',
       })
     : ''
 
   return (
     <Fragment>
-      <MultiSelect
-        label={t('layer.source_plural', 'Sources')}
-        placeholder={getPlaceholderBySelections(sourcesSelected)}
-        options={sourceOptions}
-        selectedOptions={sourcesSelected}
-        onSelect={onSelectSourceClick}
-        onRemove={sourcesSelected?.length > 1 ? onRemoveSourceClick : undefined}
-      />
+      {sourceOptions && sourceOptions?.length > 1 && (
+        <MultiSelect
+          label={t('layer.source_plural', 'Sources')}
+          placeholder={getPlaceholderBySelections(sourcesSelected)}
+          options={sourceOptions}
+          selectedOptions={sourcesSelected}
+          onSelect={onSelectSourceClick}
+          onRemove={sourcesSelected?.length > 1 ? onRemoveSourceClick : undefined}
+        />
+      )}
       <MultiSelect
         label={t('layer.flagState_plural', 'Flag States')}
-        placeholder={getPlaceholderBySelections(fishingFiltersOptions)}
+        placeholder={getPlaceholderBySelections(flagOptions)}
         options={flags}
-        selectedOptions={fishingFiltersOptions}
+        selectedOptions={flagOptions}
         className={styles.multiSelect}
         onSelect={(selection) => onSelectFilterClick('flag', selection)}
         onRemove={(selection, rest) => onRemoveFilterClick('flag', rest)}
         onCleanClick={() => onCleanFilterClick('flag')}
       />
-      <MultiSelect
-        disabled={disabledGearType}
-        disabledMsg={disabledGearTypeTooltip}
-        label={t('layer.gearType_plural', 'Gear types')}
-        placeholder={getPlaceholderBySelections(gearTypeSelected)}
-        options={gearTypeOptions}
-        selectedOptions={gearTypeSelected}
-        className={styles.multiSelect}
-        onSelect={(selection) => onSelectFilterClick('geartype', selection)}
-        onRemove={(selection, rest) => onRemoveFilterClick('geartype', rest)}
-        onCleanClick={() => onCleanFilterClick('geartype')}
-      />
+      {supportsGearTypeSelection && (
+        <MultiSelect
+          disabled={disabledGeartype}
+          disabledMsg={disabledGeartypeTooltip}
+          label={t('layer.gearType_plural', 'Gear types')}
+          placeholder={getPlaceholderBySelections(gearTypeSelected)}
+          options={gearTypeOptions}
+          selectedOptions={gearTypeSelected}
+          className={styles.multiSelect}
+          onSelect={(selection) => onSelectFilterClick('geartype', selection)}
+          onRemove={(selection, rest) => onRemoveFilterClick('geartype', rest)}
+          onCleanClick={() => onCleanFilterClick('geartype')}
+        />
+      )}
+      {supportsFleetSelection && (
+        <MultiSelect
+          disabled={disabledFleet}
+          disabledMsg={disabledFleetTooltip}
+          label={t('vessels.fleet', 'Fleet')}
+          placeholder={getPlaceholderBySelections(fleetSelected)}
+          options={fleetOptions}
+          selectedOptions={fleetSelected}
+          className={styles.multiSelect}
+          onSelect={(selection) => onSelectFilterClick('fleet', selection)}
+          onRemove={(selection, rest) => onRemoveFilterClick('fleet', rest)}
+          onCleanClick={() => onCleanFilterClick('fleet')}
+        />
+      )}
     </Fragment>
   )
 }

--- a/applications/fishing-map/src/features/workspace/heatmaps/HeatmapLayerPanel.tsx
+++ b/applications/fishing-map/src/features/workspace/heatmaps/HeatmapLayerPanel.tsx
@@ -11,7 +11,7 @@ import { useDataviewInstancesConnect } from 'features/workspace/workspace.hook'
 import { selectBivariate } from 'features/app/app.selectors'
 import { useLocationConnect } from 'routes/routes.hook'
 import Filters from './HeatmapFilters'
-import { getGearTypesSelectedInDataview, getSourcesSelectedInDataview } from './heatmaps.utils'
+import { getSchemaFieldsSelectedInDataview, getSourcesSelectedInDataview } from './heatmaps.utils'
 import HeatmapInfoModal from './HeatmapInfoModal'
 
 type LayerPanelProps = {
@@ -26,7 +26,7 @@ function LayerPanel({ dataview, index, isOpen }: LayerPanelProps): React.ReactEl
   const [modalInfoOpen, setModalInfoOpen] = useState(false)
   const sourcesOptions = getSourcesSelectedInDataview(dataview)
   const fishingFiltersOptions = getFlagsByIds(dataview.config?.filters?.flag || [])
-  const gearTypesSelected = getGearTypesSelectedInDataview(dataview)
+  const gearTypesSelected = getSchemaFieldsSelectedInDataview(dataview, 'geartype')
   const { upsertDataviewInstance, deleteDataviewInstance } = useDataviewInstancesConnect()
   const { dispatchQueryParams } = useLocationConnect()
   const bivariate = useSelector(selectBivariate)

--- a/applications/fishing-map/src/features/workspace/heatmaps/heatmaps.utils.ts
+++ b/applications/fishing-map/src/features/workspace/heatmaps/heatmaps.utils.ts
@@ -4,38 +4,60 @@ import { FISHING_DATASET_TYPE } from 'data/datasets'
 import { UrlDataviewInstance } from 'types'
 import { capitalize } from 'utils/shared'
 
-export const getNotSupportedGearTypesDatasets = (dataview: UrlDataviewInstance) => {
-  const datasetsWithoutGearTypeSupport = dataview?.datasets?.flatMap((dataset) => {
-    const hasGeartype = dataset.schema?.geartype?.enum !== undefined
+type DatasetSchema = 'geartype' | 'fleet'
+
+export const getSupportedSchemaFieldsDatasets = (
+  dataview: UrlDataviewInstance,
+  schema: DatasetSchema
+) => {
+  const datasetsWithSchemaFieldsSupport = dataview?.datasets?.flatMap((dataset) => {
+    const hasSchemaFields = dataset.schema?.[schema]?.enum !== undefined
+    return hasSchemaFields ? dataset : []
+  })
+  return datasetsWithSchemaFieldsSupport
+}
+
+export const getNotSupportedSchemaFieldsDatasets = (
+  dataview: UrlDataviewInstance,
+  schema: DatasetSchema
+) => {
+  const datasetsWithoutSchemaFieldsSupport = dataview?.datasets?.flatMap((dataset) => {
+    const hasSchemaFields = dataset.schema?.[schema]?.enum !== undefined
     const datasetSelected = dataview.config?.datasets.includes(dataset.id)
-    if (!datasetSelected || hasGeartype) {
+    if (!datasetSelected || hasSchemaFields) {
       return []
     }
     return dataset
   })
-  return datasetsWithoutGearTypeSupport
+  return datasetsWithoutSchemaFieldsSupport
 }
 
-export const getCommonGearTypesInDataview = (dataview: UrlDataviewInstance) => {
+export const getCommonSchemaFieldsInDataview = (
+  dataview: UrlDataviewInstance,
+  schema: DatasetSchema
+) => {
   const activeDatasets = dataview?.datasets?.filter((dataset) =>
     dataview.config?.datasets.includes(dataset.id)
   )
-  const geartypes = activeDatasets?.map((d) => d.schema?.geartype?.enum || [])
-  const commonGeartypes = geartypes
-    ? intersection(...geartypes).map((geartype) => ({
-        id: geartype,
-        label: capitalize(lowerCase(geartype)),
+  const schemaFields = activeDatasets?.map((d) => d.schema?.[schema]?.enum || [])
+  const commonSchemaFields = schemaFields
+    ? intersection(...schemaFields).map((field) => ({
+        id: field,
+        label: capitalize(lowerCase(field)),
       }))
     : []
-  return commonGeartypes
+  return commonSchemaFields
 }
 
-export const getGearTypesSelectedInDataview = (dataview: UrlDataviewInstance) => {
-  const gearTypeOptions = getCommonGearTypesInDataview(dataview)
-  const gearTypeSelected = gearTypeOptions?.filter((geartype) =>
-    dataview.config?.filters?.geartype?.includes(geartype.id)
+export const getSchemaFieldsSelectedInDataview = (
+  dataview: UrlDataviewInstance,
+  schema: DatasetSchema
+) => {
+  const options = getCommonSchemaFieldsInDataview(dataview, schema)
+  const optionsSelected = options?.filter((option) =>
+    dataview.config?.filters?.[schema]?.includes(option.id)
   )
-  return gearTypeSelected
+  return optionsSelected
 }
 
 export const getSourcesOptionsInDataview = (


### PR DESCRIPTION
Using same logic that https://github.com/GlobalFishingWatch/frontend/pull/251 to include Fleet filter when VMS Peru source is selected.
There is only a small change when any of the sources has the filter available the selector won't appear