### PR TITLE
Bump api types dependencies

### DIFF
--- a/applications/vessel-history/package.json
+++ b/applications/vessel-history/package.json
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "@globalfishingwatch/api-client": "^1.2.4",
-    "@globalfishingwatch/api-types": "^2.15.0",
+    "@globalfishingwatch/api-types": "^2.17.0",
     "@globalfishingwatch/data-transforms": "^1.1.0",
     "@globalfishingwatch/dataviews-client": "^4.1.0",
     "@globalfishingwatch/layer-composer": "4.18.0",

--- a/applications/vessel-history/src/features/profile/components/InfoFieldHistory.tsx
+++ b/applications/vessel-history/src/features/profile/components/InfoFieldHistory.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment, useCallback, useState } from 'react'
+import React, { Fragment, useCallback } from 'react'
 import { DateTime } from 'luxon'
 import { Modal } from '@globalfishingwatch/ui-components'
 import { useTranslation } from 'utils/i18n'

--- a/packages/dataviews-client/package.json
+++ b/packages/dataviews-client/package.json
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "@globalfishingwatch/api-client": "^1.6.2",
-    "@globalfishingwatch/api-types": "^2.15.0",
+    "@globalfishingwatch/api-types": "^2.17.0",
     "qs": "^6.9.4"
   },
   "devDependencies": {


### PR DESCRIPTION
- Updated `api-types` version on `vessel-history` and `dataviews-client`
- Cleanup unused import