### PR TITLE
Fishing map/presence choice

### DIFF
--- a/.changeset/little-rocks-approve.md
+++ b/.changeset/little-rocks-approve.md
@@ -1,0 +1,5 @@
+---
+'@globalfishingwatch/ui-components': patch
+---
+
+support choice classname

--- a/.changeset/rotten-keys-refuse.md
+++ b/.changeset/rotten-keys-refuse.md
@@ -1,0 +1,5 @@
+---
+'@globalfishingwatch/layer-composer': patch
+---
+
+fix crash when no sublayers present

--- a/.changeset/twelve-shrimps-drum.md
+++ b/.changeset/twelve-shrimps-drum.md
@@ -1,0 +1,6 @@
+---
+'@globalfishingwatch/api-types': minor
+'@globalfishingwatch/dataviews-client': minor
+---
+
+new dataview categories

--- a/applications/fishing-map/public/locales/en/translations.json
+++ b/applications/fishing-map/public/locales/en/translations.json
@@ -20,7 +20,7 @@
   "common": {
     "active_after": "Active after",
     "active_before": "Active Before",
-    "activity": "Vessel activity",
+    "activity": "Activity",
     "apparentFishing": "Apparent Fishing Effort",
     "confirm": "Confirm",
     "context_area_plural": "Reference Layers",

--- a/applications/fishing-map/public/locales/source/translations.json
+++ b/applications/fishing-map/public/locales/source/translations.json
@@ -27,6 +27,7 @@
     "environment": "Environment",
     "events": "Events",
     "feedback": "Feedback",
+    "fishing": "Fishing",
     "help": "Help",
     "hour": "Hour",
     "hour_plural": "hours",
@@ -197,6 +198,19 @@
   "timebarSettings": {
     "fishingEffortDisabled": "Select at least one apparent fishing effort layer",
     "graph": "Graph",
+    "eventOptions": {
+      "all": "All events",
+      "fishing": "Fishing",
+      "encounters": "Encounters",
+      "loitering": "Loitering",
+      "ports": "Port visits",
+      "none": "None"
+    },
+    "graphOptions": {
+      "speed": "Speed",
+      "depth": "Depth $t(common.comingSoon)",
+      "none": "None"
+    },
     "settings_close": "Close timebar settings",
     "settings_open": "Open timebar settings",
     "showFishingEffort": "Show fishing hours graph",

--- a/applications/fishing-map/src/data/config.ts
+++ b/applications/fishing-map/src/data/config.ts
@@ -154,7 +154,8 @@ export const TIMEBAR_GRAPH_OPTIONS: SelectOption[] = [
 ]
 
 export const POPUP_CATEGORY_ORDER = [
-  DataviewCategory.Activity,
+  DataviewCategory.Fishing,
+  DataviewCategory.Presence,
   DataviewCategory.Events,
   DataviewCategory.Environment,
   DataviewCategory.Context,

--- a/applications/fishing-map/src/data/config.ts
+++ b/applications/fishing-map/src/data/config.ts
@@ -1,6 +1,8 @@
 import { DataviewCategory } from '@globalfishingwatch/api-types/dist'
 import { SelectOption } from '@globalfishingwatch/ui-components/dist/select'
+import { ChoiceOption } from '@globalfishingwatch/ui-components/dist/choice'
 import { TimebarEvents, TimebarGraphs, TimebarVisualisations } from 'types'
+import { t } from 'features/i18n/i18n'
 
 export const SUPPORT_EMAIL = 'support@globalfishingwatch.org'
 
@@ -29,6 +31,8 @@ export const DEFAULT_TIME_RANGE = {
   end: end,
 }
 
+export const DEFAULT_ACTIVITY_CATEGORY = 'fishing'
+
 export const DEFAULT_WORKSPACE = {
   ...DEFAULT_VIEWPORT,
   query: undefined,
@@ -41,6 +45,7 @@ export const DEFAULT_WORKSPACE = {
   timebarGraph: TimebarGraphs.None,
   bivariate: false,
   analysis: undefined,
+  activityCategory: DEFAULT_ACTIVITY_CATEGORY,
   version: DEFAULT_VERSION,
 }
 
@@ -94,48 +99,57 @@ export const sources: SelectOption[] = [
   },
 ]
 
-// TODO translate this
-export const TIMEBAR_EVENT_OPTIONS: SelectOption[] = [
-  {
-    id: 'all',
-    label: 'All events',
-  },
+export const ACTIVITY_OPTIONS: ChoiceOption[] = [
   {
     id: 'fishing',
-    label: 'Fishing',
+    title: t('common.fishing', 'Fishing'),
   },
   {
-    id: 'encounters',
-    label: 'Encounters',
-  },
-  {
-    id: 'loitering',
-    label: 'Loitering',
-  },
-  {
-    id: 'ports',
-    label: 'Port visits',
-  },
-  {
-    id: 'none',
-    label: 'None',
+    id: 'presence',
+    title: t('common.presence', 'Presence'),
   },
 ]
 
-// TODO translate this
+export const TIMEBAR_EVENT_OPTIONS: SelectOption[] = [
+  {
+    id: 'all',
+    label: t('timebarSettings.eventOptions', 'All events'),
+  },
+  {
+    id: 'fishing',
+    label: t('timebarSettings.eventOptions', 'Fishing'),
+  },
+  {
+    id: 'encounters',
+    label: t('timebarSettings.eventOptions', 'Encounters'),
+  },
+  {
+    id: 'loitering',
+    label: t('timebarSettings.eventOptions', 'Loitering'),
+  },
+  {
+    id: 'ports',
+    label: t('timebarSettings.eventOptions', 'Port visits'),
+  },
+  {
+    id: 'none',
+    label: t('timebarSettings.eventOptions', 'None'),
+  },
+]
+
 export const TIMEBAR_GRAPH_OPTIONS: SelectOption[] = [
   {
     id: 'speed',
-    label: 'Speed',
+    label: t('timebarSettings.graphOptions.speed', 'Speed'),
   },
   {
     id: 'depth',
-    label: 'Depth (Coming soon)',
+    label: t('timebarSettings.graphOptions.depth', 'Depth (Coming soon)'),
     disabled: true,
   },
   {
     id: 'none',
-    label: 'None',
+    label: t('timebarSettings.graphOptions.none', 'None'),
   },
 ]
 

--- a/applications/fishing-map/src/data/default-workspaces/workspace.development.ts
+++ b/applications/fishing-map/src/data/default-workspaces/workspace.development.ts
@@ -54,12 +54,33 @@ const workspace: Workspace<WorkspaceState> = {
       dataviewId: DEFAULT_BASEMAP_DATAVIEW_ID,
     },
     {
-      id: 'fishing-1',
+      id: 'fishing-ais',
       config: {
-        // datasets: [`fishing_v5`],
-        // filters: { flag: ['ESP'] },
+        datasets: ['public-global-fishing-effort:v20201001'],
       },
       dataviewId: DEFAULT_FISHING_DATAVIEW_ID,
+    },
+    {
+      id: 'fishing-vms',
+      config: {
+        color: '#FFAA0D',
+        colorRamp: 'orange',
+        datasets: [
+          'public-chile-fishing-effort:v20200331',
+          'public-indonesia-fishing-effort:v20200320',
+          'public-panama-fishing-effort:v20200331',
+          'public-peru-fishing-effort:v20200324',
+        ],
+      },
+      dataviewId: DEFAULT_FISHING_DATAVIEW_ID,
+    },
+    {
+      id: 'presence',
+      config: {
+        color: '#FF64CE',
+        colorRamp: 'magenta',
+      },
+      dataviewId: DEFAULT_PRESENCE_DATAVIEW_ID,
     },
     {
       id: 'context-layer-eez',

--- a/applications/fishing-map/src/data/default-workspaces/workspace.production.ts
+++ b/applications/fishing-map/src/data/default-workspaces/workspace.production.ts
@@ -47,12 +47,33 @@ const workspace: Workspace<WorkspaceState> = {
       dataviewId: DEFAULT_BASEMAP_DATAVIEW_ID,
     },
     {
-      id: 'fishing-1',
+      id: 'fishing-ais',
       config: {
-        // datasets: [`${PUBLIC_SUFIX}-fishing_v4`],
-        // filters: ['ESP'],
+        datasets: ['public-global-fishing-effort:v20201001'],
       },
       dataviewId: DEFAULT_FISHING_DATAVIEW_ID,
+    },
+    {
+      id: 'fishing-vms',
+      config: {
+        color: '#FFAA0D',
+        colorRamp: 'orange',
+        datasets: [
+          'public-chile-fishing-effort:v20200331',
+          'public-indonesia-fishing-effort:v20200320',
+          'public-panama-fishing-effort:v20200331',
+          'public-peru-fishing-effort:v20200324',
+        ],
+      },
+      dataviewId: DEFAULT_FISHING_DATAVIEW_ID,
+    },
+    {
+      id: 'presence',
+      config: {
+        color: '#FF64CE',
+        colorRamp: 'magenta',
+      },
+      dataviewId: DEFAULT_PRESENCE_DATAVIEW_ID,
     },
     {
       id: 'context-layer-eez',

--- a/applications/fishing-map/src/data/workspaces.ts
+++ b/applications/fishing-map/src/data/workspaces.ts
@@ -33,9 +33,11 @@ export const DEFAULT_RFMO_DATAVIEW_ID = WORKSPACE_ENV === 'development' ? 95 : 1
 
 // Workspaces dataviews
 export const DEFAULT_VESSEL_DATAVIEW_ID = WORKSPACE_ENV === 'development' ? 92 : 171
-export const DEFAULT_FISHING_DATAVIEW_ID = WORKSPACE_ENV === 'development' ? 91 : 178
+// TODO restore 91 once reviewed and update to fishing category on the api entity
+export const DEFAULT_FISHING_DATAVIEW_ID = WORKSPACE_ENV === 'development' ? 1 : 178
 export const DEFAULT_EVENTS_DATAVIEW_ID = WORKSPACE_ENV === 'development' ? 140 : 0
-export const DEFAULT_PRESENCE_DATAVIEW_ID = WORKSPACE_ENV === 'development' ? 124 : 241
+// TODO restore 124 once reviewed and update to presence category on the api entity
+export const DEFAULT_PRESENCE_DATAVIEW_ID = WORKSPACE_ENV === 'development' ? 2 : 241
 export const DEFAULT_CONTEXT_DATAVIEW_ID = WORKSPACE_ENV === 'development' ? 123 : 220
 export const DEFAULT_ENVIRONMENT_DATAVIEW_ID = WORKSPACE_ENV === 'development' ? 125 : 223
 export const DEFAULT_USER_TRACK_ID = WORKSPACE_ENV === 'development' ? 154 : 251

--- a/applications/fishing-map/src/features/app/app.selectors.ts
+++ b/applications/fishing-map/src/features/app/app.selectors.ts
@@ -12,6 +12,7 @@ import {
   selectUrlViewport,
   selectUrlTimeRange,
   selectLocationCategory,
+  selectActivityCategory,
 } from 'routes/routes.selectors'
 import {
   TimebarEvents,
@@ -113,9 +114,17 @@ export const selectWorkspaceAppState = createSelector(
     selectTimebarVisualisation,
     selectTimebarEvents,
     selectTimebarGraph,
+    selectActivityCategory,
   ],
-  (bivariate, sidebarOpen, timebarVisualisation, timebarEvents, timebarGraph) => {
-    return { bivariate, sidebarOpen, timebarVisualisation, timebarEvents, timebarGraph }
+  (bivariate, sidebarOpen, timebarVisualisation, timebarEvents, timebarGraph, activityCategory) => {
+    return {
+      bivariate,
+      sidebarOpen,
+      timebarVisualisation,
+      timebarEvents,
+      timebarGraph,
+      activityCategory,
+    }
   }
 )
 

--- a/applications/fishing-map/src/features/dataviews/dataviews.mock.ts
+++ b/applications/fishing-map/src/features/dataviews/dataviews.mock.ts
@@ -1,5 +1,117 @@
-import { Dataview } from '@globalfishingwatch/api-types/dist'
+import { Dataview, DataviewCategory } from '@globalfishingwatch/api-types/dist'
 
-export const dataviews: Dataview[] = []
+export const dataviews: Dataview[] = [
+  {
+    id: 1,
+    name: 'Apparent fishing effort',
+    description: '',
+    app: 'fishing-map',
+    config: {
+      type: 'HEATMAP_ANIMATED',
+      color: '#00FFBC',
+      datasets: [
+        'public-global-fishing-effort:v20201001',
+        'public-chile-fishing-effort:v20200331',
+        'public-indonesia-fishing-effort:v20200320',
+        'public-panama-fishing-effort:v20200331',
+        'public-peru-fishing-effort:v20200324',
+      ],
+      colorRamp: 'teal',
+    },
+    category: DataviewCategory.Fishing,
+    datasetsConfig: [
+      {
+        params: [
+          {
+            id: 'type',
+            value: 'heatmap',
+          },
+        ],
+        endpoint: '4wings-tiles',
+        datasetId: 'public-global-fishing-effort:v20201001',
+      },
+      {
+        params: [
+          {
+            id: 'type',
+            value: 'heatmap',
+          },
+        ],
+        endpoint: '4wings-tiles',
+        datasetId: 'public-chile-fishing-effort:v20200331',
+      },
+      {
+        params: [
+          {
+            id: 'type',
+            value: 'heatmap',
+          },
+        ],
+        endpoint: '4wings-tiles',
+        datasetId: 'public-indonesia-fishing-effort:v20200320',
+      },
+      {
+        params: [
+          {
+            id: 'type',
+            value: 'heatmap',
+          },
+        ],
+        endpoint: '4wings-tiles',
+        datasetId: 'public-peru-fishing-effort:v20200324',
+      },
+      {
+        params: [
+          {
+            id: 'type',
+            value: 'heatmap',
+          },
+        ],
+        endpoint: '4wings-tiles',
+        datasetId: 'public-panama-fishing-effort:v20200331',
+      },
+    ],
+    createdAt: '2020-10-26T09:53:07.549Z',
+    updatedAt: '2021-03-24T12:41:54.218Z',
+  },
+  {
+    id: 2,
+    name: 'Fishing presence',
+    description: '',
+    app: 'fishing-map',
+    config: {
+      type: 'HEATMAP_ANIMATED',
+      color: '#00FFBC',
+      datasets: ['public-global-presence:v20201001', 'public-panama-carrier-presence:v20200331'],
+      interval: 'day',
+      colorRamp: 'teal',
+    },
+    category: DataviewCategory.Presence,
+    datasetsConfig: [
+      {
+        params: [
+          {
+            id: 'type',
+            value: 'heatmap',
+          },
+        ],
+        endpoint: '4wings-tiles',
+        datasetId: 'public-global-presence:v20201001',
+      },
+      {
+        params: [
+          {
+            id: 'type',
+            value: 'heatmap',
+          },
+        ],
+        endpoint: '4wings-tiles',
+        datasetId: 'public-panama-carrier-presence:v20200331',
+      },
+    ],
+    createdAt: '2021-02-08T15:27:48.243Z',
+    updatedAt: '2021-04-26T15:50:04.016Z',
+  },
+]
 
 export default dataviews

--- a/applications/fishing-map/src/features/dataviews/dataviews.selectors.ts
+++ b/applications/fishing-map/src/features/dataviews/dataviews.selectors.ts
@@ -17,13 +17,14 @@ import { Type } from '@globalfishingwatch/layer-composer/dist/generators/types'
 import { ThinningLevels, THINNING_LEVELS } from 'data/config'
 import { selectDebugOptions } from 'features/debug/debug.slice'
 import { AsyncReducerStatus } from 'utils/async-slice'
-import { selectUrlDataviewInstances } from 'routes/routes.selectors'
+import { selectActivityCategory, selectUrlDataviewInstances } from 'routes/routes.selectors'
 import { selectDatasets } from 'features/datasets/datasets.slice'
 import {
   selectWorkspaceStatus,
   selectWorkspaceDataviewInstances,
 } from 'features/workspace/workspace.selectors'
 import { GUEST_USER_TYPE, selectUserData } from 'features/user/user.slice'
+import { isActivityDataview } from 'features/workspace/heatmaps/heatmaps.utils'
 import { selectAllDataviews } from './dataviews.slice'
 
 export const isGuestUser = createSelector([selectUserData], (userData) => {
@@ -97,12 +98,22 @@ export const selectDataviewInstancesMerged = createSelector(
   }
 )
 
-export const selectDataviewInstancesResolved = createSelector(
+export const selectAllDataviewInstancesResolved = createSelector(
   [selectDataviewInstancesMerged, selectDataviews, selectDatasets],
   (dataviewInstances, dataviews, datasets): UrlDataviewInstance[] | undefined => {
     if (!dataviewInstances) return
     const dataviewInstancesResolved = resolveDataviews(dataviewInstances, dataviews, datasets)
     return dataviewInstancesResolved
+  }
+)
+
+export const selectDataviewInstancesResolved = createSelector(
+  [selectAllDataviewInstancesResolved, selectActivityCategory],
+  (dataviews = [], activityCategory) => {
+    return dataviews.filter((dataview) => {
+      const activityDataview = isActivityDataview(dataview)
+      return activityDataview ? dataview.category === activityCategory : true
+    })
   }
 )
 
@@ -161,9 +172,21 @@ export const selectActiveContextAreasDataviews = createSelector(
   (dataviews) => dataviews?.filter((d) => d.config?.visible)
 )
 
-export const selectActivityDataviews = createSelector(
-  [selectDataviewInstancesByCategory(DataviewCategory.Activity)],
+export const selectFishingDataviews = createSelector(
+  [selectDataviewInstancesByCategory(DataviewCategory.Fishing)],
   (dataviews) => dataviews
+)
+
+export const selectPresenceDataviews = createSelector(
+  [selectDataviewInstancesByCategory(DataviewCategory.Presence)],
+  (dataviews) => dataviews
+)
+
+export const selectActivityDataviews = createSelector(
+  [selectFishingDataviews, selectPresenceDataviews, selectActivityCategory],
+  (fishingDataviews = [], presenceDataviews = [], activityCategory) => {
+    return activityCategory === 'presence' ? presenceDataviews : fishingDataviews
+  }
 )
 
 export const selectActiveActivityDataviews = createSelector(

--- a/applications/fishing-map/src/features/map/popups/HeatmapLayers.tsx
+++ b/applications/fishing-map/src/features/map/popups/HeatmapLayers.tsx
@@ -1,5 +1,4 @@
 import React from 'react'
-import cx from 'classnames'
 import { useTranslation } from 'react-i18next'
 import Spinner from '@globalfishingwatch/ui-components/dist/spinner'
 import { DatasetTypes } from '@globalfishingwatch/api-types'

--- a/applications/fishing-map/src/features/map/popups/HeatmapLayers.tsx
+++ b/applications/fishing-map/src/features/map/popups/HeatmapLayers.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import cx from 'classnames'
 import { useTranslation } from 'react-i18next'
 import Spinner from '@globalfishingwatch/ui-components/dist/spinner'
 import { DatasetTypes } from '@globalfishingwatch/api-types'
@@ -73,7 +74,12 @@ function HeatmapTooltipRow({ feature, showFeaturesDetails }: HeatmapTooltipRowPr
             {feature.vesselsInfo.vessels.map((vessel, i) => {
               const vesselLabel = getVesselLabel(vessel, true)
               return (
-                <button key={i} className={styles.vesselRow} onClick={() => onVesselClick(vessel)}>
+                <button
+                  disabled={feature.category === 'presence'}
+                  key={i}
+                  className={styles.vesselRow}
+                  onClick={() => onVesselClick(vessel)}
+                >
                   <span className={styles.vesselName}>
                     {vesselLabel}
                     {vessel.dataset && vessel.dataset.name && (

--- a/applications/fishing-map/src/features/map/popups/Popup.module.css
+++ b/applications/fishing-map/src/features/map/popups/Popup.module.css
@@ -88,10 +88,13 @@
 .vesselRow {
   color: currentColor;
   width: 100%;
-  cursor: pointer;
   display: flex;
   justify-content: space-between;
   margin-bottom: var(--space-XS);
+}
+
+.vesselRow:not(:disabled) {
+  cursor: pointer;
 }
 
 .vesselRowLegend {

--- a/applications/fishing-map/src/features/map/popups/PopupWrapper.tsx
+++ b/applications/fishing-map/src/features/map/popups/PopupWrapper.tsx
@@ -55,7 +55,8 @@ function PopupWrapper({
       <div className={styles.content}>
         {Object.entries(featureByCategory).map(([featureCategory, features]) => {
           switch (featureCategory) {
-            case DataviewCategory.Activity:
+            case DataviewCategory.Fishing:
+            case DataviewCategory.Presence:
               return features.map((feature, i) => (
                 <HeatmapTooltipRow
                   key={i + (feature.title as string)}

--- a/applications/fishing-map/src/features/workspace/heatmaps/HeatmapsSection.tsx
+++ b/applications/fishing-map/src/features/workspace/heatmaps/HeatmapsSection.tsx
@@ -2,7 +2,8 @@ import React, { useCallback, useState } from 'react'
 import cx from 'classnames'
 import { useSelector } from 'react-redux'
 import { useTranslation } from 'react-i18next'
-import { IconButton } from '@globalfishingwatch/ui-components'
+import IconButton from '@globalfishingwatch/ui-components/dist/icon-button'
+import Choice, { ChoiceOption } from '@globalfishingwatch/ui-components/dist/choice'
 import { Generators } from '@globalfishingwatch/layer-composer'
 import { selectActivityDataviews } from 'features/dataviews/dataviews.selectors'
 import { selectWorkspaceDataviews } from 'features/workspace/workspace.selectors'
@@ -15,6 +16,9 @@ import {
   getPresenceDataviewInstance,
 } from 'features/dataviews/dataviews.utils'
 import { DEFAULT_PRESENCE_DATAVIEW_ID } from 'data/workspaces'
+import { ACTIVITY_OPTIONS } from 'data/config'
+import { WorkspaceActivityCategory } from 'types'
+import { selectActivityCategory } from 'routes/routes.selectors'
 import TooltipContainer, { TooltipListContainer } from '../shared/TooltipContainer'
 import LayerPanel from './HeatmapLayerPanel'
 
@@ -27,6 +31,7 @@ function HeatmapsSection(): React.ReactElement {
   const [newLayerOpen, setNewLayerOpen] = useState<boolean>(false)
   const workspaceDataviews = useSelector(selectWorkspaceDataviews)
   const dataviews = useSelector(selectActivityDataviews)
+  const activityCategory = useSelector(selectActivityCategory)
   const { upsertDataviewInstance } = useDataviewInstancesConnect()
   const { dispatchQueryParams } = useLocationConnect()
   const bivariate = useSelector(selectBivariate)
@@ -39,6 +44,13 @@ function HeatmapsSection(): React.ReactElement {
     { id: 'activity', label: t('common.apparentFishing', 'Apparent Fishing Effort') },
     { id: 'presence', label: t('common.presence', 'Fishing presence') },
   ]
+
+  const onActivityOptionClick = useCallback(
+    (activityOption: ChoiceOption) => {
+      dispatchQueryParams({ activityCategory: activityOption.id as WorkspaceActivityCategory })
+    },
+    [dispatchQueryParams]
+  )
 
   const onAddClick = useCallback(
     (category: HeatmapCategory) => {
@@ -89,8 +101,16 @@ function HeatmapsSection(): React.ReactElement {
     <div className={cx(styles.container, { 'print-hidden': !hasVisibleDataviews })}>
       <div className={styles.header}>
         <h2 className={styles.sectionTitle}>{t('common.activity', 'Activity')}</h2>
+        <Choice
+          size="small"
+          className={cx('print-hidden')}
+          options={ACTIVITY_OPTIONS}
+          activeOption={activityCategory}
+          onOptionClick={onActivityOptionClick}
+        />
         <div className={cx('print-hidden', styles.sectionButtons)}>
-          <IconButton
+          {/* // TODO move this between layers */}
+          {/* <IconButton
             icon={bivariate ? 'split' : 'compare'}
             type="border"
             size="medium"
@@ -98,7 +118,7 @@ function HeatmapsSection(): React.ReactElement {
             tooltip={bivariateTooltip}
             tooltipPlacement="top"
             onClick={onToggleCombinationMode}
-          />
+          /> */}
           {supportsPresence ? (
             <TooltipContainer
               visible={newLayerOpen}

--- a/applications/fishing-map/src/features/workspace/heatmaps/heatmaps.utils.ts
+++ b/applications/fishing-map/src/features/workspace/heatmaps/heatmaps.utils.ts
@@ -8,6 +8,9 @@ export const isFishingDataview = (dataview: UrlDataviewInstance) =>
 export const isPresenceDataview = (dataview: UrlDataviewInstance) =>
   dataview.dataviewId === DEFAULT_PRESENCE_DATAVIEW_ID
 
+export const isActivityDataview = (dataview: UrlDataviewInstance) =>
+  isFishingDataview(dataview) || isPresenceDataview(dataview)
+
 export const getSourcesOptionsInDataview = (
   dataview: UrlDataviewInstance,
   datasetType = DatasetTypes.Fourwings

--- a/applications/fishing-map/src/routes/routes.selectors.ts
+++ b/applications/fishing-map/src/routes/routes.selectors.ts
@@ -3,8 +3,8 @@ import memoize from 'lodash/memoize'
 import { Query, RouteObject } from 'redux-first-router'
 import { UrlDataviewInstance } from '@globalfishingwatch/dataviews-client'
 import { RootState } from 'store'
-import { WorkspaceParam } from 'types'
-import { DEFAULT_VERSION } from 'data/config'
+import { WorkspaceActivityCategory, WorkspaceParam } from 'types'
+import { DEFAULT_ACTIVITY_CATEGORY, DEFAULT_VERSION } from 'data/config'
 import { WorkspaceCategories } from 'data/workspaces'
 import { HOME, ROUTE_TYPES, WORKSPACE } from './routes'
 
@@ -62,6 +62,10 @@ export const selectUrlStartQuery = selectQueryParam<string>('start')
 export const selectUrlEndQuery = selectQueryParam<string>('end')
 export const selectUrlDataviewInstances = selectQueryParam<UrlDataviewInstance[]>(
   'dataviewInstances'
+)
+export const selectActivityCategory = createSelector(
+  [selectQueryParam<WorkspaceActivityCategory>('activityCategory')],
+  (activityCategory) => activityCategory || DEFAULT_ACTIVITY_CATEGORY
 )
 
 export const selectUrlViewport = createSelector(

--- a/applications/fishing-map/src/types/index.ts
+++ b/applications/fishing-map/src/types/index.ts
@@ -19,6 +19,8 @@ export type WorkspaceStateProperty =
   | 'timebarGraph'
   | 'bivariate'
   | 'version'
+  | 'activityCategory'
+
 export type WorkspaceParam =
   | WorkspaceViewportParam
   | WorkspaceTimeRangeParam
@@ -31,16 +33,19 @@ export type WorkspaceAnalysis = {
   sourceId: string
   bounds?: [number, number, number, number]
 }
+export type WorkspaceActivityCategory = 'fishing' | 'presence'
+
 export type WorkspaceState = {
   query?: string
+  version?: string
   sidebarOpen?: boolean
   analysis?: WorkspaceAnalysis
   dataviewInstances?: Partial<UrlDataviewInstance[]>
   timebarVisualisation?: TimebarVisualisations
   timebarEvents?: TimebarEvents
   timebarGraph?: TimebarGraphs
-  bivariate?: boolean
-  version?: string
+  bivariate?: boolean // TODO move this between layers saving layer indexes
+  activityCategory?: WorkspaceActivityCategory
 }
 export type QueryParams = Partial<WorkspaceViewport> & Partial<WorkspaceTimeRange> & WorkspaceState
 

--- a/packages/api-types/src/dataviews.ts
+++ b/packages/api-types/src/dataviews.ts
@@ -45,7 +45,8 @@ export enum DataviewCategory {
   Context = 'context',
   Events = 'events',
   Environment = 'environment',
-  Activity = 'activity',
+  Fishing = 'fishing',
+  Presence = 'presence',
 }
 
 export interface Dataview<Type = any, Category = DataviewCategory> {

--- a/packages/dataviews-client/src/resolve-dataviews-generators.ts
+++ b/packages/dataviews-client/src/resolve-dataviews-generators.ts
@@ -288,7 +288,8 @@ export function getDataviewsGeneratorConfigs(
   // Collect heatmap animated generators and filter them out from main dataview list
   const dataviewsFiltered = dataviews.filter((d) => {
     const isActivityDataview =
-      d.category === DataviewCategory.Activity && d.config?.type === Generators.Type.HeatmapAnimated
+      (d.category === DataviewCategory.Fishing || d.category === DataviewCategory.Presence) &&
+      d.config?.type === Generators.Type.HeatmapAnimated
     if (isActivityDataview) {
       activityDataviews.push(d)
     }

--- a/packages/layer-composer/src/generators/heatmap/heatmap-animated.ts
+++ b/packages/layer-composer/src/generators/heatmap/heatmap-animated.ts
@@ -183,9 +183,9 @@ class HeatmapAnimatedGenerator {
   }
 
   getCacheKey = (config: FetchBreaksParams) => {
-    const visibleSublayers = config.sublayers.filter((sublayer) => sublayer.visible)
-    const datasetKey = getSubLayersDatasets(visibleSublayers).join(',')
-    const filtersKey = visibleSublayers.flatMap((subLayer) => subLayer.filter || []).join(',')
+    const visibleSublayers = config.sublayers?.filter((sublayer) => sublayer.visible)
+    const datasetKey = getSubLayersDatasets(visibleSublayers)?.join(',')
+    const filtersKey = visibleSublayers?.flatMap((subLayer) => subLayer.filter || []).join(',')
     return [datasetKey, filtersKey, config.mode].join(',')
   }
 

--- a/packages/ui-components/src/choice/Choice.tsx
+++ b/packages/ui-components/src/choice/Choice.tsx
@@ -9,9 +9,16 @@ interface ChoiceProps {
   activeOption: string
   onOptionClick?: (option: ChoiceOption, e: React.MouseEvent) => void
   size?: 'default' | 'small'
+  className?: string
 }
 
-function Choice({ activeOption, options, onOptionClick, size = 'default' }: ChoiceProps) {
+function Choice({
+  activeOption,
+  options,
+  onOptionClick,
+  size = 'default',
+  className = '',
+}: ChoiceProps) {
   const activeOptionId = activeOption || options?.[0]?.id
   const [activeElementProperties, setActiveElementProperties] = useState<{
     width: number
@@ -38,7 +45,7 @@ function Choice({ activeOption, options, onOptionClick, size = 'default' }: Choi
     }
   }, [activeRef])
   return (
-    <div className={styles.Choice}>
+    <div className={cx(styles.Choice, className)}>
       <ul className={styles.list} role="radiogroup">
         {options.map((option, index) => {
           const optionSelected = activeOptionId === option.id


### PR DESCRIPTION
Using <Choice /> component to toggle between fishing and presence layers with new dataviews categories: `fishing` and `presence`

https://user-images.githubusercontent.com/10500650/117045687-1480cf00-ad10-11eb-8b63-4e15d6fd144c.mp4

Also disables presence layer interaction on vessel click.

Blocked by https://github.com/GlobalFishingWatch/api-datasets/pull/25 to remove dataseis mock before merging

Pending:
- [ ] Review performance on toggle as rendering takes some time
- [ ] Enable again the bivariate mode with new UI
