### PR TITLE
Fishingmap/expanded container refactor

### DIFF
--- a/applications/fishing-map/package.json
+++ b/applications/fishing-map/package.json
@@ -49,6 +49,7 @@
     "react-i18next": "^11.7.3",
     "react-redux": "^7.2.2",
     "react-scripts": "4.0.1",
+    "react-spring": "^8.0.27",
     "react-sticky-el": "^2.0.5",
     "redux": "^4.0.5",
     "redux-first-router": "^2.1.5",

--- a/applications/fishing-map/src/features/search/Search.module.css
+++ b/applications/fishing-map/src/features/search/Search.module.css
@@ -5,13 +5,27 @@
 }
 
 .expandedContainerOpen::after {
-  content: "";
+  content: '';
   position: absolute;
   top: 6rem;
   right: 0;
   bottom: 0;
   left: 0;
   background-color: var(--color-veil);
+}
+
+.expandedContainer {
+  background-color: var(--color-white);
+  width: 36.9rem;
+}
+
+.expandedArrow {
+  left: 0 !important;
+}
+
+.expandedArrow::before {
+  left: 5px !important;
+  background-color: var(--color-white);
 }
 
 .search {
@@ -28,7 +42,6 @@
   background-color: var(--color-white);
   box-shadow: var(--box-shadow);
   z-index: 1;
-  z-index: 0;
   position: relative;
   border-bottom: var(--border);
 }
