### PR TITLE
VH-69 Added SourceAPI to display TMT,GFW in development

### DIFF
--- a/applications/vessel-history/src/data/constants.ts
+++ b/applications/vessel-history/src/data/constants.ts
@@ -1,3 +1,4 @@
 export const BASE_URL = process.env.NODE_ENV === 'production' ? '/port-inspector' : ''
 
 export const SPLASH_TIMEOUT = 1000
+export const SHOW_VESSEL_API_SOURCE = process.env.NODE_ENV === 'production' ? false : true

--- a/applications/vessel-history/src/features/vessel-list-item/VesselListItem.test.tsx
+++ b/applications/vessel-history/src/features/vessel-list-item/VesselListItem.test.tsx
@@ -1,0 +1,50 @@
+import { render } from '@testing-library/react'
+import { Vessel } from 'types'
+import VesselListItem from './VesselListItem'
+
+const mockShowSourceAPI = jest.fn()
+jest.mock('data/constants', () => ({
+  get SHOW_VESSEL_API_SOURCE() {
+    return mockShowSourceAPI() // set some default value
+  },
+}))
+
+describe('<VesselListItem />', () => {
+  const vessel: Vessel = {
+    callsign: 'CB5527',
+    firstTransmissionDate: '2012-01-19T14:24:39Z',
+    flag: 'CHL',
+    id: '9e075a986-6162-fe6e-b25e-81188438a00c',
+    imo: null,
+    lastTransmissionDate: '2020-12-13T23:51:36Z',
+    mmsi: '725000410',
+    otherCallsigns: [],
+    otherImos: [],
+    otherShipnames: [],
+    shipname: 'DON TITO',
+    source: 'AIS',
+    dataset: 'public-global-vessels:v20190502',
+    vesselMatchId: '6dd26b05-c055-5b5a-b396-2cc6503fdd4c',
+  }
+
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('shows source API in environments others than production', () => {
+    mockShowSourceAPI.mockReturnValueOnce(true)
+    const component = render(<VesselListItem vessel={vessel} />)
+    expect(component.getAllByText('SOURCE').length).toBe(1)
+    expect(component.getAllByText('GFW+TMT').length).toBe(1)
+    expect(component.asFragment()).toMatchSnapshot()
+  })
+
+  it('does not show source API in production environment', () => {
+    mockShowSourceAPI.mockReturnValueOnce(false)
+    const component = render(<VesselListItem vessel={vessel} />)
+    expect(() => component.getAllByText('SOURCE')).toThrow(
+      'Unable to find an element with the text: SOURCE.'
+    )
+    expect(component.asFragment()).toMatchSnapshot()
+  })
+})

--- a/applications/vessel-history/src/features/vessel-list-item/VesselListItem.tsx
+++ b/applications/vessel-history/src/features/vessel-list-item/VesselListItem.tsx
@@ -2,6 +2,8 @@ import React from 'react'
 import { IconButton } from '@globalfishingwatch/ui-components'
 import { Vessel } from 'types'
 import { getFlagById } from 'utils/flags'
