### PR TITLE
Fishingmap/load categories by spreadsheet

### DIFF
--- a/.changeset/tasty-starfishes-search.md
+++ b/.changeset/tasty-starfishes-search.md
@@ -1,0 +1,6 @@
+---
+"@globalfishingwatch/ui-components": patch
+"@globalfishingwatchapp/fishing-map": patch
+---
+
+Rename fishing-activity category icon to match names from spreadsheets

--- a/applications/fishing-map/src/features/app/App.tsx
+++ b/applications/fishing-map/src/features/app/App.tsx
@@ -46,6 +46,7 @@ function App(): React.ReactElement {
   const locationType = useSelector(selectLocationType)
   const urlWorkspaceId = useSelector(selectWorkspaceId)
   const currentWorkspaceId = useSelector(selectCurrentWorkspaceId)
+  // const availableCategories = useSelector(selectAvailableWorkspacesCategories)
   const narrowSidebar = useSelector(isWorkspaceLocation)
 
   const { debugActive, dispatchToggleDebugMenu } = useDebugMenu()
@@ -58,7 +59,25 @@ function App(): React.ReactElement {
     dispatch(fetchHighlightWorkspacesThunk())
   }, [dispatch])
 
-  const homeNeedsFetch = locationType === HOME && currentWorkspaceId !== DEFAULT_WORKSPACE_ID
+  const isHomeLocation = locationType === HOME
+  // TODO: decide if we want to redirect when only one category is supported and
+  // we want to hide the default workspace
+  // const onlyOneCategorySupported = availableCategories?.length === 1
+  // const categorySupportedNotFishing =
+  //   availableCategories?.[0] === WorkspaceCategories.FishingActivity
+
+  // useEffect(() => {
+  //   if (isHomeLocation && onlyOneCategorySupported && !categorySupportedNotFishing) {
+  //     dispatchLocation(
+  //       WORKSPACES_LIST,
+  //       { category: availableCategories?.[0] as WorkspaceCategories },
+  //       true
+  //     )
+  //   }
+  //   // eslint-disable-next-line react-hooks/exhaustive-deps
+  // }, [isHomeLocation, onlyOneCategorySupported])
+
+  const homeNeedsFetch = isHomeLocation && currentWorkspaceId !== DEFAULT_WORKSPACE_ID
   const hasWorkspaceIdChanged = locationType === WORKSPACE && currentWorkspaceId !== urlWorkspaceId
   useEffect(() => {
     if (userLogged && (homeNeedsFetch || hasWorkspaceIdChanged)) {

--- a/applications/fishing-map/src/features/app/App.tsx
+++ b/applications/fishing-map/src/features/app/App.tsx
@@ -22,6 +22,7 @@ import { isUserLogged } from 'features/user/user.selectors'
 import { HOME, WORKSPACE } from 'routes/routes'
 import { fetchWorkspaceThunk } from 'features/workspace/workspace.slice'
 import { DEFAULT_WORKSPACE_ID } from 'data/workspaces'
+import { fetchHighlightWorkspacesThunk } from 'features/workspaces-list/workspaces-list.slice'
 import styles from './App.module.css'
 import { selectSidebarOpen } from './app.selectors'
 
@@ -51,6 +52,10 @@ function App(): React.ReactElement {
 
   useEffect(() => {
     dispatch(fetchUserThunk())
+  }, [dispatch])
+
+  useEffect(() => {
+    dispatch(fetchHighlightWorkspacesThunk())
   }, [dispatch])
 
   const homeNeedsFetch = locationType === HOME && currentWorkspaceId !== DEFAULT_WORKSPACE_ID

--- a/applications/fishing-map/src/features/sidebar/CategoryTabs.tsx
+++ b/applications/fishing-map/src/features/sidebar/CategoryTabs.tsx
@@ -3,7 +3,7 @@ import Link from 'redux-first-router-link'
 import { useTranslation } from 'react-i18next'
 import cx from 'classnames'
 import { useSelector } from 'react-redux'
-import Icon from '@globalfishingwatch/ui-components/dist/icon'
+import Icon, { IconType } from '@globalfishingwatch/ui-components/dist/icon'
 import GFWAPI from '@globalfishingwatch/api-client'
 import Tooltip from '@globalfishingwatch/ui-components/dist/tooltip'
 import { Locale } from 'types'
@@ -13,6 +13,7 @@ import { selectLocationCategory, selectLocationType } from 'routes/routes.select
 import { selectUserData } from 'features/user/user.slice'
 import { isGuestUser } from 'features/user/user.selectors'
 import { LocaleLabels } from 'features/i18n/i18n'
+import { selectHighlightedWorkspaces } from 'features/workspaces-list/workspaces-list.slice'
 import styles from './CategoryTabs.module.css'
 
 const DEFAULT_WORKSPACE_LIST_VIEWPORT = {
@@ -39,6 +40,18 @@ function getLinkToCategory(category: WorkspaceCategories) {
 function CategoryTabs({ onMenuClick }: CategoryTabsProps) {
   const { t, i18n } = useTranslation()
   const guestUser = useSelector(isGuestUser)
+  const highlightedWorkspaces = useSelector(selectHighlightedWorkspaces)
+  const availableCategories = highlightedWorkspaces
+    ? Object.entries(highlightedWorkspaces)
+        .filter(([category, entries]) => {
+          const hasEntries = entries.length > 0
+          const isInSupportedCategories = Object.values(WorkspaceCategories).includes(
+            category as WorkspaceCategories
+          )
+          return hasEntries && isInSupportedCategories
+        })
+        .map(([category]) => category)
+    : []
   const locationType = useSelector(selectLocationType)
   const locationCategory = useSelector(selectLocationCategory)
   const userData = useSelector(selectUserData)
@@ -57,43 +70,23 @@ function CategoryTabs({ onMenuClick }: CategoryTabsProps) {
           <Icon icon="menu" />
         </span>
       </li>
-      <li
-        className={cx(styles.tab, {
-          [styles.current]:
-            locationCategory === WorkspaceCategories.FishingActivity || locationType === HOME,
-        })}
-      >
-        <Link
-          className={styles.tabContent}
-          to={getLinkToCategory(WorkspaceCategories.FishingActivity)}
+      {availableCategories.map((category, index) => (
+        <li
+          key={category}
+          className={cx(styles.tab, {
+            [styles.current]:
+              locationCategory === (category as WorkspaceCategories) ||
+              (index === 0 && locationType === HOME),
+          })}
         >
-          <Icon icon="category-fishing" />
-        </Link>
-      </li>
-      <li
-        className={cx(styles.tab, {
-          [styles.current]: locationCategory === WorkspaceCategories.MarineReserves,
-        })}
-      >
-        <Link
-          className={styles.tabContent}
-          to={getLinkToCategory(WorkspaceCategories.MarineReserves)}
-        >
-          <Icon icon="category-marine-reserves" />
-        </Link>
-      </li>
-      <li
-        className={cx(styles.tab, {
-          [styles.current]: locationCategory === WorkspaceCategories.CountryPortals,
-        })}
-      >
-        <Link
-          className={styles.tabContent}
-          to={getLinkToCategory(WorkspaceCategories.CountryPortals)}
-        >
-          <Icon icon="category-country-portals" />
-        </Link>
-      </li>
+          <Link
+            className={styles.tabContent}
+            to={getLinkToCategory(category as WorkspaceCategories)}
+          >
+            <Icon icon={`category-${category}` as IconType} />
+          </Link>
+        </li>
+      ))}
       <div className={styles.separator}></div>
       <li className={cx(styles.tab, styles.languageToggle)}>
         <button className={styles.tabContent}>

--- a/applications/fishing-map/src/features/sidebar/CategoryTabs.tsx
+++ b/applications/fishing-map/src/features/sidebar/CategoryTabs.tsx
@@ -13,7 +13,7 @@ import { selectLocationCategory, selectLocationType } from 'routes/routes.select
 import { selectUserData } from 'features/user/user.slice'
 import { isGuestUser } from 'features/user/user.selectors'
 import { LocaleLabels } from 'features/i18n/i18n'
-import { selectHighlightedWorkspaces } from 'features/workspaces-list/workspaces-list.slice'
+import { selectAvailableWorkspacesCategories } from 'features/workspaces-list/workspaces-list.selectors'
 import styles from './CategoryTabs.module.css'
 
 const DEFAULT_WORKSPACE_LIST_VIEWPORT = {
@@ -40,20 +40,9 @@ function getLinkToCategory(category: WorkspaceCategories) {
 function CategoryTabs({ onMenuClick }: CategoryTabsProps) {
   const { t, i18n } = useTranslation()
   const guestUser = useSelector(isGuestUser)
-  const highlightedWorkspaces = useSelector(selectHighlightedWorkspaces)
-  const availableCategories = highlightedWorkspaces
-    ? Object.entries(highlightedWorkspaces)
-        .filter(([category, entries]) => {
-          const hasEntries = entries.length > 0
-          const isInSupportedCategories = Object.values(WorkspaceCategories).includes(
-            category as WorkspaceCategories
-          )
-          return hasEntries && isInSupportedCategories
-        })
-        .map(([category]) => category)
-    : []
   const locationType = useSelector(selectLocationType)
   const locationCategory = useSelector(selectLocationCategory)
+  const availableCategories = useSelector(selectAvailableWorkspacesCategories)
   const userData = useSelector(selectUserData)
   const initials = userData
     ? `${userData?.firstName?.slice(0, 1)}${userData?.lastName?.slice(0, 1)}`
@@ -70,7 +59,7 @@ function CategoryTabs({ onMenuClick }: CategoryTabsProps) {
           <Icon icon="menu" />
         </span>
       </li>
-      {availableCategories.map((category, index) => (
+      {availableCategories?.map((category, index) => (
         <li
           key={category}
           className={cx(styles.tab, {

--- a/applications/fishing-map/src/features/sidebar/Sidebar.tsx
+++ b/applications/fishing-map/src/features/sidebar/Sidebar.tsx
@@ -12,6 +12,8 @@ import User from 'features/user/User'
 import Workspace from 'features/workspace/Workspace'
 import WorkspacesList from 'features/workspaces-list/WorkspacesList'
 import NewDataset from 'features/datasets/NewDataset'
+import { AsyncReducerStatus } from 'types'
+import { selectHighlightedWorkspacesStatus } from 'features/workspaces-list/workspaces-list.slice'
 import styles from './Sidebar.module.css'
 import CategoryTabs from './CategoryTabs'
 import SidebarHeader from './SidebarHeader'
@@ -25,10 +27,11 @@ function Sidebar({ onMenuClick }: SidebarProps) {
   const locationType = useSelector(selectLocationType)
   const userLogged = useSelector(isUserLogged)
   const userAuthorized = useSelector(isUserAuthorized)
+  const highlightedWorkspacesStatus = useSelector(selectHighlightedWorkspacesStatus)
   const dispatch = useDispatch()
 
   const sidebarComponent = useMemo(() => {
-    if (!userLogged) {
+    if (!userLogged || highlightedWorkspacesStatus === AsyncReducerStatus.Loading) {
       return <Spinner />
     }
     // TODO remove once public release and permissions to use map in anonymous user
@@ -55,7 +58,7 @@ function Sidebar({ onMenuClick }: SidebarProps) {
       return <WorkspacesList />
     }
     return <Workspace />
-  }, [dispatch, locationType, userAuthorized, userLogged])
+  }, [dispatch, locationType, userAuthorized, userLogged, highlightedWorkspacesStatus])
 
   if (searchQuery !== undefined) {
     return <Search />

--- a/applications/fishing-map/src/features/workspaces-list/WorkspacesList.tsx
+++ b/applications/fishing-map/src/features/workspaces-list/WorkspacesList.tsx
@@ -1,37 +1,26 @@
-import React, { useEffect } from 'react'
+import React from 'react'
 import cx from 'classnames'
-import { useDispatch, useSelector } from 'react-redux'
+import { useSelector } from 'react-redux'
 import Link from 'redux-first-router-link'
 import { useTranslation } from 'react-i18next'
 import { Spinner } from '@globalfishingwatch/ui-components'
-import { selectLocationCategory } from 'routes/routes.selectors'
+import { isValidLocationCategory, selectLocationCategory } from 'routes/routes.selectors'
 import { HOME, WORKSPACE } from 'routes/routes'
 import { AsyncReducerStatus } from 'types'
-import { DEFAULT_WORKSPACE_KEY, WorkspaceCategories } from 'data/workspaces'
+import { DEFAULT_WORKSPACE_KEY } from 'data/workspaces'
 import styles from './WorkspacesList.module.css'
 import { selectCurrentHighlightedWorkspaces } from './workspaces-list.selectors'
-import {
-  fetchHighlightWorkspacesThunk,
-  selectHighlightedWorkspacesStatus,
-} from './workspaces-list.slice'
+import { selectHighlightedWorkspacesStatus } from './workspaces-list.slice'
 
 function WorkspacesList() {
   const { t } = useTranslation()
-  const dispatch = useDispatch()
   const locationCategory = useSelector(selectLocationCategory)
   const userFriendlyCategory = locationCategory.replace('-', ' ')
   const highlightedWorkspaces = useSelector(selectCurrentHighlightedWorkspaces)
   const highlightedWorkspacesStatus = useSelector(selectHighlightedWorkspacesStatus)
-  const validCategory = Object.values(WorkspaceCategories).includes(locationCategory)
+  const validCategory = useSelector(isValidLocationCategory)
 
-  useEffect(() => {
-    if (validCategory && highlightedWorkspacesStatus !== AsyncReducerStatus.Finished) {
-      dispatch(fetchHighlightWorkspacesThunk())
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [validCategory])
-
-  if (!validCategory) {
+  if (highlightedWorkspacesStatus === AsyncReducerStatus.Finished && !validCategory) {
     return (
       <div className={styles.placeholder}>
         <h2>{t('errors.pageNotFound', 'Page not found')}</h2>

--- a/applications/fishing-map/src/features/workspaces-list/workspaces-list.selectors.ts
+++ b/applications/fishing-map/src/features/workspaces-list/workspaces-list.selectors.ts
@@ -23,6 +23,24 @@ export const selectCurrentWorkspaces = createSelector(
   }
 )
 
+export const selectAvailableWorkspacesCategories = createSelector(
+  [selectHighlightedWorkspaces],
+  (highlightedWorkspaces) => {
+    return (
+      highlightedWorkspaces &&
+      Object.entries(highlightedWorkspaces)
+        .filter(([category, entries]) => {
+          const hasEntries = entries.length > 0
+          const isInSupportedCategories = Object.values(WorkspaceCategories).includes(
+            category as WorkspaceCategories
+          )
+          return hasEntries && isInSupportedCategories
+        })
+        .map(([category]) => category as WorkspaceCategories)
+    )
+  }
+)
+
 export const selectCurrentHighlightedWorkspaces = createSelector(
   [selectLocationCategory, selectHighlightedWorkspaces, selectWorkspaces],
   (locationCategory, highlightedWorkspaces, apiWorkspaces): HighlightedWorkspace[] | undefined => {

--- a/applications/fishing-map/src/routes/routes.selectors.ts
+++ b/applications/fishing-map/src/routes/routes.selectors.ts
@@ -49,6 +49,11 @@ export const selectLocationCategory = createSelector(
   (payload) => payload?.category as WorkspaceCategories
 )
 
+export const isValidLocationCategory = createSelector(
+  [selectLocationCategory],
+  (locationCategory) => Object.values(WorkspaceCategories).includes(locationCategory)
+)
+
 export const selectUrlMapZoomQuery = selectQueryParam<number>('zoom')
 export const selectUrlMapLatitudeQuery = selectQueryParam<number>('latitude')
 export const selectUrlMapLongitudeQuery = selectQueryParam<number>('longitude')

--- a/packages/ui-components/src/icon/Icon.tsx
+++ b/packages/ui-components/src/icon/Icon.tsx
@@ -58,7 +58,7 @@ export const IconComponents = {
   calendar: Calendar,
   camera: Camera,
   'category-country-portals': CategoryCountryPortals,
-  'category-fishing': CategoryFishing,
+  'category-fishing-activity': CategoryFishing,
   'category-marine-reserves': CategoryMarineReserves,
   'category-news': CategoryNews,
   'category-reports': CategoryReports,


### PR DESCRIPTION
Show only categories which are in: 
- https://github.com/GlobalFishingWatch/frontend/blob/1b93b35250920ce4149ab523a26d79e3c885ff5d/applications/fishing-map/src/data/workspaces.ts#L16 
- and in the spreadsheet, checking if the category has content too 

to be able to generate categories with only marine-reserves categories, or maybe country portals for the future
![image](https://user-images.githubusercontent.com/10500650/107979240-858cd200-6fbe-11eb-8f4b-f54544a5ca88.png)
