### PR TITLE
Fishingmap/flag aliases

### DIFF
--- a/.changeset/eighty-queens-destroy.md
+++ b/.changeset/eighty-queens-destroy.md
@@ -1,0 +1,5 @@
+---
+'@globalfishingwatch/ui-components': minor
+---
+
+support aliases in multiselect

--- a/applications/fishing-map/src/data/flags.ts
+++ b/applications/fishing-map/src/data/flags.ts
@@ -38,10 +38,12 @@ const flags = [
   {
     id: 'ARM',
     label: 'Armenia',
+    alias: 'Hayastan',
   },
   {
     id: 'ASM',
     label: 'American Samoa',
+    alias: 'Amerika Sāmoa',
   },
   {
     id: 'ATA',
@@ -50,6 +52,7 @@ const flags = [
   {
     id: 'ATF',
     label: 'French Southern and Antarctic Lands',
+    alias: 'Terres australes et antarctiques françaises',
   },
   {
     id: 'ATG',
@@ -62,10 +65,12 @@ const flags = [
   {
     id: 'AUT',
     label: 'Austria',
+    alias: 'Österreich',
   },
   {
     id: 'AZE',
     label: 'Azerbaijan',
+    alias: 'Azərbaycan',
   },
   {
     id: 'BDI',
@@ -74,6 +79,7 @@ const flags = [
   {
     id: 'BEL',
     label: 'Belgium',
+    alias: ['België', 'Belgique', 'Belgien'],
   },
   {
     id: 'BEN',
@@ -90,10 +96,12 @@ const flags = [
   {
     id: 'BGR',
     label: 'Bulgaria',
+    alias: 'Bǎlgariya',
   },
   {
     id: 'BHR',
     label: 'Bahrain',
+    alias: 'Baḥrayn',
   },
   {
     id: 'BHS',
@@ -102,6 +110,7 @@ const flags = [
   {
     id: 'BIH',
     label: 'Bosnia and Herzegovina',
+    alias: 'Hercegovina',
   },
   {
     id: 'BLM',
@@ -130,10 +139,12 @@ const flags = [
   {
     id: 'BES',
     label: 'Caribbean Netherlands',
+    alias: 'Caribisch Nederland',
   },
   {
     id: 'BRA',
     label: 'Brazil',
+    alias: 'Brasil',
   },
   {
     id: 'BRB',
@@ -146,6 +157,7 @@ const flags = [
   {
     id: 'BTN',
     label: 'Bhutan',
+    alias: 'Druk Gyal Khap',
   },
   {
     id: 'BVT',
@@ -158,6 +170,7 @@ const flags = [
   {
     id: 'CAF',
     label: 'Central African Republic',
+    alias: ['Ködörösêse tî Bêafrîka', 'République centrafricaine'],
   },
   {
     id: 'CAN',
@@ -170,6 +183,7 @@ const flags = [
   {
     id: 'CHE',
     label: 'Switzerland',
+    alias: ['Schweizerische', 'Suisse', 'Svizzera', 'Svizra', 'Helvetica'],
   },
   {
     id: 'CHL',
@@ -178,26 +192,32 @@ const flags = [
   {
     id: 'CHN',
     label: 'China',
+    alias: 'Zhōnghuá Rénmín Gònghéguó',
   },
   {
     id: 'CIV',
     label: 'Ivory Coast',
+    alias: "Côte d'Ivoire",
   },
   {
     id: 'CMR',
     label: 'Cameroon',
+    alias: 'Cameroun',
   },
   {
     id: 'COD',
     label: 'DR Congo',
+    alias: 'Kôngo',
   },
   {
     id: 'COG',
     label: 'Republic of the Congo',
+    alias: 'Kôngo',
   },
   {
     id: 'COK',
     label: 'Cook Islands',
+    alias: "Kūki 'Āirani",
   },
   {
     id: 'COL',
@@ -206,10 +226,12 @@ const flags = [
   {
     id: 'COM',
     label: 'Comoros',
+    alias: ['Qumurī', 'Komori'],
   },
   {
     id: 'CPV',
     label: 'Cape Verde',
+    alias: 'Kabu Verdi',
   },
   {
     id: 'CRI',
@@ -234,18 +256,22 @@ const flags = [
   {
     id: 'CYP',
     label: 'Cyprus',
+    alias: 'Cumhuriyeti',
   },
   {
     id: 'CZE',
     label: 'Czech Republic',
+    alias: 'Česká',
   },
   {
     id: 'DEU',
     label: 'Germany',
+    alias: 'Deutschland',
   },
   {
     id: 'DJI',
     label: 'Djibouti',
+    alias: ['Jabuuti', 'Gabuutih'],
   },
   {
     id: 'DMA',
@@ -254,18 +280,22 @@ const flags = [
   {
     id: 'DNK',
     label: 'Denmark',
+    alias: 'Danmark',
   },
   {
     id: 'DOM',
     label: 'Dominican Republic',
+    alias: 'República Dominicana',
   },
   {
     id: 'DZA',
     label: 'Algeria',
+    alias: 'Algérienne',
   },
   {
     id: 'ECU',
     label: 'Ecuador',
+    alias: ['Ikwayur', 'Ekuatur'],
   },
   {
     id: 'EGY',
@@ -278,14 +308,17 @@ const flags = [
   {
     id: 'ESH',
     label: 'Western Sahara',
+    alias: ['Taneẓroft Tutrimt', 'Sahara Occidental'],
   },
   {
     id: 'ESP',
     label: 'Spain',
+    alias: ['España'],
   },
   {
     id: 'EST',
     label: 'Estonia',
+    alias: 'Eesti',
   },
   {
     id: 'ETH',
@@ -294,10 +327,12 @@ const flags = [
   {
     id: 'FIN',
     label: 'Finland',
+    alias: 'Suomen',
   },
   {
     id: 'FJI',
     label: 'Fiji',
+    alias: 'Matanitu Tugalala o Viti',
   },
   {
     id: 'FLK',
@@ -306,6 +341,7 @@ const flags = [
   {
     id: 'FRA',
     label: 'France',
+    alias: 'française',
   },
   {
     id: 'FRO',
@@ -342,6 +378,7 @@ const flags = [
   {
     id: 'GIN',
     label: 'Guinea',
+    alias: 'Guinée',
   },
   {
     id: 'GLP',
@@ -362,6 +399,7 @@ const flags = [
   {
     id: 'GRC',
     label: 'Greece',
+    alias: ['Ellinikí', 'Hellas'],
   },
   {
     id: 'GRD',
@@ -370,6 +408,7 @@ const flags = [
   {
     id: 'GRL',
     label: 'Greenland',
+    alias: ['Kalaallit Nunaat', 'Grønland'],
   },
   {
     id: 'GTM',
@@ -378,10 +417,12 @@ const flags = [
   {
     id: 'GUF',
     label: 'French Guiana',
+    alias: 'Guyane',
   },
   {
     id: 'GUM',
     label: 'Guam',
+    alias: 'Guåhån',
   },
   {
     id: 'GUY',
@@ -402,14 +443,17 @@ const flags = [
   {
     id: 'HRV',
     label: 'Croatia',
+    alias: 'Hrvatska',
   },
   {
     id: 'HTI',
     label: 'Haiti',
+    alias: 'Ayiti',
   },
   {
     id: 'HUN',
     label: 'Hungary',
+    alias: 'Magyarország',
   },
   {
     id: 'IDN',
@@ -430,6 +474,7 @@ const flags = [
   {
     id: 'IRL',
     label: 'Ireland',
+    alias: ['Éire', 'Airlann'],
   },
   {
     id: 'IRN',
@@ -442,6 +487,7 @@ const flags = [
   {
     id: 'ISL',
     label: 'Iceland',
+    alias: 'Ísland',
   },
   {
     id: 'ISR',
@@ -450,6 +496,7 @@ const flags = [
   {
     id: 'ITA',
     label: 'Italy',
+    alias: 'Italia',
   },
   {
     id: 'JAM',
@@ -466,10 +513,12 @@ const flags = [
   {
     id: 'JPN',
     label: 'Japan',
+    alias: ['Nippon', 'Nihon'],
   },
   {
     id: 'KAZ',
     label: 'Kazakhstan',
+    alias: 'Qazaqstan',
   },
   {
     id: 'KEN',
@@ -478,10 +527,12 @@ const flags = [
   {
     id: 'KGZ',
     label: 'Kyrgyzstan',
+    alias: 'Kırğız',
   },
   {
     id: 'KHM',
     label: 'Cambodia',
+    alias: ['kampuciə', 'Cambodge'],
   },
   {
     id: 'KIR',
@@ -494,6 +545,7 @@ const flags = [
   {
     id: 'KOR',
     label: 'South Korea',
+    alias: 'Daehan Minguk',
   },
   {
     id: 'UNK',
@@ -510,6 +562,7 @@ const flags = [
   {
     id: 'LBN',
     label: 'Lebanon',
+    alias: ['Liban', 'Lubnān'],
   },
   {
     id: 'LBR',
@@ -538,14 +591,17 @@ const flags = [
   {
     id: 'LTU',
     label: 'Lithuania',
+    alias: 'Lietuva',
   },
   {
     id: 'LUX',
     label: 'Luxembourg',
+    alias: 'Lëtzebuerg',
   },
   {
     id: 'LVA',
     label: 'Latvia',
+    alias: 'Latvijas',
   },
   {
     id: 'MAC',
@@ -598,10 +654,12 @@ const flags = [
   {
     id: 'MMR',
     label: 'Myanmar',
+    alias: 'Burma',
   },
   {
     id: 'MNE',
     label: 'Montenegro',
+    alias: 'Crna Gora',
   },
   {
     id: 'MNG',
@@ -614,10 +672,12 @@ const flags = [
   {
     id: 'MOZ',
     label: 'Mozambique',
+    alias: ['Mozambiki', 'Msumbiji'],
   },
   {
     id: 'MRT',
     label: 'Mauritania',
+    alias: 'Mūrītānīyah',
   },
   {
     id: 'MSR',
@@ -662,6 +722,7 @@ const flags = [
   {
     id: 'NGA',
     label: 'Nigeria',
+    alias: ['Nijeriya', 'Naìjíríyà'],
   },
   {
     id: 'NIC',
@@ -674,10 +735,12 @@ const flags = [
   {
     id: 'NLD',
     label: 'Netherlands',
+    alias: 'Nederland',
   },
   {
     id: 'NOR',
     label: 'Norway',
+    alias: 'Norge',
   },
   {
     id: 'NPL',
@@ -690,10 +753,12 @@ const flags = [
   {
     id: 'NZL',
     label: 'New Zealand',
+    alias: 'Aotearoa',
   },
   {
     id: 'OMN',
     label: 'Oman',
+    alias: 'ʻUmān',
   },
   {
     id: 'PAK',
@@ -714,6 +779,7 @@ const flags = [
   {
     id: 'PHL',
     label: 'Philippines',
+    alias: 'Pilipinas',
   },
   {
     id: 'PLW',
@@ -726,6 +792,7 @@ const flags = [
   {
     id: 'POL',
     label: 'Poland',
+    alias: 'Polska',
   },
   {
     id: 'PRI',
@@ -734,6 +801,7 @@ const flags = [
   {
     id: 'PRK',
     label: 'North Korea',
+    alias: 'PRK',
   },
   {
     id: 'PRT',
@@ -746,10 +814,12 @@ const flags = [
   {
     id: 'PSE',
     label: 'Palestine',
+    alias: 'Dawlat Filasṭīn',
   },
   {
     id: 'PYF',
     label: 'French Polynesia',
+    alias: ['Polynésie française', 'Pōrīnetia Farāni'],
   },
   {
     id: 'QAT',
@@ -766,6 +836,7 @@ const flags = [
   {
     id: 'RUS',
     label: 'Russia',
+    alias: 'Rossiya',
   },
   {
     id: 'RWA',
@@ -774,6 +845,7 @@ const flags = [
   {
     id: 'SAU',
     label: 'Saudi Arabia',
+    alias: 'Arabīyah as-Saʿūdīyah',
   },
   {
     id: 'SDN',
@@ -822,6 +894,7 @@ const flags = [
   {
     id: 'SRB',
     label: 'Serbia',
+    alias: 'Srbija',
   },
   {
     id: 'SSD',
@@ -838,14 +911,17 @@ const flags = [
   {
     id: 'SVK',
     label: 'Slovakia',
+    alias: 'Slovenská',
   },
   {
     id: 'SVN',
     label: 'Slovenia',
+    alias: 'Slovenija',
   },
   {
     id: 'SWE',
     label: 'Sweden',
+    alias: 'Sverige',
   },
   {
     id: 'SWZ',
@@ -906,10 +982,12 @@ const flags = [
   {
     id: 'TUN',
     label: 'Tunisia',
+    alias: 'Tūnisīyah',
   },
   {
     id: 'TUR',
     label: 'Turkey',
+    alias: 'Türkiye',
   },
   {
     id: 'TUV',
@@ -918,10 +996,7 @@ const flags = [
   {
     id: 'TAI',
     label: 'Chinese Taipei',
-  },
-  {
-    id: 'TWN',
-    label: 'Chinese Taipei',
+    alias: ['Taiwan'],
   },
   {
     id: 'TZA',
@@ -934,6 +1009,7 @@ const flags = [
   {
     id: 'UKR',
     label: 'Ukraine',
+    alias: 'Ukrayina',
   },
   {
     id: 'UMI',
@@ -1004,4 +1080,5 @@ const flags = [
     label: 'Zimbabwe',
   },
 ]
+
 export default flags

--- a/applications/fishing-map/src/utils/flags.ts
+++ b/applications/fishing-map/src/utils/flags.ts
@@ -19,10 +19,10 @@ export const getFlagsByIds = (ids: string[], lng = i18n.language): Flag[] =>
 
 export const getFlags = (lng = i18n.language): Flag[] =>
   flags
-    .map(({ id, label }) => {
+    .map((flag) => {
       return {
-        id,
-        label: i18n.t(`flags:${id}`, { lng }) || label,
+        ...flag,
+        label: i18n.t(`flags:${flag.id}`, { lng }) || flag.label,
       }
     })
     .sort((a, b) => a.label.localeCompare(b.label))

--- a/packages/timebar/types/utils/internal-utils.d.ts
+++ b/packages/timebar/types/utils/internal-utils.d.ts
@@ -7,5 +7,5 @@ export function clampToAbsoluteBoundaries(start: any, end: any, desiredDeltaMs: 
 export function getDeltaMs(start: any, end: any): number;
 export function getDeltaDays(start: any, end: any): number;
 export function isMoreThanADay(start: any, end: any): boolean;
-export function getDefaultFormat(start: any, end: any): "MMM D YYYY HH:mm" | "MMM D YYYY";
+export function getDefaultFormat(start: any, end: any): "MMM D YYYY" | "MMM D YYYY HH:mm";
 export function stickToClosestUnit(date: any, unit: any): any;

--- a/packages/ui-components/package.json
+++ b/packages/ui-components/package.json
@@ -39,11 +39,11 @@
     "d3-geo": "1.12.0",
     "d3-scale": "^3.2.2",
     "downshift": "^6.0.6",
+    "match-sorter": "^6.3.0",
     "react-modal": "^3.11.2",
     "topojson-client": "3.1.0"
   },
   "devDependencies": {
-    "autoprefixer": "^9.8.0",
     "@rollup/plugin-commonjs": "^16.0.0",
     "@rollup/plugin-json": "^4.1.0",
     "@rollup/plugin-node-resolve": "^10.0.0",
@@ -52,17 +52,18 @@
     "@svgr/rollup": "^5.4.0",
     "@types/react-modal": "^3.10.5",
     "@types/topojson-client": "^3.0.0",
+    "autoprefixer": "^9.8.0",
     "cross-env": "^7.0.3",
     "cssnano": "^4.1.10",
-    "ts-node": "^8.10.1",
+    "postcss-cli": "^7.1.1",
+    "postcss-import": "^12.0.1",
+    "postcss-modules": "^2.0.0",
+    "postcss-nested": "^4.2.1",
     "rollup": "^2.33.1",
     "rollup-plugin-multi-input": "^1.1.1",
     "rollup-plugin-postcss": "^3.1.8",
     "rollup-plugin-terser": "^7.0.2",
-    "postcss-cli": "^7.1.1",
-    "postcss-import": "^12.0.1",
-    "postcss-modules": "^2.0.0",
-    "postcss-nested": "^4.2.1"
+    "ts-node": "^8.10.1"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/ui-components/src/multi-select/MultiSelect.tsx
+++ b/packages/ui-components/src/multi-select/MultiSelect.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback, useState, useMemo, memo } from 'react'
+import { matchSorter } from 'match-sorter'
 import {
   useMultipleSelection,
   useCombobox,
@@ -38,10 +39,10 @@ const isItemSelected = (selectedItems: MultiSelectOption[], item: MultiSelectOpt
 
 const getItemsFiltered = (items: MultiSelectOption[], filter?: string) => {
   if (!filter) return items
-
-  return (items || []).filter(
-    (item) => !filter || item.label.toLowerCase().startsWith(filter.toLowerCase())
-  )
+  const matchingItems = matchSorter(items, filter, {
+    keys: ['label', 'alias'],
+  })
+  return matchingItems
 }
 
 function MultiSelect(props: MultiSelectProps) {

--- a/packages/ui-components/src/multi-select/MultiSelect.tsx
+++ b/packages/ui-components/src/multi-select/MultiSelect.tsx
@@ -40,7 +40,7 @@ const isItemSelected = (selectedItems: MultiSelectOption[], item: MultiSelectOpt
 const getItemsFiltered = (items: MultiSelectOption[], filter?: string) => {
   if (!filter) return items
   const matchingItems = matchSorter(items, filter, {
-    keys: ['label', 'alias'],
+    keys: ['id', 'label', 'alias'],
   })
   return matchingItems
 }

--- a/packages/ui-components/src/multi-select/index.ts
+++ b/packages/ui-components/src/multi-select/index.ts
@@ -4,6 +4,7 @@ export type SelectOptionId = number | string
 export type MultiSelectOption<T = any> = {
   id: T
   label: string
+  alias?: string[]
   tooltip?: string
 }
 /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -6554,7 +6554,17 @@ babel-jest@^26.6.0, babel-jest@^26.6.3:
     graceful-fs "^4.2.4"
     slash "^3.0.0"
 
-babel-loader@8.0.6, babel-loader@8.1.0:
+babel-loader@8.0.6:
+  version "8.0.6"
+  resolved "https://registry.yarnpkg.com/babel-loader/-/babel-loader-8.0.6.tgz#e33bdb6f362b03f4bb141a0c21ab87c501b70dfb"
+  integrity sha512-4BmWKtBOBm13uoUwd08UwjZlaw3O9GWf456R9j+5YykFZ6LUIjIKLc0zEZf+hauxPOJs96C8k6FvYD09vWzhYw==
+  dependencies:
+    find-cache-dir "^2.0.0"
+    loader-utils "^1.0.2"
+    mkdirp "^0.5.1"
+    pify "^4.0.1"
+
+babel-loader@8.1.0:
   version "8.1.0"
   resolved "https://registry.yarnpkg.com/babel-loader/-/babel-loader-8.1.0.tgz#c611d5112bd5209abe8b9fa84c3e4da25275f1c3"
   integrity sha512-7q7nC1tYOrqvUrN3LQK4GwSk/TQorZSOlO9C+RZDZpODgyN4ZlCqE5q9cDsyWOliN+aU9B4JX01xK9eJXowJLw==
@@ -15128,7 +15138,7 @@ loader-utils@^0.2.16:
     json5 "^0.5.0"
     object-assign "^4.0.1"
 
-loader-utils@^1.1.0, loader-utils@^1.2.3, loader-utils@^1.4.0:
+loader-utils@^1.0.2, loader-utils@^1.1.0, loader-utils@^1.2.3, loader-utils@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-1.4.0.tgz#c579b5e34cb34b1a74edc6c1fb36bfa371d5a613"
   integrity sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA==
@@ -15549,7 +15559,7 @@ map-visit@^1.0.0:
   dependencies:
     object-visit "^1.0.0"
 
-match-sorter@^6.0.2:
+match-sorter@^6.0.2, match-sorter@^6.3.0:
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/match-sorter/-/match-sorter-6.3.0.tgz#454a1b31ed218cddbce6231a0ecb5fdc549fed01"
   integrity sha512-efYOf/wUpNb8FgNY+cOD2EIJI1S5I7YPKsw0LBp7wqPh5pmMS6i/wr3ZWwfwrAw1NvqTA2KUReVRWDX84lUcOQ==


### PR DESCRIPTION
Multiselect filtering supports aliases and now uses [matchSorter](https://github.com/kentcdodds/match-sorter) to filter results.
Updates the flag list with the same than CVP to include some flag aliases, for example:
![image](https://user-images.githubusercontent.com/10500650/114669896-b65d5f00-9d02-11eb-9d34-62bae7ec4734.png)

or by ISO code:
![image](https://user-images.githubusercontent.com/10500650/114669693-74341d80-9d02-11eb-8f97-78c448401351.png)
