### PR TITLE
Update vessel-history to use latest ui-components version

### DIFF
--- a/applications/vessel-history/package.json
+++ b/applications/vessel-history/package.json
@@ -23,7 +23,7 @@
     "@globalfishingwatch/react-hooks": "^4.4.3",
     "@globalfishingwatch/react-map-gl": "5.2.9-gfw.3",
     "@globalfishingwatch/timebar": "^1.1.5",
-    "@globalfishingwatch/ui-components": "^2.8.3",
+    "@globalfishingwatch/ui-components": "^2.12.8",
     "@reduxjs/toolkit": "^1.4.0",
     "@researchgate/react-intersection-observer": "^1.3.5",
     "countryflag": "^4.0.1",


### PR DESCRIPTION
Given that the package.json has not been updated and there's a new version of ui-components, vessel-history continues using the old (cached) version of the component during the build.
- Update vessel-history to use latest ui-components version
