### PR TITLE
Fishingmap/screenshot preview

### DIFF
--- a/.changeset/serious-otters-approve.md
+++ b/.changeset/serious-otters-approve.md
@@ -1,0 +1,6 @@
+---
+"@globalfishingwatch/ui-components": patch
+"@globalfishingwatchapp/fishing-map": patch
+---
+
+Include ids in ui-buttons

--- a/applications/fishing-map/public/locales/en/translations.json
+++ b/applications/fishing-map/public/locales/en/translations.json
@@ -54,7 +54,8 @@
     "source": "Source"
   },
   "map": {
-    "capture_map": "Capture map",
+    "captureMap": "Capture map",
+    "captureMapLoading": "Please wait until map loads",
     "change_basemap_default": "Switch to default basemap",
     "change_basemap_satellite": "Switch to satellite basemap",
     "loading": "Map loading",

--- a/applications/fishing-map/public/locales/en/translations.json
+++ b/applications/fishing-map/public/locales/en/translations.json
@@ -55,7 +55,7 @@
   },
   "map": {
     "captureMap": "Capture map",
-    "captureMapLoading": "Please wait until map loads",
+    "mapLoadingWait": "Please wait until map loads",
     "change_basemap_default": "Switch to default basemap",
     "change_basemap_satellite": "Switch to satellite basemap",
     "loading": "Map loading",

--- a/applications/fishing-map/public/locales/es/translations.json
+++ b/applications/fishing-map/public/locales/es/translations.json
@@ -54,7 +54,7 @@
     "source": "Fuente"
   },
   "map": {
-    "capture_map": "Captura el mapa",
+    "captureMap": "Captura el mapa",
     "change_basemap_default": "Cambia al mapa base por defecto",
     "change_basemap_satellite": "Cambia al mapa base satelital",
     "loading": "Cargando el mapa",

--- a/applications/fishing-map/public/locales/fr/translations.json
+++ b/applications/fishing-map/public/locales/fr/translations.json
@@ -54,7 +54,7 @@
     "source": "Source"
   },
   "map": {
-    "capture_map": "Enregistrer une image de la carte",
+    "captureMap": "Enregistrer une image de la carte",
     "change_basemap_default": "Fond de carte par défaut",
     "change_basemap_satellite": "Fond de carte satellite",
     "loading": "Chargement de la carte",

--- a/applications/fishing-map/public/locales/source/translations.json
+++ b/applications/fishing-map/public/locales/source/translations.json
@@ -54,7 +54,8 @@
     "source": "Source"
   },
   "map": {
-    "capture_map": "Capture map",
+    "captureMap": "Capture map",
+    "captureMapLoading": "Please wait until map loads",
     "change_basemap_default": "Switch to default basemap",
     "change_basemap_satellite": "Switch to satellite basemap",
     "loading": "Map loading",

--- a/applications/fishing-map/public/locales/source/translations.json
+++ b/applications/fishing-map/public/locales/source/translations.json
@@ -55,7 +55,7 @@
   },
   "map": {
     "captureMap": "Capture map",
-    "captureMapLoading": "Please wait until map loads",
+    "mapLoadingWait": "Please wait until map loads",
     "change_basemap_default": "Switch to default basemap",
     "change_basemap_satellite": "Switch to satellite basemap",
     "loading": "Map loading",

--- a/applications/fishing-map/src/features/map/Map.tsx
+++ b/applications/fishing-map/src/features/map/Map.tsx
@@ -180,9 +180,12 @@ const MapWrapper = (): React.ReactElement | null => {
     style?.metadata
   )
   const hoveredTooltipEvent = useMapTooltip(hoveredEvent)
-  const onMouseOut = useCallback(() => {
+
+  const resetHoverState = useCallback(() => {
     setHoveredEvent(null)
-  }, [])
+    setHoveredDebouncedEvent(null)
+    cleanFeatureState()
+  }, [cleanFeatureState])
 
   const { viewport, onViewportChange } = useViewport()
 
@@ -243,7 +246,7 @@ const MapWrapper = (): React.ReactElement | null => {
           onClick={onMapClick}
           onHover={onMapHover}
           onError={handleError}
-          onMouseOut={onMouseOut}
+          onMouseOut={resetHoverState}
           transitionDuration={viewport.transitionDuration}
         >
           {clickedEvent && (
@@ -263,7 +266,7 @@ const MapWrapper = (): React.ReactElement | null => {
           <MapInfo center={hoveredEvent} />
         </InteractiveMap>
       )}
-      <MapControls loading={tilesLoading.loading} />
+      <MapControls onMouseEnter={resetHoverState} mapLoading={tilesLoading.loading} />
       {layersWithLegend?.map((legend) => {
         const legendDomElement = document.getElementById(legend.id as string)
         if (legendDomElement) {

--- a/applications/fishing-map/src/features/map/MapScreenshot.tsx
+++ b/applications/fishing-map/src/features/map/MapScreenshot.tsx
@@ -18,7 +18,7 @@ type PrintSize = {
 }
 
 const browser = getParser(window.navigator.userAgent)
-const isPrintSupported = browser.satisfies({
+export const isPrintSupported = browser.satisfies({
   chrome: '>22',
   opera: '>30',
   edge: '>79',

--- a/applications/fishing-map/src/features/map/controls/MapControls.module.css
+++ b/applications/fishing-map/src/features/map/controls/MapControls.module.css
@@ -40,10 +40,40 @@
 
 .loadingBtn {
   opacity: 0;
+  height: 0;
   pointer-events: none;
   transition: opacity 0.3s 0.5s;
 }
 
 .visible {
   opacity: 1;
+  height: var(--size-M);
+}
+
+.previewContainer {
+  display: flex;
+  flex-direction: column;
+}
+
+.previewPlaceholder {
+  height: calc(100% - 5rem);
+}
+
+.previewImage {
+  flex: 1;
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+  filter: drop-shadow(0 0 4px var(--color-border));
+}
+
+.previewFooter {
+  margin-top: var(--space-S);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.printBtn {
+  margin-right: var(--space-S);
 }

--- a/applications/fishing-map/src/features/map/controls/MapControls.tsx
+++ b/applications/fishing-map/src/features/map/controls/MapControls.tsx
@@ -133,7 +133,7 @@ const MapControls = ({
               disabled={mapLoading || loading}
               tooltip={
                 mapLoading || loading
-                  ? t('map.captureMapLoading', 'Please wait until map loads')
+                  ? t('map.mapLoadingWait', 'Please wait until map loads')
                   : t('map.captureMap', 'Capture map')
               }
               onClick={onScreenshotClick}

--- a/applications/fishing-map/src/features/map/controls/MapControls.tsx
+++ b/applications/fishing-map/src/features/map/controls/MapControls.tsx
@@ -12,7 +12,13 @@ import { isWorkspaceLocation } from 'routes/routes.selectors'
 import styles from './MapControls.module.css'
 import MapSearch from './MapSearch'
 
-const MapControls = ({ loading = false }: { loading?: boolean }): React.ReactElement => {
+const MapControls = ({
+  mapLoading = false,
+  onMouseEnter,
+}: {
+  mapLoading?: boolean
+  onMouseEnter: () => void
+}): React.ReactElement => {
   const { t } = useTranslation()
   const resolvedDataviewInstances = useSelector(selectDataviewInstancesResolved)
   const { upsertDataviewInstance } = useDataviewInstancesConnect()
@@ -45,7 +51,7 @@ const MapControls = ({ loading = false }: { loading?: boolean }): React.ReactEle
   }
   const extendedControls = useSelector(isWorkspaceLocation)
   return (
-    <div className={styles.mapControls}>
+    <div className={styles.mapControls} onMouseEnter={onMouseEnter}>
       <MiniGlobe
         className={styles.miniglobe}
         size={60}

--- a/applications/fishing-map/src/features/map/map.slice.ts
+++ b/applications/fishing-map/src/features/map/map.slice.ts
@@ -22,7 +22,6 @@ import { selectTimeRange } from 'features/app/app.selectors'
 export const MAX_TOOLTIP_VESSELS = 5
 
 type MapState = {
-  screenshotMode: boolean
   clicked: InteractionEvent | null
   hovered: InteractionEvent | null
   status: AsyncReducerStatus
@@ -30,7 +29,6 @@ type MapState = {
 }
 
 const initialState: MapState = {
-  screenshotMode: false,
   clicked: null,
   hovered: null,
   status: AsyncReducerStatus.Idle,

--- a/applications/fishing-map/src/features/sidebar/Sidebar.module.css
+++ b/applications/fishing-map/src/features/sidebar/Sidebar.module.css
@@ -6,7 +6,6 @@
 :global(.scrollContainer) {
   height: 100%;
   overflow-y: auto;
-  padding-bottom: var(--space-L);
   width: 100%;
 }
 

--- a/applications/fishing-map/src/features/workspace/Sections.module.css
+++ b/applications/fishing-map/src/features/workspace/Sections.module.css
@@ -1,5 +1,8 @@
 .container {
   padding: var(--space-XS) 0;
+}
+
+.container:not(:last-of-type) {
   border-bottom: var(--border);
 }
 

--- a/applications/fishing-map/src/features/workspace/vessels/VesselsSection.tsx
+++ b/applications/fishing-map/src/features/workspace/vessels/VesselsSection.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback } from 'react'
 import { useSelector } from 'react-redux'
+import cx from 'classnames'
 import { useTranslation } from 'react-i18next'
 import { IconButton } from '@globalfishingwatch/ui-components'
 import { useLocationConnect } from 'routes/routes.hook'
@@ -17,7 +18,7 @@ function VesselsSection(): React.ReactElement {
     dispatchQueryParams({ query: '' })
   }, [dispatchQueryParams])
   return (
-    <div className={styles.container}>
+    <div className={cx(styles.container, { 'print-hidden': !dataviews?.length })}>
       <div className={styles.header}>
         <h2 className={styles.sectionTitle}>{t('common.vessel_plural', 'Vessels')}</h2>
         <IconButton

--- a/applications/fishing-map/src/hooks/screen.hooks.ts
+++ b/applications/fishing-map/src/hooks/screen.hooks.ts
@@ -3,12 +3,14 @@ import { saveAs } from 'file-saver'
 import setInlineStyles from 'utils/dom'
 
 export const useDownloadDomElementAsImage = (
-  domElement: HTMLElement | null,
+  domElement: HTMLElement | undefined,
   autoDownload = true,
   fileName?: string
 ) => {
   const [error, setError] = useState<string | null>('')
   const [loading, setLoading] = useState<boolean>(false)
+  const [previewImage, setPreviewImage] = useState<string>('')
+  const [previewImageLoading, setPreviewImageLoading] = useState(false)
   const [finished, setFinished] = useState<boolean>(false)
   const html2canvasRef = useRef<any>(null)
 
@@ -31,8 +33,20 @@ export const useDownloadDomElementAsImage = (
       }
     } catch (e) {
       console.warn(e)
+      throw e
     }
   }, [domElement])
+
+  const generatePreviewImage = useCallback(async () => {
+    try {
+      setPreviewImageLoading(true)
+      const canvas = await getCanvas()
+      setPreviewImage(canvas.toDataURL())
+      setPreviewImageLoading(false)
+    } catch (e) {
+      setPreviewImageLoading(false)
+    }
+  }, [getCanvas])
 
   const downloadImage = useCallback(
     async (fileName = `GFW-fishingmap-${new Date().toLocaleString()}.png`) => {
@@ -80,5 +94,14 @@ export const useDownloadDomElementAsImage = (
     }
   }, [downloadImage, domElement, autoDownload, fileName])
 
-  return { loading, error, finished, downloadImage, getCanvas }
+  return {
+    loading,
+    error,
+    finished,
+    downloadImage,
+    getCanvas,
+    previewImage,
+    generatePreviewImage,
+    previewImageLoading,
+  }
 }

--- a/packages/ui-components/src/button/Button.tsx
+++ b/packages/ui-components/src/button/Button.tsx
@@ -9,6 +9,7 @@ export type ButtonType = 'default' | 'secondary'
 export type ButtonSize = 'default' | 'small'
 
 interface ButtonProps {
+  id?: string
   type?: ButtonType
   size?: ButtonSize
   disabled?: boolean
@@ -23,6 +24,7 @@ interface ButtonProps {
 
 function Button(props: ButtonProps) {
   const {
+    id,
     type = 'default',
     size = 'default',
     disabled = false,
@@ -42,6 +44,7 @@ function Button(props: ButtonProps) {
         </a>
       ) : (
         <button
+          id={id}
           className={cx(styles.button, styles[type], styles[size], className)}
           onClick={(e) => !loading && onClick && onClick(e)}
           disabled={disabled}

--- a/packages/ui-components/src/icon-button/IconButton.tsx
+++ b/packages/ui-components/src/icon-button/IconButton.tsx
@@ -6,13 +6,13 @@ import Spinner from '../spinner'
 import styles from './IconButton.module.css'
 import { IconButtonProps } from '.'
 
-
 const warningVarColor = getComputedStyle(document.documentElement).getPropertyValue(
   '--color-danger-red'
 )
 
 function IconButton(props: IconButtonProps, ref: Ref<HTMLButtonElement>) {
   const {
+    id,
     type = 'default',
     size = 'default',
     disabled = false,
@@ -31,6 +31,7 @@ function IconButton(props: IconButtonProps, ref: Ref<HTMLButtonElement>) {
   return (
     <Tooltip content={tooltip} placement={tooltipPlacement}>
       <button
+        id={id}
         ref={ref}
         className={cx(
           styles.iconButton,

--- a/packages/ui-components/src/icon-button/index.ts
+++ b/packages/ui-components/src/icon-button/index.ts
@@ -9,6 +9,7 @@ export type IconButtonType = 'default' | 'invert' | 'border' | 'map-tool' | 'war
 export type IconButtonSize = 'default' | 'medium' | 'small' | 'tiny'
 
 export interface IconButtonProps {
+  id?: string
   icon?: IconType
   type?: IconButtonType
   size?: IconButtonSize

--- a/packages/ui-components/src/tooltip/Tooltip.module.css
+++ b/packages/ui-components/src/tooltip/Tooltip.module.css
@@ -22,3 +22,10 @@
 .tooltip :global(.tippy-arrow) {
   display: none;
 }
+
+@media print {
+  .tooltip  {
+    display: none !important;
+  }
+}
+


### PR DESCRIPTION
Extend the screenshot feature to prepare a modal with the image preview and allow user to select between print to PDF or download an image using the [useDownloadDomElementAsImage](https://github.com/GlobalFishingWatch/frontend/blob/fishingmap/screenshot-preview/applications/fishing-map/src/hooks/screen.hooks.ts#L5) hook
**NOTE:** PDF is only supported in chrome and edge

This is how the modal looks: 
![image](https://user-images.githubusercontent.com/10500650/105746091-4deeb500-5f3f-11eb-82b6-efd863d296cf.png)

And this is how the download image looks:
![GFW-fishingmap-25_01_2021, 18_47_13](https://user-images.githubusercontent.com/10500650/105746117-5810b380-5f3f-11eb-9c90-355f1a5202d5.png)