@@ -118,56 +131,6 @@
 .searchResult:hover .properties label {
   cursor: pointer;
   opacity: var(--opacity-primary);
-}
-
-.expandable::after {
-  content: '';
-  opacity: 0;
-  transform: translateX(-50%) translateY(-50%) rotateZ(-45deg);
-  transition: transform 150ms ease-out, opacity 150ms linear;
-}
-
-.expanded {
-  position: relative;
-  opacity: 1;
-}
-
-.expanded::after {
-  position: absolute;
-  width: 36%;
-  height: 36%;
-  border-top: var(--border);
-  border-right: var(--border);
-  top: 100%;
-  left: 50%;
-  background-color: var(--color-white);
-  transform: translateX(-50%) rotateZ(-45deg);
-  transform-origin: center;
-  opacity: 1;
-}
-
-.expandedContainer {
-  width: 100%;
-  position: absolute;
-  left: 0;
-  top: 0;
-  z-index: -1;
-  transform: translateY(0);
-  transition: transform 150ms ease-out;
-  opacity: 0;
-  border-top: var(--border);
-  border-bottom: var(--border);
-  background: var(--color-white);
-}
-
-.expandedContainerOpen .expandedContainer {
-  padding: var(--space-S);
-  padding-bottom: var(--space-M);
-  transform: translateY(5.8rem);
-  opacity: 1;
-  border-top: var(--border);
-  border-bottom: var(--border);
-  z-index: 2;
 }
 
 .spinner {

--- a/applications/fishing-map/src/features/search/Search.module.css
+++ b/applications/fishing-map/src/features/search/Search.module.css
@@ -20,7 +20,7 @@
 }
 
 .expandedArrow {
-  left: 0 !important;
+  left: -5px !important;
 }
 
 .expandedArrow::before {

--- a/applications/fishing-map/src/features/search/Search.tsx
+++ b/applications/fishing-map/src/features/search/Search.tsx
@@ -18,6 +18,7 @@ import { resetWorkspaceSearchQuery } from 'features/workspace/workspace.slice'
 import { AsyncReducerStatus } from 'types'
 import { getFlagById } from 'utils/flags'
 import { formatInfoField } from 'utils/info'
+import ExpandedContainer from 'features/workspace/ExpandedContainer'
 import {
   fetchVesselSearchThunk,
   selectSearchResults,
@@ -175,19 +176,24 @@ function Search() {
               <Spinner className={styles.textSpinner} size="small" />
             )}
             {searchAllowed && (
-              <IconButton
-                icon={searchFiltersOpen ? 'close' : hasSearchFilters ? 'filter-on' : 'filter-off'}
-                tooltip={
-                  searchFiltersOpen
-                    ? t('search.filterClose', 'Close search filters')
-                    : t('search.filterOpen', 'Open search filters')
-                }
-                className={cx(styles.expandable, {
-                  [styles.expanded]: searchFiltersOpen,
-                })}
-                onClick={() => setSearchFiltersOpen(!searchFiltersOpen)}
-                tooltipPlacement="bottom"
-              />
+              <ExpandedContainer
+                visible={searchFiltersOpen}
+                onClickOutside={() => setSearchFiltersOpen(false)}
+                className={styles.expandedContainer}
+                arrowClassName={styles.expandedArrow}
+                component={<SearchFilters />}
+              >
+                <IconButton
+                  icon={searchFiltersOpen ? 'close' : hasSearchFilters ? 'filter-on' : 'filter-off'}
+                  tooltip={
+                    searchFiltersOpen
+                      ? t('search.filterClose', 'Close search filters')
+                      : t('search.filterOpen', 'Open search filters')
+                  }
+                  onClick={() => setSearchFiltersOpen(!searchFiltersOpen)}
+                  tooltipPlacement="bottom"
+                />
+              </ExpandedContainer>
             )}
             {searchFiltersOpen === false && (
               <IconButton
@@ -199,7 +205,6 @@ function Search() {
               />
             )}
           </div>
-          <SearchFilters className={cx(styles.expandedContainer)} />
           {searchStatus === AsyncReducerStatus.Loading &&
           searchPagination.loading === false ? null : searchAllowed ? (
             <Fragment>

--- a/applications/fishing-map/src/features/search/SearchFilters.tsx
+++ b/applications/fishing-map/src/features/search/SearchFilters.tsx
@@ -6,7 +6,6 @@ import MultiSelect from '@globalfishingwatch/ui-components/dist/multi-select'
 import InputDate from '@globalfishingwatch/ui-components/dist/input-date'
 import { getFlags } from 'utils/flags'
 import { getPlaceholderBySelections } from 'features/i18n/utils'
-import useClickedOutside from 'hooks/use-clicked-outside'
 import { DEFAULT_WORKSPACE } from 'data/config'
 import { getFiltersBySchema, SchemaFieldDataview } from 'features/datasets/datasets.utils'
 import { useSearchFiltersConnect } from './search.hook'
@@ -19,7 +18,7 @@ type SearchFiltersProps = {
 
 function SearchFilters({ className = '' }: SearchFiltersProps) {
   const { t } = useTranslation()
-  const { searchFilters, setSearchFiltersOpen, setSearchFilters } = useSearchFiltersConnect()
+  const { searchFilters, setSearchFilters } = useSearchFiltersConnect()
   const {
     flags,
     sources,
@@ -49,10 +48,8 @@ function SearchFilters({ className = '' }: SearchFiltersProps) {
   const fleetFilters = getFiltersBySchema(dataview, 'fleet')
   const originFilters = getFiltersBySchema(dataview, 'origin')
 
-  const expandedContainerRef = useClickedOutside(() => setSearchFiltersOpen(false))
-
   return (
-    <div className={cx(className)} ref={expandedContainerRef}>
+    <div className={cx(className)}>
       {sourceOptions && sourceOptions.length > 0 && (
         <MultiSelect
           label={t('layer.source_plural', 'Sources')}

--- a/applications/fishing-map/src/features/sidebar/Sidebar.module.css
+++ b/applications/fishing-map/src/features/sidebar/Sidebar.module.css
@@ -5,6 +5,7 @@
 
 :global(.scrollContainer) {
   height: 100%;
+  overflow-x: hidden;
   overflow-y: auto;
   width: 100%;
 }

--- a/applications/fishing-map/src/features/sidebar/SidebarHeader.module.css
+++ b/applications/fishing-map/src/features/sidebar/SidebarHeader.module.css
@@ -1,7 +1,7 @@
 :global(.sticky) {
   background-color: var(--color-white);
   box-shadow: var(--box-shadow);
-  z-index: 1;
+  z-index: 2;
 }
 
 .sidebarHeader {

--- a/applications/fishing-map/src/features/workspace/ExpandedContainer.module.css
+++ b/applications/fishing-map/src/features/workspace/ExpandedContainer.module.css
@@ -1,6 +1,7 @@
 .expandedContainer {
   min-width: 32rem;
   transform: translate(-5px, -5px);
+  transform-origin: top;
   transition: transform 150ms ease-out, opacity 150ms linear;
   opacity: 0;
 }

--- a/applications/fishing-map/src/features/workspace/ExpandedContainer.module.css
+++ b/applications/fishing-map/src/features/workspace/ExpandedContainer.module.css
@@ -1,0 +1,47 @@
+.expandedContainer {
+  min-width: 32rem;
+  transform: translate(-5px, -5px);
+  transition: transform 150ms ease-out, opacity 150ms linear;
+  opacity: 0;
+}
+
+.expandedContainerTop {
+  transform: translate(-5px, 5px);
+}
+
+.expandedContainerOpen {
+  padding: var(--space-S);
+  padding-bottom: var(--space-M);
+  background-color: var(--color-off-white);
+  opacity: 1;
+  border-top: var(--border);
+  border-bottom: var(--border);
+  z-index: 100;
+}
+
+.tooltipArrow,
+.tooltipArrow::before {
+  position: absolute;
+  left: 2px !important;
+  top: -3px !important;
+  width: 8px;
+  height: 8px;
+  z-index: 1;
+}
+
+.tooltipArrow::before {
+  content: '';
+  transform: rotate(45deg);
+  border-top: var(--border);
+  border-left: var(--border);
+  background-color: var(--color-off-white);
+}
+
+.tooltipArrowTop {
+  top: auto !important;
+  bottom: -7px !important;
+}
+
+.tooltipArrowTop::before {
+  transform: rotate(225deg);
+}

--- a/applications/fishing-map/src/features/workspace/ExpandedContainer.module.css
+++ b/applications/fishing-map/src/features/workspace/ExpandedContainer.module.css
@@ -1,6 +1,6 @@
 .expandedContainer {
-  min-width: 32rem;
-  transform: translate(-5px, -5px);
+  min-width: 31.8rem;
+  transform: translate(0, -5px);
   transform-origin: top;
   transition: transform 150ms ease-out, opacity 150ms linear;
   opacity: 0;
@@ -23,7 +23,6 @@
 .tooltipArrow,
 .tooltipArrow::before {
   position: absolute;
-  left: 2px !important;
   top: -3px !important;
   width: 8px;
   height: 8px;

--- a/applications/fishing-map/src/features/workspace/ExpandedContainer.tsx
+++ b/applications/fishing-map/src/features/workspace/ExpandedContainer.tsx
@@ -31,13 +31,16 @@ function ExpandedContainer({
   className = '',
   arrowClassName = '',
 }: ExpandedContainerProps) {
-  const config = { tension: 200, friction: 15 }
-  const initialStyles = { opacity: 0.4, transform: 'scaleY(0) translate(-5px, -5px)' }
+  const config = { tension: 300, friction: 50, velocity: 40 }
+  const initialStyles = { transform: 'translate(-5px, -20px)' }
   const [props, setSpring] = useSpring(() => initialStyles)
-  const onMount = useCallback(() => {
+  const onMount = useCallback(({ popper }) => {
+    const { y, height } = popper.getBoundingClientRect()
+    if (y + height >= window.innerHeight) {
+      popper.scrollIntoView({ behavior: 'smooth', block: 'end', inline: 'nearest' })
+    }
     setSpring({
-      opacity: 1,
-      transform: 'scaleY(1) translate(-5px, -5px)',
+      transform: 'translateY(-5px, -5px)',
       onRest: function () {
         return
       },
@@ -60,7 +63,7 @@ function ExpandedContainer({
       animation={true}
       onMount={onMount}
       onHide={onHide}
-      placement="bottom-end"
+      placement="bottom-start"
       popperOptions={popperOptions}
       onClickOutside={onClickOutside}
       render={(attrs) => {

--- a/applications/fishing-map/src/features/workspace/ExpandedContainer.tsx
+++ b/applications/fishing-map/src/features/workspace/ExpandedContainer.tsx
@@ -1,0 +1,92 @@
+import React from 'react'
+import cx from 'classnames'
+import Tippy from '@tippyjs/react'
+import { Options } from '@popperjs/core'
+import styles from './ExpandedContainer.module.css'
+
+interface ExpandedContainerProps {
+  visible: boolean
+  children: React.ReactElement
+  component: React.ReactElement
+  className?: string
+  arrowClassName?: string
+  onClickOutside: () => void
+}
+
+const popperOptions: Partial<Options> = {
+  modifiers: [
+    {
+      name: 'flip',
+      enabled: false,
+    },
+    {
+      name: 'sameWidth',
+      enabled: true,
+      phase: 'beforeWrite',
+      requires: ['computeStyles'],
+      fn: ({ state }) => {
+        // state.styles.popper.width = `${state.rects.reference.width}px`
+        state.styles.popper.left = '0px'
+      },
+      effect: ({ state }) => {
+        state.elements.popper.style.left = '0px'
+        // state.elements.popper.style.width = `${
+        //   state.elements.reference.getBoundingClientRect().width
+        // }px`
+      },
+    },
+  ],
+}
+
+function ExpandedContainer({
+  visible,
+  children,
+  component,
+  onClickOutside,
+  className = '',
+  arrowClassName = '',
+}: ExpandedContainerProps) {
+  return (
+    <Tippy
+      interactive
+      // appendTo="parent"
+      visible={visible}
+      placement="bottom-end"
+      popperOptions={popperOptions}
+      onClickOutside={onClickOutside}
+      render={(attrs) => {
+        const topPlacement = attrs['data-placement'] === 'top'
+        return (
+          <div
+            className={cx(
+              styles.expandedContainer,
+              {
+                [styles.expandedContainerOpen]: visible,
+                [styles.expandedContainerTop]: topPlacement,
+              },
+              className
+            )}
+            tabIndex={-1}
+            {...attrs}
+          >
+            {visible && component}
+            <div
+              className={cx(
+                styles.tooltipArrow,
+                {
+                  [styles.tooltipArrowTop]: topPlacement,
+                },
+                arrowClassName
+              )}
+              data-popper-arrow
+            ></div>
+          </div>
+        )
+      }}
+    >
+      {children}
+    </Tippy>
+  )
+}
+
+export default ExpandedContainer

--- a/applications/fishing-map/src/features/workspace/ExpandedContainer.tsx
+++ b/applications/fishing-map/src/features/workspace/ExpandedContainer.tsx
@@ -19,22 +19,22 @@ const popperOptions: Partial<Options> = {
       name: 'flip',
       enabled: false,
     },
-    {
-      name: 'sameWidth',
-      enabled: true,
-      phase: 'beforeWrite',
-      requires: ['computeStyles'],
-      fn: ({ state }) => {
-        // state.styles.popper.width = `${state.rects.reference.width}px`
-        state.styles.popper.left = '0px'
-      },
-      effect: ({ state }) => {
-        state.elements.popper.style.left = '0px'
-        // state.elements.popper.style.width = `${
-        //   state.elements.reference.getBoundingClientRect().width
-        // }px`
-      },
-    },
+    // {
+    //   name: 'sameWidth',
+    //   enabled: true,
+    //   phase: 'beforeWrite',
+    //   requires: ['computeStyles'],
+    //   fn: ({ state }) => {
+    //     // state.styles.popper.width = `${state.rects.reference.width}px`
+    //     state.styles.popper.left = '0px'
+    //   },
+    //   effect: ({ state }) => {
+    //     state.elements.popper.style.left = '0px'
+    //     // state.elements.popper.style.width = `${
+    //     //   state.elements.reference.getBoundingClientRect().width
+    //     // }px`
+    //   },
+    // },
   ],
 }
 

--- a/applications/fishing-map/src/features/workspace/ExpandedContainer.tsx
+++ b/applications/fishing-map/src/features/workspace/ExpandedContainer.tsx
@@ -17,11 +17,22 @@ interface ExpandedContainerProps {
 const popperOptions: Partial<Options> = {
   modifiers: [
     {
+      // To avoid the default 5px margin popper leaves between popper and reference
+      // https://popper.js.org/docs/v2/modifiers/prevent-overflow/#padding
+      name: 'preventOverflow',
+      options: {
+        padding: 0,
+      },
+    },
+    {
       name: 'flip',
       enabled: false,
     },
   ],
 }
+
+const config = { tension: 300, friction: 50, velocity: 40 }
+const initialStyles = { transform: 'translate(0, -20px)' }
 
 function ExpandedContainer({
   visible,
@@ -31,30 +42,35 @@ function ExpandedContainer({
   className = '',
   arrowClassName = '',
 }: ExpandedContainerProps) {
-  const config = { tension: 300, friction: 50, velocity: 40 }
-  const initialStyles = { transform: 'translate(-5px, -20px)' }
   const [props, setSpring] = useSpring(() => initialStyles)
-  const onMount = useCallback(({ popper }) => {
-    const { y, height } = popper.getBoundingClientRect()
-    if (y + height >= window.innerHeight) {
-      popper.scrollIntoView({ behavior: 'smooth', block: 'end', inline: 'nearest' })
-    }
-    setSpring({
-      transform: 'translateY(-5px, -5px)',
-      onRest: function () {
-        return
-      },
-      config,
-    })
-  }, [])
 
-  const onHide = useCallback(({ unmount }) => {
-    setSpring({
-      ...initialStyles,
-      onRest: unmount,
-      config: { ...config, clamp: true },
-    })
-  }, [])
+  const onMount = useCallback(
+    ({ popper }) => {
+      const { y, height } = popper.getBoundingClientRect()
+      if (y + height >= window.innerHeight) {
+        popper.scrollIntoView({ behavior: 'smooth', block: 'end', inline: 'nearest' })
+      }
+      setSpring({
+        transform: 'translateY(0, -5px)',
+        onRest: function () {
+          return
+        },
+        config,
+      })
+    },
+    [setSpring]
+  )
+
+  const onHide = useCallback(
+    ({ unmount }) => {
+      setSpring({
+        ...initialStyles,
+        onRest: unmount,
+        config: { ...config, clamp: true },
+      })
+    },
+    [setSpring]
+  )
 
   return (
     <Tippy
@@ -63,7 +79,7 @@ function ExpandedContainer({
       animation={true}
       onMount={onMount}
       onHide={onHide}
-      placement="bottom-start"
+      placement="bottom-end"
       popperOptions={popperOptions}
       onClickOutside={onClickOutside}
       render={(attrs) => {

--- a/applications/fishing-map/src/features/workspace/LayerPanel.module.css
+++ b/applications/fishing-map/src/features/workspace/LayerPanel.module.css
@@ -44,6 +44,7 @@
 
 .actions {
   opacity: 0;
+  z-index: 2;
   transition: opacity 150ms linear;
   line-height: 1;
   display: flex;
@@ -59,55 +60,8 @@
   z-index: 1;
 }
 
-.expandedContainer {
-  width: 100%;
-  position: absolute;
-  left: 0;
-  top: 1px;
-  transform: translateY(0);
-  transition: transform 150ms ease-out, opacity 150ms linear;
-  opacity: 0;
-}
-
-.expandedContainerOpen .expandedContainer {
-  padding: var(--space-S);
-  padding-bottom: var(--space-M);
-  background-color: var(--color-off-white);
-  transform: translateY(4.2rem);
-  opacity: 1;
-  border-top: var(--border);
-  border-bottom: var(--border);
-  z-index: 1;
-}
-
 .selectLabel:not(:first-child) {
   margin-top: var(--space-S);
-}
-
-.expandable::after {
-  content: '';
-  opacity: 0;
-  transform: translateX(-50%) translateY(-50%) rotateZ(-45deg);
-  transition: transform 150ms ease-out, opacity 150ms linear;
-}
-
-.expanded {
-  position: relative;
-  opacity: 1;
-}
-
-.expanded::after {
-  position: absolute;
-  width: 36%;
-  height: 36%;
-  border-top: var(--border);
-  border-right: var(--border);
-  top: 100%;
-  left: 50%;
-  background-color: var(--color-off-white);
-  transform: translateX(-50%) rotateZ(-45deg);
-  transform-origin: center;
-  opacity: 1;
 }
 
 .properties {
@@ -176,4 +130,3 @@
 :global(.printing) .switch > span {
   display: none !important;
 }
-

--- a/applications/fishing-map/src/features/workspace/context-areas/ContextAreaLayerPanel.tsx
+++ b/applications/fishing-map/src/features/workspace/context-areas/ContextAreaLayerPanel.tsx
@@ -10,13 +10,13 @@ import {
   TrackColorBarOptions,
 } from '@globalfishingwatch/ui-components/dist/color-bar'
 import { Generators } from '@globalfishingwatch/layer-composer'
-import useClickedOutside from 'hooks/use-clicked-outside'
 import { UrlDataviewInstance, AsyncReducerStatus } from 'types'
 import styles from 'features/workspace/LayerPanel.module.css'
 import { useDataviewInstancesConnect } from 'features/workspace/workspace.hook'
 import { resolveDataviewDatasetResource } from 'features/workspace/workspace.selectors'
 import { selectResourceByUrl } from 'features/resources/resources.slice'
 import { useDatasetsAPI } from 'features/datasets/datasets.hook'
+import ExpandedContainer from '../ExpandedContainer'
 
 const DATASET_REFRESH_TIMEOUT = 10000
 
@@ -63,7 +63,7 @@ function LayerPanel({ dataview }: LayerPanelProps): React.ReactElement {
   const closeExpandedContainer = () => {
     setColorOpen(false)
   }
-  const expandedContainerRef = useClickedOutside(closeExpandedContainer)
+
   const isCustomUserLayer = dataview.config?.type === Generators.Type.UserContext
 
   const dataset = dataview.datasets?.find((d) => d.type === DatasetTypes.Context)
@@ -170,17 +170,31 @@ function LayerPanel({ dataview }: LayerPanelProps): React.ReactElement {
             tooltipPlacement="top"
           />
           {layerActive && (
-            <IconButton
-              icon={colorOpen ? 'color-picker' : 'color-picker-filled'}
-              size="small"
-              style={colorOpen ? {} : { color: dataview.config?.color }}
-              tooltip={t('layer.color_change', 'Change color')}
-              tooltipPlacement="top"
-              onClick={onToggleColorOpen}
-              className={cx(styles.actionButton, styles.expandable, {
-                [styles.expanded]: colorOpen,
-              })}
-            />
+            <ExpandedContainer
+              visible={colorOpen}
+              onClickOutside={closeExpandedContainer}
+              component={
+                <ColorBar
+                  colorBarOptions={
+                    isEnviromentalLayerUsedAsContextTemporally
+                      ? HeatmapColorBarOptions
+                      : TrackColorBarOptions
+                  }
+                  selectedColor={dataview.config?.color}
+                  onColorClick={changeColor}
+                />
+              }
+            >
+              <IconButton
+                icon={colorOpen ? 'color-picker' : 'color-picker-filled'}
+                size="small"
+                style={colorOpen ? {} : { color: dataview.config?.color }}
+                tooltip={t('layer.color_change', 'Change color')}
+                tooltipPlacement="top"
+                onClick={onToggleColorOpen}
+                className={cx(styles.actionButton)}
+              />
+            </ExpandedContainer>
           )}
           {isCustomUserLayer && (
             <IconButton
@@ -199,19 +213,6 @@ function LayerPanel({ dataview }: LayerPanelProps): React.ReactElement {
           <div id={`legend_${dataview.id}`}></div>
         </div>
       )}
-      <div className={styles.expandedContainer} ref={expandedContainerRef}>
-        {colorOpen && (
-          <ColorBar
-            colorBarOptions={
-              isEnviromentalLayerUsedAsContextTemporally
-                ? HeatmapColorBarOptions
-                : TrackColorBarOptions
-            }
-            selectedColor={dataview.config?.color}
-            onColorClick={changeColor}
-          />
-        )}
-      </div>
     </div>
   )
 }

--- a/applications/fishing-map/src/features/workspace/environmental/EnvironmentalLayerPanel.tsx
+++ b/applications/fishing-map/src/features/workspace/environmental/EnvironmentalLayerPanel.tsx
@@ -8,12 +8,12 @@ import {
   ColorBarOption,
   HeatmapColorBarOptions,
 } from '@globalfishingwatch/ui-components/dist/color-bar'
-import useClickedOutside from 'hooks/use-clicked-outside'
 import { UrlDataviewInstance, AsyncReducerStatus } from 'types'
 import styles from 'features/workspace/LayerPanel.module.css'
 import { useDataviewInstancesConnect } from 'features/workspace/workspace.hook'
 import { resolveDataviewDatasetResource } from 'features/workspace/workspace.selectors'
 import { selectResourceByUrl } from 'features/resources/resources.slice'
+import ExpandedContainer from '../ExpandedContainer'
 
 type LayerPanelProps = {
   dataview: UrlDataviewInstance
@@ -53,7 +53,6 @@ function LayerPanel({ dataview }: LayerPanelProps): React.ReactElement {
   const closeExpandedContainer = () => {
     setColorOpen(false)
   }
-  const expandedContainerRef = useClickedOutside(closeExpandedContainer)
 
   const dataset = dataview.datasets?.find((d) => d.type === DatasetTypes.Fourwings)
   const title = t(`datasets:${dataset?.id}.name`)
@@ -95,29 +94,31 @@ function LayerPanel({ dataview }: LayerPanelProps): React.ReactElement {
             tooltipPlacement="top"
           />
           {layerActive && (
-            <IconButton
-              icon={colorOpen ? 'color-picker' : 'color-picker-filled'}
-              size="small"
-              style={colorOpen ? {} : { color: dataview.config?.color }}
-              tooltip={t('layer.color_change', 'Change color')}
-              tooltipPlacement="top"
-              onClick={onToggleColorOpen}
-              className={cx(styles.actionButton, styles.expandable, {
-                [styles.expanded]: colorOpen,
-              })}
-            />
+            <ExpandedContainer
+              visible={colorOpen}
+              onClickOutside={closeExpandedContainer}
+              component={
+                <ColorBar
+                  colorBarOptions={HeatmapColorBarOptions}
+                  selectedColor={dataview.config?.color}
+                  onColorClick={changeColor}
+                />
+              }
+            >
+              <IconButton
+                icon={colorOpen ? 'color-picker' : 'color-picker-filled'}
+                size="small"
+                style={colorOpen ? {} : { color: dataview.config?.color }}
+                tooltip={t('layer.color_change', 'Change color')}
+                tooltipPlacement="top"
+                onClick={onToggleColorOpen}
+                className={styles.actionButton}
+              />
+            </ExpandedContainer>
           )}
         </div>
       </div>
-      <div className={styles.expandedContainer} ref={expandedContainerRef}>
-        {colorOpen && (
-          <ColorBar
-            colorBarOptions={HeatmapColorBarOptions}
-            selectedColor={dataview.config?.color}
-            onColorClick={changeColor}
-          />
-        )}
-      </div>
+
       {layerActive && (
         <div className={styles.properties}>
           <div id={`legend_${dataview.id}`}></div>

--- a/applications/fishing-map/src/features/workspace/heatmaps/HeatmapLayerPanel.tsx
+++ b/applications/fishing-map/src/features/workspace/heatmaps/HeatmapLayerPanel.tsx
@@ -3,7 +3,6 @@ import cx from 'classnames'
 import { useTranslation } from 'react-i18next'
 import { useSelector } from 'react-redux'
 import { Switch, IconButton, TagList, Tooltip } from '@globalfishingwatch/ui-components'
-import useClickedOutside from 'hooks/use-clicked-outside'
 import { getFlagsByIds } from 'utils/flags'
 import { UrlDataviewInstance } from 'types'
 import styles from 'features/workspace/LayerPanel.module.css'
@@ -12,6 +11,7 @@ import { selectBivariate } from 'features/app/app.selectors'
 import { useLocationConnect } from 'routes/routes.hook'
 import { getSchemaFieldsSelectedInDataview } from 'features/datasets/datasets.utils'
 import { DEFAULT_PRESENCE_DATAVIEW_ID } from 'data/workspaces'
+import ExpandedContainer from '../ExpandedContainer'
 import Filters from './HeatmapFilters'
 import HeatmapInfoModal from './HeatmapInfoModal'
 import { getSourcesSelectedInDataview } from './heatmaps.utils'
@@ -63,7 +63,6 @@ function LayerPanel({ dataview, index, isOpen }: LayerPanelProps): React.ReactEl
   const closeExpandedContainer = () => {
     setFiltersOpen(false)
   }
-  const expandedContainerRef = useClickedOutside(closeExpandedContainer)
 
   const datasetName =
     dataview.dataviewId === DEFAULT_PRESENCE_DATAVIEW_ID
@@ -99,20 +98,24 @@ function LayerPanel({ dataview, index, isOpen }: LayerPanelProps): React.ReactEl
         )}
         <div className={cx('print-hidden', styles.actions, { [styles.active]: layerActive })}>
           {layerActive && (
-            <IconButton
-              icon={filterOpen ? 'filter-on' : 'filter-off'}
-              size="small"
-              onClick={onToggleFilterOpen}
-              className={cx(styles.actionButton, styles.expandable, {
-                [styles.expanded]: filterOpen,
-              })}
-              tooltip={
-                filterOpen
-                  ? t('layer.filterClose', 'Close filters')
-                  : t('layer.filterOpen', 'Open filters')
-              }
-              tooltipPlacement="top"
-            />
+            <ExpandedContainer
+              visible={filterOpen}
+              onClickOutside={closeExpandedContainer}
+              component={<Filters dataview={dataview} />}
+            >
+              <IconButton
+                icon={filterOpen ? 'filter-on' : 'filter-off'}
+                size="small"
+                onClick={onToggleFilterOpen}
+                className={styles.actionButton}
+                tooltip={
+                  filterOpen
+                    ? t('layer.filterClose', 'Close filters')
+                    : t('layer.filterOpen', 'Open filters')
+                }
+                tooltipPlacement="top"
+              />
+            </ExpandedContainer>
           )}
           <IconButton
             icon="info"
@@ -189,9 +192,6 @@ function LayerPanel({ dataview, index, isOpen }: LayerPanelProps): React.ReactEl
           <div id={`legend_${dataview.id}`}></div>
         </div>
       )}
-      <div className={styles.expandedContainer} ref={expandedContainerRef}>
-        {filterOpen && <Filters dataview={dataview} />}
-      </div>
       <HeatmapInfoModal
         dataview={dataview}
         isOpen={modalInfoOpen}

--- a/applications/fishing-map/src/features/workspace/vessels/VesselLayerPanel.tsx
+++ b/applications/fishing-map/src/features/workspace/vessels/VesselLayerPanel.tsx
@@ -15,7 +15,6 @@ import {
   filterSegmentsByTimerange,
 } from '@globalfishingwatch/data-transforms'
 import { formatInfoField } from 'utils/info'
-import useClickedOutside from 'hooks/use-clicked-outside'
 import { UrlDataviewInstance, AsyncReducerStatus } from 'types'
 import styles from 'features/workspace/LayerPanel.module.css'
 import { useDataviewInstancesConnect } from 'features/workspace/workspace.hook'
@@ -27,6 +26,7 @@ import { useMapboxInstance } from 'features/map/map.context'
 import useViewport from 'features/map/map-viewport.hooks'
 import { useTimerangeConnect } from 'features/timebar/timebar.hooks'
 import { DATAVIEW_INSTANCE_PREFIX } from 'features/dataviews/dataviews.utils'
+import ExpandedContainer from '../ExpandedContainer'
 
 // Translations by feature.unit static keys
 // t('vessel.flag', 'Flag')
@@ -118,7 +118,6 @@ function LayerPanel({ dataview }: LayerPanelProps): React.ReactElement {
     setColorOpen(false)
     setInfoOpen(false)
   }
-  const expandedContainerRef = useClickedOutside(closeExpandedContainer)
 
   const vesselId = dataview.id.replace(DATAVIEW_INSTANCE_PREFIX, '')
   const title = vesselName || vesselId || dataview.name
@@ -163,17 +162,27 @@ function LayerPanel({ dataview }: LayerPanelProps): React.ReactElement {
             <Fragment>
               {layerActive && (
                 <Fragment>
-                  <IconButton
-                    icon={colorOpen ? 'color-picker' : 'color-picker-filled'}
-                    size="small"
-                    style={colorOpen ? {} : { color: dataview.config?.color }}
-                    tooltip={t('layer.color_change', 'Change color')}
-                    tooltipPlacement="top"
-                    onClick={onToggleColorOpen}
-                    className={cx(styles.actionButton, styles.expandable, {
-                      [styles.expanded]: colorOpen,
-                    })}
-                  />
+                  <ExpandedContainer
+                    visible={colorOpen}
+                    onClickOutside={closeExpandedContainer}
+                    component={
+                      <ColorBar
+                        colorBarOptions={TrackColorBarOptions}
+                        selectedColor={dataview.config?.color}
+                        onColorClick={changeTrackColor}
+                      />
+                    }
+                  >
+                    <IconButton
+                      icon={colorOpen ? 'color-picker' : 'color-picker-filled'}
+                      size="small"
+                      style={colorOpen ? {} : { color: dataview.config?.color }}
+                      tooltip={t('layer.color_change', 'Change color')}
+                      tooltipPlacement="top"
+                      onClick={onToggleColorOpen}
+                      className={styles.actionButton}
+                    />
+                  </ExpandedContainer>
                   <IconButton
                     icon="target"
                     size="small"
@@ -184,16 +193,52 @@ function LayerPanel({ dataview }: LayerPanelProps): React.ReactElement {
                   />
                 </Fragment>
               )}
-              <IconButton
-                icon="info"
-                size="small"
-                className={styles.actionButton}
-                tooltip={
-                  infoOpen ? t('layer.infoClose', 'Hide info') : t('layer.infoOpen', 'Show info')
+              <ExpandedContainer
+                visible={infoOpen}
+                onClickOutside={closeExpandedContainer}
+                component={
+                  <ul className={styles.infoContent}>
+                    {dataview.infoConfig?.fields.map((field: any) => {
+                      const fieldValue = resource?.data?.[field.id as keyof Vessel]
+                      if (!fieldValue) return null
+                      return (
+                        <li key={field.id} className={styles.infoContentItem}>
+                          <label>{t(`vessel.${field.id}`)}</label>
+                          <span>
+                            {field.type === 'date' ? (
+                              <I18nDate date={fieldValue} />
+                            ) : field.type === 'flag' ? (
+                              <I18nFlag iso={fieldValue} />
+                            ) : field.id === 'mmsi' ? (
+                              <a
+                                className={styles.link}
+                                target="_blank"
+                                rel="noreferrer"
+                                href={`https://www.marinetraffic.com/en/ais/details/ships/${fieldValue}`}
+                              >
+                                {formatInfoField(fieldValue, field.type)}
+                              </a>
+                            ) : (
+                              formatInfoField(fieldValue, field.type)
+                            )}
+                          </span>
+                        </li>
+                      )
+                    })}
+                  </ul>
                 }
-                onClick={onToggleInfoOpen}
-                tooltipPlacement="top"
-              />
+              >
+                <IconButton
+                  icon="info"
+                  size="small"
+                  className={styles.actionButton}
+                  tooltip={
+                    infoOpen ? t('layer.infoClose', 'Hide info') : t('layer.infoOpen', 'Show info')
+                  }
+                  onClick={onToggleInfoOpen}
+                  tooltipPlacement="top"
+                />
+              </ExpandedContainer>
               <IconButton
                 icon="delete"
                 size="small"
@@ -205,46 +250,6 @@ function LayerPanel({ dataview }: LayerPanelProps): React.ReactElement {
             </Fragment>
           )}
         </div>
-      </div>
-      <div className={styles.expandedContainer} ref={expandedContainerRef}>
-        {colorOpen && (
-          <ColorBar
-            colorBarOptions={TrackColorBarOptions}
-            selectedColor={dataview.config?.color}
-            onColorClick={changeTrackColor}
-          />
-        )}
-        {infoOpen && (
-          <ul className={styles.infoContent}>
-            {dataview.infoConfig?.fields.map((field: any) => {
-              const fieldValue = resource?.data?.[field.id as keyof Vessel]
-              if (!fieldValue) return null
-              return (
-                <li key={field.id} className={styles.infoContentItem}>
-                  <label>{t(`vessel.${field.id}`)}</label>
-                  <span>
-                    {field.type === 'date' ? (
-                      <I18nDate date={fieldValue} />
-                    ) : field.type === 'flag' ? (
-                      <I18nFlag iso={fieldValue} />
-                    ) : field.id === 'mmsi' ? (
-                      <a
-                        className={styles.link}
-                        target="_blank"
-                        rel="noreferrer"
-                        href={`https://www.marinetraffic.com/en/ais/details/ships/${fieldValue}`}
-                      >
-                        {formatInfoField(fieldValue, field.type)}
-                      </a>
-                    ) : (
-                      formatInfoField(fieldValue, field.type)
-                    )}
-                  </span>
-                </li>
-              )
-            })}
-          </ul>
-        )}
       </div>
     </div>
   )

--- a/yarn.lock
+++ b/yarn.lock
@@ -6339,7 +6339,17 @@ babel-jest@^26.6.0, babel-jest@^26.6.3:
     graceful-fs "^4.2.4"
     slash "^3.0.0"
 
-babel-loader@8.0.6, babel-loader@8.1.0:
+babel-loader@8.0.6:
+  version "8.0.6"
+  resolved "https://registry.yarnpkg.com/babel-loader/-/babel-loader-8.0.6.tgz#e33bdb6f362b03f4bb141a0c21ab87c501b70dfb"
+  integrity sha512-4BmWKtBOBm13uoUwd08UwjZlaw3O9GWf456R9j+5YykFZ6LUIjIKLc0zEZf+hauxPOJs96C8k6FvYD09vWzhYw==
+  dependencies:
+    find-cache-dir "^2.0.0"
+    loader-utils "^1.0.2"
+    mkdirp "^0.5.1"
+    pify "^4.0.1"
+
+babel-loader@8.1.0:
   version "8.1.0"
   resolved "https://registry.yarnpkg.com/babel-loader/-/babel-loader-8.1.0.tgz#c611d5112bd5209abe8b9fa84c3e4da25275f1c3"
   integrity sha512-7q7nC1tYOrqvUrN3LQK4GwSk/TQorZSOlO9C+RZDZpODgyN4ZlCqE5q9cDsyWOliN+aU9B4JX01xK9eJXowJLw==
@@ -14691,7 +14701,7 @@ loader-utils@^0.2.16:
     json5 "^0.5.0"
     object-assign "^4.0.1"
 
-loader-utils@^1.1.0, loader-utils@^1.2.3, loader-utils@^1.4.0:
+loader-utils@^1.0.2, loader-utils@^1.1.0, loader-utils@^1.2.3, loader-utils@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-1.4.0.tgz#c579b5e34cb34b1a74edc6c1fb36bfa371d5a613"
   integrity sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA==
@@ -18785,7 +18795,7 @@ react-smooth@^1.0.5:
     raf "^3.4.0"
     react-transition-group "^2.5.0"
 
-react-spring@^8.0.19:
+react-spring@^8.0.19, react-spring@^8.0.27:
   version "8.0.27"
   resolved "https://registry.yarnpkg.com/react-spring/-/react-spring-8.0.27.tgz#97d4dee677f41e0b2adcb696f3839680a3aa356a"
   integrity sha512-nDpWBe3ZVezukNRandTeLSPcwwTMjNVu1IDq9qA/AMiUqHuRN4BeSWvKr3eIxxg1vtiYiOLy4FqdfCP5IoP77g==


### PR DESCRIPTION
Simplify and remove duplication logic using the https://github.com/atomiks/tippyjs-react#headless-tippy for expanded containers and fix the bug of firing twice the click outside
- [x] Color picker
- [x] Heatmap filters
- [x] Search filters 

As we were including react-spring for the timber animation I'm using it also to render the appear animation

![Kapture 2021-02-15 at 09 38 40](https://user-images.githubusercontent.com/10500650/107923333-a0852500-6f71-11eb-876d-f887ab92b38f.gif)

cc @satellitestudiodesign to review the animation