### PR TITLE
Fishingmap tweak timebar visualisation

### DIFF
--- a/.changeset/khaki-planes-reflect.md
+++ b/.changeset/khaki-planes-reflect.md
@@ -1,0 +1,5 @@
+---
+'@globalfishingwatch/timebar': patch
+---
+
+graph tweaks

--- a/packages/timebar/src/charts/stacked-activity.js
+++ b/packages/timebar/src/charts/stacked-activity.js
@@ -7,7 +7,8 @@ import ImmediateContext from '../immediateContext'
 import { DEFAULT_CSS_TRANSITION } from '../constants'
 import { TimelineContext } from '../components/timeline'
 
-const MARGIN_BOTTOM = 10
+const MARGIN_BOTTOM = 20
+const MARGIN_TOP = 5
 
 const getPathContainers = (data, graphHeight, overallScale, numSublayers) => {
   if (!data) return []
@@ -55,10 +56,10 @@ const StackedActivity = ({ data, colors, numSublayers }) => {
       >
         {pathContainers.map((pathContainer, sublayerIndex) => (
           <Fragment key={sublayerIndex}>
-            <g key="top" transform={`scale(1, -1) translate(0, ${-middleY}) `}>
+            <g key="top" transform={`scale(1, -1) translate(0, ${-middleY - MARGIN_TOP}) `}>
               <path d={pathContainer.path} fill={colors ? colors[sublayerIndex] : '#ff00ff'} />
             </g>
-            <g key="bottom" transform={`translate(0, ${middleY})`}>
+            <g key="bottom" transform={`translate(0, ${middleY + MARGIN_TOP})`}>
               <path d={pathContainer.path} fill={colors ? colors[sublayerIndex] : '#ff00ff'} />
             </g>
           </Fragment>

--- a/packages/timebar/src/charts/utils/index.js
+++ b/packages/timebar/src/charts/utils/index.js
@@ -1,7 +1,8 @@
 export const getTrackY = (numTracks, trackIndex, graphHeight) => {
-  const Y_TRACK_SPACE = 14
-  const totalHeightOffset = ((numTracks - 1) * Y_TRACK_SPACE) / 2
-  const startY = -8 + graphHeight / 2
-  const y = startY + trackIndex * Y_TRACK_SPACE - totalHeightOffset
+  const MARGIN_BOTTOM = 10
+  const MARGIN_TOP = 5
+  const finalHeight = graphHeight - MARGIN_BOTTOM - MARGIN_TOP
+  const heightPerTrack = finalHeight / numTracks
+  const y = heightPerTrack * trackIndex + heightPerTrack / 2
   return y
 }

--- a/packages/timebar/src/charts/utils/index.js
+++ b/packages/timebar/src/charts/utils/index.js
@@ -1,7 +1,6 @@
 export const getTrackY = (numTracks, trackIndex, graphHeight) => {
-  const MARGIN_BOTTOM = 10
-  const MARGIN_TOP = 5
-  const finalHeight = graphHeight - MARGIN_BOTTOM - MARGIN_TOP
+  const TOTAL_MARGIN = 15
+  const finalHeight = graphHeight - TOTAL_MARGIN
   const heightPerTrack = finalHeight / numTracks
   const y = heightPerTrack * trackIndex + heightPerTrack / 2
   return y


### PR DESCRIPTION
Changes the way we allocate space to tracks 
![Screenshot 2021-02-11 at 14 16 30](https://user-images.githubusercontent.com/38662877/107645880-974a3e80-6c79-11eb-91e0-5585d34723d0.png)

and adds padding to the stacked-activity graph
![Screenshot 2021-02-11 at 14 22 03](https://user-images.githubusercontent.com/38662877/107645933-a9c47800-6c79-11eb-9a52-29dc21183693.png)


