### PR TITLE
added color scales to white and fixed legend

### DIFF
--- a/.changeset/lovely-cows-swim.md
+++ b/.changeset/lovely-cows-swim.md
@@ -1,0 +1,6 @@
+---
+"@globalfishingwatch/layer-composer": patch
+"@globalfishingwatch/ui-components": patch
+---
+
+added color scales to white and fixed legend

--- a/packages/layer-composer/src/generators/heatmap/config.ts
+++ b/packages/layer-composer/src/generators/heatmap/config.ts
@@ -48,13 +48,50 @@ const hex2Rgb = (hex: string) => {
     g: parseInt(cleanHex.slice(2, 4), 16),
     b: parseInt(cleanHex.slice(4, 6), 16),
   }
-  return `${color.r}, ${color.g}, ${color.b}`
+  return color
+}
+
+const rgbToRgbString = ({ r, g, b }: { r: number; g: number; b: number }) => {
+  return `${r}, ${g}, ${b}`
+}
+
+const hexToRgbString = (hex: string) => {
+  const color = hex2Rgb(hex)
+  return rgbToRgbString(color)
 }
 
 const getColorRampByOpacitySteps = (finalColor: string, numSteps = 8) => {
-  const color = finalColor.includes('#') ? hex2Rgb(finalColor) : finalColor
+  const color = finalColor.includes('#') ? hexToRgbString(finalColor) : finalColor
   const opacitySteps = [...Array(numSteps)].map((_, i) => i / (numSteps - 1))
   return opacitySteps.map((opacity) => `rgba(${color}, ${opacity})`)
+}
+
+const getColorRampToWhite = (hexColor: string, numSteps = 3) => {
+  const rgbColor = hex2Rgb(hexColor)
+  const steps = [...Array(numSteps - 1)].map((_, i) => {
+    const ratio = (i + 1) / numSteps
+    const rgb = {
+      r: rgbColor.r + (255 - rgbColor.r) * ratio,
+      g: rgbColor.g + (255 - rgbColor.g) * ratio,
+      b: rgbColor.b + (255 - rgbColor.b) * ratio,
+    }
+    return `rgb(${rgbToRgbString(rgb)})`
+  })
+
+  const ramp = [...steps, 'rgb(255, 255, 255)']
+
+  return ramp
+}
+
+const getMixedOpacityToWhiteColorRamp = (
+  finalColor: string,
+  numStepsOpacity = 5,
+  numStepsTopWhite = 3
+) => {
+  return [
+    ...getColorRampByOpacitySteps(finalColor, numStepsOpacity),
+    ...getColorRampToWhite(finalColor, numStepsTopWhite),
+  ]
 }
 
 const DEFAULT_BACKGROUND_TRANSPARENT_COLOR = DEFAULT_BACKGROUND_COLOR.replace(
@@ -74,24 +111,23 @@ export const HEATMAP_COLOR_RAMPS: Record<ColorRampsIds, string[]> = {
   ],
   reception: ['rgb(255, 69, 115, 1)', '#7b2e8d', '#093b76', DEFAULT_BACKGROUND_TRANSPARENT_COLOR],
   teal: getColorRampByOpacitySteps('#00FFBC'),
-  // teal: [
-  //   DEFAULT_BACKGROUND_TRANSPARENT_COLOR,
-  //   '#FF64CE',
-  //   '#9CA4FF',
-  //   '#FFAE9B',
-  //   '#00EEFF',
-  //   '#FF6854',
-  //   '#FFEA00',
-  //   '#A6FF59',
-  // ],
+  teal_toWhite: getMixedOpacityToWhiteColorRamp('#00FFBC'),
   magenta: getColorRampByOpacitySteps('#FF64CE'),
+  magenta_toWhite: getMixedOpacityToWhiteColorRamp('#FF64CE'),
   lilac: getColorRampByOpacitySteps('#9CA4FF'),
+  lilac_toWhite: getMixedOpacityToWhiteColorRamp('#9CA4FF'),
   salmon: getColorRampByOpacitySteps('#FFAE9B'),
+  salmon_toWhite: getMixedOpacityToWhiteColorRamp('#FFAE9B'),
   sky: getColorRampByOpacitySteps('#00EEFF'),
+  sky_toWhite: getMixedOpacityToWhiteColorRamp('#00EEFF'),
   red: getColorRampByOpacitySteps('#FF6854'),
+  red_toWhite: getMixedOpacityToWhiteColorRamp('#FF6854'),
   yellow: getColorRampByOpacitySteps('#FFEA00'),
+  yellow_toWhite: getMixedOpacityToWhiteColorRamp('#FFEA00'),
   green: getColorRampByOpacitySteps('#A6FF59'), // 166,255,89
+  green_toWhite: getMixedOpacityToWhiteColorRamp('#A6FF59'), // 166,255,89
   orange: getColorRampByOpacitySteps('#FFAA0D'),
+  orange_toWhite: getMixedOpacityToWhiteColorRamp('#FFAA0D'),
   // prettier-ignore
   bivariate: [
     DEFAULT_BACKGROUND_TRANSPARENT_COLOR,
@@ -100,11 +136,4 @@ export const HEATMAP_COLOR_RAMPS: Record<ColorRampsIds, string[]> = {
     '#A659A9', '#A67CB2', '#A6B3BB', '#A6FFC7',
     '#FF64CE', '#FF7CCE', '#FFB3CE', '#FFFFFF',
   ],
-  // bivariate: [
-  //   DEFAULT_BACKGROUND_TRANSPARENT_COLOR,
-  //   '#000', '#267C8A', '#26B39F', 'red',
-  //   '#66518F', '#FFEA00', '#667C9E', '#66FFC2',
-  //   '#A659A9', '#A67CB2', '#FFAA0D', '#A6FFC7',
-  //   'blue', '#FF7CCE', '#FFB3CE', '#FFFFFF',
-  // ],
 }

--- a/packages/layer-composer/src/generators/heatmap/util/get-legends.ts
+++ b/packages/layer-composer/src/generators/heatmap/util/get-legends.ts
@@ -1,5 +1,5 @@
 import { LayerMetadataLegend, LegendType } from '../../../types'
-import { HeatmapAnimatedMode } from '../../types'
+import { ColorRampsIds, HeatmapAnimatedMode } from '../../types'
 import { HEATMAP_DEFAULT_MAX_ZOOM, HEATMAP_COLOR_RAMPS, GRID_AREA_BY_ZOOM_LEVEL } from '../config'
 import { GlobalHeatmapAnimatedGeneratorConfig } from '../heatmap-animated'
 import getBreaks from './get-breaks'
@@ -11,6 +11,11 @@ export const getSublayersColorRamps = (config: GlobalHeatmapAnimatedGeneratorCon
   // Force bivariate color ramp depending on config
   if (config.mode === HeatmapAnimatedMode.Bivariate) {
     colorRampIds = ['bivariate']
+  }
+
+  const numActiveSublayers = config.sublayers.filter((s) => s.visible).length
+  if (numActiveSublayers === 1) {
+    colorRampIds = [(colorRampIds[0] + '_toWhite') as ColorRampsIds]
   }
   const colorRamps = colorRampIds.map((colorRampId) => {
     const originalColorRamp = HEATMAP_COLOR_RAMPS[colorRampId]

--- a/packages/layer-composer/src/generators/types.ts
+++ b/packages/layer-composer/src/generators/types.ts
@@ -360,14 +360,23 @@ export type ColorRampsIds =
   | 'reception'
   | 'bivariate'
   | 'teal'
+  | 'teal_toWhite'
   | 'magenta'
+  | 'magenta_toWhite'
   | 'lilac'
+  | 'lilac_toWhite'
   | 'salmon'
+  | 'salmon_toWhite'
   | 'sky'
+  | 'sky_toWhite'
   | 'red'
+  | 'red_toWhite'
   | 'yellow'
+  | 'yellow_toWhite'
   | 'green'
+  | 'green_toWhite'
   | 'orange'
+  | 'orange_toWhite'
 
 export enum HeatmapAnimatedMode {
   // Pick sublayer with highest value and place across this sublayer's color ramp. Works with 0 - n sublayers

--- a/packages/ui-components/src/map-legend/ColorRamp.tsx
+++ b/packages/ui-components/src/map-legend/ColorRamp.tsx
@@ -40,6 +40,15 @@ function ColorRampLegend({
       .domain(domainValues)
   }, [cleanRamp, ramp])
 
+  const backgroundStyle = useMemo(() => {
+    if (!cleanRamp || type === 'colorramp-discrete') return {}
+    return {
+      backgroundImage: `linear-gradient(to right, ${cleanRamp
+        .map(([value, color]) => color)
+        .join()})`,
+    }
+  }, [cleanRamp, type])
+
   if (!ramp || !cleanRamp) return null
   return (
     <div className={cx(styles.row, className)}>
@@ -59,14 +68,7 @@ function ColorRampLegend({
       )}
       {cleanRamp?.length > 0 && (
         <Fragment>
-          <div
-            className={styles.ramp}
-            style={{
-              backgroundImage: `linear-gradient(to right, ${cleanRamp
-                .map(([value, color]) => color)
-                .join()})`,
-            }}
-          >
+          <div className={styles.ramp} style={backgroundStyle}>
             {currentValue && (
               <span
                 className={cx(styles.currentValue, currentValueClassName)}


### PR DESCRIPTION
Changes the color scales so that when only one activity sublayer is in the workspace, color scales goes to white beyond fully saturated hue (number of buckets stays the same at 8).
Also fixed a bug that showed slightly wrong colors in legend.

![Screenshot 2021-04-26 at 15 02 26](https://user-images.githubusercontent.com/1583415/116089656-5f14a280-a6a3-11eb-9e66-b8164e598263.png)


https://user-images.githubusercontent.com/1583415/116089691-650a8380-a6a3-11eb-91dd-0031999e9fcb.mov

