### PR TITLE
Fishingmap/context layers attribution

### DIFF
--- a/applications/fishing-map/CHANGELOG.md
+++ b/applications/fishing-map/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @globalfishingwatchapp/fishing-map
 
+## 0.17.9
+
+### Patch Changes
+
+- support context layers attribution
+- Updated dependencies [undefined]
+  - @globalfishingwatch/layer-composer@4.11.2
+
 ## 0.17.8
 
 ### Patch Changes

--- a/applications/fishing-map/package.json
+++ b/applications/fishing-map/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@globalfishingwatchapp/fishing-map",
-  "version": "0.17.8",
+  "version": "0.17.9",
   "private": true,
   "scripts": {
     "start": "PORT=3003 react-scripts start",
@@ -15,7 +15,7 @@
     "@globalfishingwatch/api-types": "^2.6.1",
     "@globalfishingwatch/data-transforms": "^1.1.0",
     "@globalfishingwatch/dataviews-client": "^4.0.3",
-    "@globalfishingwatch/layer-composer": "4.11.1",
+    "@globalfishingwatch/layer-composer": "4.11.2",
     "@globalfishingwatch/mapbox-gl": "1.12.0-gfw.8",
     "@globalfishingwatch/ocean-areas": "^0.1.0",
     "@globalfishingwatch/pbf": "^1.0.9",

--- a/applications/fishing-map/src/features/map/map.selectors.ts
+++ b/applications/fishing-map/src/features/map/map.selectors.ts
@@ -114,23 +114,31 @@ export const getWorkspaceGeneratorsConfig = createSelector(
       } else if (dataview.config?.type === Generators.Type.Context) {
         if (Array.isArray(dataview.config.layers)) {
           const tilesUrls = dataview.config.layers?.flatMap(({ id, dataset }) => {
-            const { url } = resolveDataviewDatasetResource(dataview, { id: dataset })
+            const { dataset: resolvedDataset, url } = resolveDataviewDatasetResource(dataview, {
+              id: dataset,
+            })
             if (!url) return []
-            return { id, tilesUrl: url }
+            return { id, tilesUrl: url, attribution: resolvedDataset?.source }
           })
           // Duplicated generators when context dataview have multiple layers
-          return tilesUrls.map(({ id, tilesUrl }) => ({
+          return tilesUrls.map(({ id, tilesUrl, attribution }) => ({
             ...generator,
             id: `${dataview.id}__${id}`,
             layer: id,
+            attribution,
             tilesUrl,
           }))
         } else {
           generator.id = `${dataview.id}__${dataview.config.layers}`
           generator.layer = dataview.config.layers
-          const { url } = resolveDataviewDatasetResource(dataview, { type: USER_CONTEXT_TYPE })
+          const { dataset, url } = resolveDataviewDatasetResource(dataview, {
+            type: USER_CONTEXT_TYPE,
+          })
           if (url) {
             generator.tilesUrl = url
+          }
+          if (dataset?.source) {
+            generator.attribution = dataset.source
           }
         }
         if (!generator.tilesUrl) {

--- a/packages/layer-composer/CHANGELOG.md
+++ b/packages/layer-composer/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @globalfishingwatch/layer-composer
 
+## 4.11.2
+
+### Patch Changes
+
+- support context layers attribution
+
 ## 4.11.1
 
 ### Patch Changes

--- a/packages/layer-composer/package.json
+++ b/packages/layer-composer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@globalfishingwatch/layer-composer",
-  "version": "4.11.1",
+  "version": "4.11.2",
   "description": "",
   "author": "satellitestudio <contact@satellitestud.io>",
   "homepage": "https://github.com/GlobalFishingWatch/frontend#readme",

--- a/packages/layer-composer/src/generators/context/context.ts
+++ b/packages/layer-composer/src/generators/context/context.ts
@@ -102,6 +102,7 @@ class ContextGenerator {
         type: 'vector',
         promoteId: 'gfw_id',
         tiles: [tilesUrl.replace(/{{/g, '{').replace(/}}/g, '}')],
+        ...(config.attribution && { attribution: config.attribution }),
       },
     ]
   }

--- a/packages/layer-composer/src/generators/types.ts
+++ b/packages/layer-composer/src/generators/types.ts
@@ -118,6 +118,10 @@ export interface ContextGeneratorConfig extends GeneratorConfig {
    */
   layer: ContextLayerType
   /**
+   * Contains the attribution to be displayed when the map is showing the layer.
+   */
+  attribution?: string
+  /**
    * Url to grab the tiles from, internally using https://docs.mapbox.com/mapbox-gl-js/style-spec/sources/#vector-tiles
    */
   tilesUrl: string


### PR DESCRIPTION
Include attribution in context generators to include in the [mapbox-gl source](https://docs.mapbox.com/mapbox-gl-js/style-spec/sources/#vector-attribution)
This value comes from the `source` api dataset field
And this is how it looks
![image](https://user-images.githubusercontent.com/10500650/106034784-a22a9e00-60d3-11eb-976f-32ae4b6f1b06.png)
