### PR TITLE
VH-95 Improvements displaying historical TMT Fields

### DIFF
--- a/applications/vessel-history/src/features/profile/Profile.tsx
+++ b/applications/vessel-history/src/features/profile/Profile.tsx
@@ -4,6 +4,7 @@ import { useDispatch, useSelector } from 'react-redux'
 import Link from 'redux-first-router-link'
 import { IconButton, Tabs } from '@globalfishingwatch/ui-components'
 import { Tab } from '@globalfishingwatch/ui-components/dist/tabs'
+import I18nDate from 'features/i18n/i18nDate'
 import { selectQueryParam, selectVesselProfileId } from 'routes/routes.selectors'
 import { HOME } from 'routes/routes'
 import { fetchVesselByIdThunk, selectVesselById } from 'features/vessels/vessels.slice'
@@ -58,6 +59,11 @@ const Profile: React.FC = (props): React.ReactElement => {
     ).toLocaleUpperCase()}`
   }, [vessel, t])
 
+  const sinceShipname = useMemo(
+    () => vessel?.history.shipname.byDate.slice(0, 1)?.shift()?.firstSeen,
+    [vessel]
+  )
+
   return (
     <Fragment>
       <header className={styles.header}>
@@ -72,12 +78,17 @@ const Profile: React.FC = (props): React.ReactElement => {
         {vessel && (
           <h1>
             {vessel.shipname}
-            {vessel.history.shipname.byDate.length && (
+            {vessel.history.shipname.byDate.length > 1 && (
               <p>
                 {t('vessel.plusPreviousValuesByField', defaultPreviousNames, {
                   quantity: vessel.history.shipname.byDate.length,
                   fieldLabel: t(`vessel.name_plural` as any, 'names').toLocaleUpperCase(),
                 })}
+              </p>
+            )}
+            {vessel.history.shipname.byDate.length === 1 && sinceShipname && (
+              <p>
+                {t('common.since', 'Since')} <I18nDate date={sinceShipname} />
               </p>
             )}
           </h1>

--- a/applications/vessel-history/src/features/profile/components/InfoField.tsx
+++ b/applications/vessel-history/src/features/profile/components/InfoField.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
+import I18nDate from 'features/i18n/i18nDate'
 import { ValueItem } from 'types'
 import styles from './Info.module.css'
 import InfoFieldHistory from './InfoFieldHistory'
@@ -82,18 +83,25 @@ const InfoField: React.FC<ListItemProps> = ({
     return `+${valuesHistory.length} previous ${labelPlural.toLocaleUpperCase()}`
   }, [valuesHistory, labelPlural])
 
+  const since = useMemo(() => valuesHistory.slice(0, 1)?.shift()?.firstSeen, [valuesHistory])
+
   return (
     <div className={styles.identifierField}>
       <label>{t(`vessel.${label}` as any, label)}</label>
       <div>
         <div onClick={openModal}>{value.length > 0 ? value : defaultEmptyValue}</div>
-        {valuesHistory.length > 0 && (
+        {valuesHistory.length > 1 && (
           <button className={styles.moreValues} onClick={openModal}>
             {t('vessel.plusPreviousValuesByField', defaultValue, {
               quantity: valuesHistory.length,
               fieldLabel: labelPlural.toLocaleUpperCase(),
             })}
           </button>
+        )}
+        {valuesHistory.length === 1 && since && (
+          <p className={styles.rangeLabel}>
+            {t('common.since', 'Since')} <I18nDate date={since} />
+          </p>
         )}
         <InfoFieldHistory
           current={current}


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/2205831/115251331-d32dd400-a100-11eb-816d-e6aeb18a7ae8.png)

- When there is only one value in the history, switch the “+1 …” for the date (e.g. “Since Jan 2018") in the same place and with the same style