+import { getVesselAPISource } from 'utils/vessel'
+import { SHOW_VESSEL_API_SOURCE } from 'data/constants'
 import styles from './VesselListItem.module.css'
 
 interface ListItemProps {
@@ -16,6 +18,7 @@ const VesselListItem: React.FC<ListItemProps> = (props): React.ReactElement => {
   }
 
   const flagLabel = getFlagById(vessel.flag)?.label
+  const sourceAPI = getVesselAPISource(vessel)
   return (
     <div className={styles.vesselItem}>
       {props.saved && (
@@ -48,6 +51,12 @@ const VesselListItem: React.FC<ListItemProps> = (props): React.ReactElement => {
           <div>
             <label>CALLSIGN</label>
             {vessel.callsign}
+          </div>
+        )}
+        {SHOW_VESSEL_API_SOURCE && (
+          <div>
+            <label>SOURCE</label>
+            {sourceAPI.join('+')}
           </div>
         )}
         <div>

--- a/applications/vessel-history/src/features/vessel-list-item/__snapshots__/VesselListItem.test.tsx.snap
+++ b/applications/vessel-history/src/features/vessel-list-item/__snapshots__/VesselListItem.test.tsx.snap
@@ -1,0 +1,87 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<VesselListItem /> does not show source API in production environment 1`] = `
+<DocumentFragment>
+  <div
+    class="vesselItem"
+  >
+    <h3>
+      DON TITO
+    </h3>
+    <div
+      class="identifiers"
+    >
+      <div>
+        <label>
+          FLAG
+        </label>
+        Chile
+      </div>
+      <div>
+        <label>
+          MMSI
+        </label>
+        725000410
+      </div>
+      <div>
+        <label>
+          CALLSIGN
+        </label>
+        CB5527
+      </div>
+      <div>
+        <label>
+          TRANSMISSIONS
+        </label>
+        from 2012-01-19T14:24:39Z to 2020-12-13T23:51:36Z
+      </div>
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`<VesselListItem /> shows source API in environments others than production 1`] = `
+<DocumentFragment>
+  <div
+    class="vesselItem"
+  >
+    <h3>
+      DON TITO
+    </h3>
+    <div
+      class="identifiers"
+    >
+      <div>
+        <label>
+          FLAG
+        </label>
+        Chile
+      </div>
+      <div>
+        <label>
+          MMSI
+        </label>
+        725000410
+      </div>
+      <div>
+        <label>
+          CALLSIGN
+        </label>
+        CB5527
+      </div>
+      <div>
+        <label>
+          SOURCE
+        </label>
+        GFW+TMT
+      </div>
+      <div>
+        <label>
+          TRANSMISSIONS
+        </label>
+        from 2012-01-19T14:24:39Z to 2020-12-13T23:51:36Z
+      </div>
+    </div>
+  </div>
+</DocumentFragment>
+`;

--- a/applications/vessel-history/src/types/index.ts
+++ b/applications/vessel-history/src/types/index.ts
@@ -40,10 +40,10 @@ export interface OtherShipname {
 export interface Vessel {
   id: string
   callsign: string
-  firstTransmissionDate: Date
+  firstTransmissionDate: string
   flag: string
   imo?: any
-  lastTransmissionDate: Date
+  lastTransmissionDate: string
   mmsi: string
   otherCallsigns: OtherCallsign[]
   otherImos: OtherImo[]
@@ -52,4 +52,9 @@ export interface Vessel {
   source: string
   dataset: string
   vesselMatchId: string
+}
+
+export enum VesselAPISource {
+  TMT = 'TMT',
+  GFW = 'GFW',
 }

--- a/applications/vessel-history/src/utils/vessel.test.tsx
+++ b/applications/vessel-history/src/utils/vessel.test.tsx
@@ -1,0 +1,57 @@
+import { Vessel, VesselAPISource } from 'types'
+import { getVesselAPISource } from './vessel'
+
+describe('getVesselAPISource', () => {
+  const vessel: Vessel = {
+    callsign: 'CB5527',
+    firstTransmissionDate: '2012-01-19T14:24:39Z',
+    flag: 'CHL',
+    id: '9e075a986-6162-fe6e-b25e-81188438a00c',
+    imo: null,
+    lastTransmissionDate: '2020-12-13T23:51:36Z',
+    mmsi: '725000410',
+    otherCallsigns: [],
+    otherImos: [],
+    otherShipnames: [],
+    shipname: 'DON TITO',
+    source: 'AIS',
+    dataset: 'public-global-vessels:v20190502',
+    vesselMatchId: '6dd26b05-c055-5b5a-b396-2cc6503fdd4c',
+  }
+
+  it('returns TMT source only when vesselMatchId is present and id not', () => {
+    const mockVessel = { ...vessel }
+    delete mockVessel['id']
+    const result = getVesselAPISource(mockVessel)
+    expect(result).toEqual([VesselAPISource.TMT])
+
+    expect(getVesselAPISource({ ...mockVessel, id: null })).toEqual([VesselAPISource.TMT])
+    expect(getVesselAPISource({ ...mockVessel, id: '' })).toEqual([VesselAPISource.TMT])
+  })
+
+  it('returns GFW source only when id is present and vesselMatchId not', () => {
+    const mockVessel = { ...vessel }
+    delete mockVessel['vesselMatchId']
+    const result = getVesselAPISource(mockVessel)
+    expect(result).toEqual([VesselAPISource.GFW])
+
+    expect(getVesselAPISource({ ...mockVessel, vesselMatchId: null })).toEqual([
+      VesselAPISource.GFW,
+    ])
+    expect(getVesselAPISource({ ...mockVessel, vesselMatchId: '' })).toEqual([VesselAPISource.GFW])
+  })
+
+  it('returns GFW and TMT source when id is present and vesselMatchId too', () => {
+    const mockVessel = { ...vessel }
+    const result = getVesselAPISource(mockVessel)
+    expect(result).toEqual([VesselAPISource.GFW, VesselAPISource.TMT])
+  })
+
+  it('returns empty array when id and vesselMatchId are missing', () => {
+    const mockVessel = { ...vessel }
+    delete mockVessel['vesselMatchId']
+    delete mockVessel['id']
+    const result = getVesselAPISource(mockVessel)
+    expect(result).toEqual([])
+  })
+})

--- a/applications/vessel-history/src/utils/vessel.ts
+++ b/applications/vessel-history/src/utils/vessel.ts
@@ -1,0 +1,8 @@
+import { Vessel, VesselAPISource } from 'types'
+
+export function getVesselAPISource(vessel: Vessel): VesselAPISource[] {
+  const source = []
+  if (vessel.id) source.push(VesselAPISource.GFW)
+  if (vessel.vesselMatchId) source.push(VesselAPISource.TMT)
+  return source
+}


### PR DESCRIPTION
JIra: [VH-69](https://globalfishingwatch.atlassian.net/browse/VH-69)
- Display Source on every vessel result only in environments others than production
- Including unit tests for this new feature
![image](https://user-images.githubusercontent.com/2205831/107516247-e1082b80-6b8a-11eb-9acc-3c9ba507a5f6.png)
