### PR TITLE
Fishing map/custom layer fixes

### DIFF
--- a/.changeset/long-melons-do.md
+++ b/.changeset/long-melons-do.md
@@ -1,0 +1,6 @@
+---
+"@globalfishingwatch/dataviews-client": patch
+"@globalfishingwatch/layer-composer": patch
+---
+
+fix color ramps

--- a/applications/fishing-map/src/features/datasets/DatasetFile.tsx
+++ b/applications/fishing-map/src/features/datasets/DatasetFile.tsx
@@ -8,19 +8,23 @@ import { ReactComponent as FilesSupportedTracksIcon } from 'assets/icons/files-s
 import styles from './NewDataset.module.css'
 
 interface DatasetFileProps {
-  type: DatasetGeometryType
+  type?: DatasetGeometryType
   className?: string
-  onFileLoaded: (fileInfo: File, type: DatasetGeometryType) => void
+  onFileLoaded: (fileInfo: File, type?: DatasetGeometryType) => void
 }
 
+const POLYGONS_ACCEPT = '.zip, .json, .geojson'
+const TRACKS_ACCEPT = '.csv'
 const ACCEPT_FILES_BY_TYPE: Record<DatasetGeometryType, string> = {
-  polygons: '.zip, .json, .geojson',
-  tracks: '.csv',
+  polygons: POLYGONS_ACCEPT,
+  tracks: TRACKS_ACCEPT,
   points: '',
 }
 
 const DatasetFile: React.FC<DatasetFileProps> = ({ onFileLoaded, type, className = '' }) => {
-  const accept = ACCEPT_FILES_BY_TYPE[type]
+  const accept = type ? ACCEPT_FILES_BY_TYPE[type] : ACCEPT_FILES_BY_TYPE.polygons
+  const filesSupportedIcon =
+    accept === POLYGONS_ACCEPT ? <FilesSupportedPolygonsIcon /> : <FilesSupportedTracksIcon />
   const { t } = useTranslation()
   const onDropAccepted = useCallback(
     (files) => {
@@ -34,7 +38,7 @@ const DatasetFile: React.FC<DatasetFileProps> = ({ onFileLoaded, type, className
   })
   return (
     <div className={cx(styles.dropFiles, className)} {...(getRootProps() as any)}>
-      {type === 'polygons' ? <FilesSupportedPolygonsIcon /> : <FilesSupportedTracksIcon />}
+      {filesSupportedIcon}
       <input {...getInputProps()} />
       {acceptedFiles.length ? (
         <p className={styles.fileText}>

--- a/applications/fishing-map/src/features/datasets/DatasetTypeSelect.tsx
+++ b/applications/fishing-map/src/features/datasets/DatasetTypeSelect.tsx
@@ -40,7 +40,7 @@ const DatasetTypeSelect = ({
   currentType,
 }: {
   onDatasetTypeChange: (e: any) => void
-  currentType: DatasetGeometryType | null
+  currentType: DatasetGeometryType | undefined
 }) => {
   const { t } = useTranslation()
   return (

--- a/applications/fishing-map/src/features/datasets/NewDataset.tsx
+++ b/applications/fishing-map/src/features/datasets/NewDataset.tsx
@@ -175,7 +175,7 @@ function NewDataset(): React.ReactElement {
       if (min && max && min >= max) {
         error = t('errors.invalidRange', 'Min has to be lower than max value')
       }
-      if (meta?.type === DatasetTypes.UserTracks) {
+      if (meta?.category === DatasetCategory.Environment && datasetGeometryType === 'tracks') {
         if (
           fileData &&
           newMetadata.configuration?.latitude &&
@@ -201,7 +201,20 @@ function NewDataset(): React.ReactElement {
     if (file) {
       let validityError
       let userTrackGeoJSONFile
-      if (metadata?.type === DatasetTypes.UserTracks) {
+      if (
+        metadata?.category === DatasetCategory.Environment &&
+        datasetGeometryType === 'polygons'
+      ) {
+        if (!metadata?.configuration?.propertyToInclude) {
+          validityError = t('dataset.requiredFields', {
+            fields: 'value',
+            defaultValue: 'Required field value',
+          }) as string
+        }
+      } else if (
+        metadata?.category === DatasetCategory.Environment &&
+        datasetGeometryType === 'tracks'
+      ) {
         if (
           !metadata.configuration?.latitude ||
           !metadata.configuration?.longitude ||

--- a/applications/fishing-map/src/features/datasets/NewDataset.tsx
+++ b/applications/fishing-map/src/features/datasets/NewDataset.tsx
@@ -113,10 +113,11 @@ function NewDataset(): React.ReactElement {
             type: DatasetTypes.Context,
             category: datasetCategory,
             configuration: {
+              geometryType: datasetGeometryType,
               // TODO when supporting multiple files upload
               // ...(geojson?.fileName && { file: geojson.fileName }),
               ...(isGeojson && { format: 'geojson' }),
-            },
+            } as DatasetConfiguration,
           }))
         } else {
           setFileData(undefined)

--- a/applications/fishing-map/src/features/datasets/datasets.hook.ts
+++ b/applications/fishing-map/src/features/datasets/datasets.hook.ts
@@ -49,9 +49,11 @@ export const useAddDataviewFromDatasetToWorkspace = () => {
       ) {
         dataviewInstance = getUserTrackDataviewInstance(dataset)
       }
-      if (dataviewInstance) {
-        upsertDataviewInstance(dataviewInstance)
+      if (!dataviewInstance) {
+        throw new Error(`
+        Dataview instance was not instanciated correctly. With dataset ${dataset.id}`)
       }
+      upsertDataviewInstance(dataviewInstance)
     },
     [upsertDataviewInstance]
   )

--- a/packages/dataviews-client/src/resolve-dataviews-generators.ts
+++ b/packages/dataviews-client/src/resolve-dataviews-generators.ts
@@ -15,6 +15,7 @@ import {
   GeneratorDataviewConfig,
   Generators,
   Group,
+  COLOR_RAMP_DEFAULT_NUM_STEPS,
 } from '@globalfishingwatch/layer-composer'
 import type {
   ColorRampsIds,
@@ -249,7 +250,7 @@ export function getGeneratorConfig(
             (dataset.configuration as EnviromentalDatasetConfiguration)?.propertyToIncludeRange ||
             {}
           const rampScale = scaleLinear().range([min, max]).domain([0, 1])
-          const numSteps = 8
+          const numSteps = COLOR_RAMP_DEFAULT_NUM_STEPS
           const steps = [...Array(numSteps)]
             .map((_, i) => parseFloat((i / (numSteps - 1))?.toFixed(2)))
             .map((value) => parseFloat((rampScale(value) as number)?.toFixed(3)))

--- a/packages/layer-composer/src/generators/heatmap/config.ts
+++ b/packages/layer-composer/src/generators/heatmap/config.ts
@@ -54,6 +54,9 @@ export const HEATMAP_COLORS_BY_ID = {
   orange: '#FFAA0D',
 }
 
+export const COLOR_RAMP_DEFAULT_NUM_STEPS = 10
+export const COLOR_RAMP_DEFAULT_NUM_STEPS_TO_WHITE = [7, 3]
+
 export const HEATMAP_COLOR_RAMPS: Record<ColorRampsIds, string[]> = {
   teal: getColorRampByOpacitySteps(HEATMAP_COLORS_BY_ID.teal),
   teal_toWhite: getMixedOpacityToWhiteColorRamp(HEATMAP_COLORS_BY_ID.teal),
@@ -69,8 +72,8 @@ export const HEATMAP_COLOR_RAMPS: Record<ColorRampsIds, string[]> = {
   red_toWhite: getMixedOpacityToWhiteColorRamp(HEATMAP_COLORS_BY_ID.red),
   yellow: getColorRampByOpacitySteps(HEATMAP_COLORS_BY_ID.yellow),
   yellow_toWhite: getMixedOpacityToWhiteColorRamp(HEATMAP_COLORS_BY_ID.yellow),
-  green: getColorRampByOpacitySteps(HEATMAP_COLORS_BY_ID.green), // 166,255,89
-  green_toWhite: getMixedOpacityToWhiteColorRamp(HEATMAP_COLORS_BY_ID.green), // 166,255,89
+  green: getColorRampByOpacitySteps(HEATMAP_COLORS_BY_ID.green),
+  green_toWhite: getMixedOpacityToWhiteColorRamp(HEATMAP_COLORS_BY_ID.green),
   orange: getColorRampByOpacitySteps(HEATMAP_COLORS_BY_ID.orange),
   orange_toWhite: getMixedOpacityToWhiteColorRamp(HEATMAP_COLORS_BY_ID.orange),
 }

--- a/packages/layer-composer/src/generators/heatmap/util/colors.ts
+++ b/packages/layer-composer/src/generators/heatmap/util/colors.ts
@@ -1,5 +1,6 @@
 import { normal, screen } from 'color-blend'
 import { RGBA } from 'color-blend/dist/types'
+import { COLOR_RAMP_DEFAULT_NUM_STEPS, COLOR_RAMP_DEFAULT_NUM_STEPS_TO_WHITE } from '../config'
 
 export const hexToRgb = (hex: string) => {
   const cleanHex = hex.replace('#', '')
@@ -43,18 +44,24 @@ export const rgbaToHex = ({ r, g, b }: RGBA) => {
   return '#' + componentToHex(r) + componentToHex(g) + componentToHex(b)
 }
 
-export const BLEND_BACKGROUND = '#244979'
+const BLEND_BACKGROUND = '#244979'
 export const getBlend = (color1: RGBA, color2: RGBA) => {
   return normal({ ...hexToRgb(BLEND_BACKGROUND), a: 1 }, screen(color1 as RGBA, color2 as RGBA))
 }
 
-export const getColorRampByOpacitySteps = (finalColor: string, numSteps = 10) => {
+export const getColorRampByOpacitySteps = (
+  finalColor: string,
+  numSteps = COLOR_RAMP_DEFAULT_NUM_STEPS
+) => {
   const color = finalColor.includes('#') ? hexToRgbString(finalColor) : finalColor
   const opacitySteps = [...Array(numSteps)].map((_, i) => i / (numSteps - 1))
   return opacitySteps.map((opacity) => `rgba(${color}, ${opacity})`)
 }
 
-export const getColorRampToWhite = (hexColor: string, numSteps = 3) => {
+export const getColorRampToWhite = (
+  hexColor: string,
+  numSteps = COLOR_RAMP_DEFAULT_NUM_STEPS_TO_WHITE[1]
+) => {
   const rgbColor = hexToRgb(hexColor)
   const steps = [...Array(numSteps - 1)].map((_, i) => {
     const ratio = (i + 1) / numSteps
@@ -73,8 +80,8 @@ export const getColorRampToWhite = (hexColor: string, numSteps = 3) => {
 
 export const getMixedOpacityToWhiteColorRamp = (
   finalColor: string,
-  numStepsOpacity = 7,
-  numStepsTopWhite = 3
+  numStepsOpacity = COLOR_RAMP_DEFAULT_NUM_STEPS_TO_WHITE[0],
+  numStepsTopWhite = COLOR_RAMP_DEFAULT_NUM_STEPS_TO_WHITE[1]
 ) => {
   return [
     ...getColorRampByOpacitySteps(finalColor, numStepsOpacity),

--- a/packages/layer-composer/src/generators/index.ts
+++ b/packages/layer-composer/src/generators/index.ts
@@ -12,7 +12,7 @@ import VesselEventsGenerator from './vessel-events/vessel-events'
 import RulersGenerator from './rulers/rulers'
 import TileClusterGenerator from './tile-cluster/tile-cluster'
 
-export { HEATMAP_COLOR_RAMPS } from './heatmap/config'
+export { HEATMAP_COLOR_RAMPS, COLOR_RAMP_DEFAULT_NUM_STEPS } from './heatmap/config'
 export { DEFAULT_HEATMAP_INTERVALS } from './heatmap/heatmap-animated'
 export { CONFIG_BY_INTERVAL } from './heatmap/util/time-chunks'
 export { TEMPORALGRID_SOURCE_LAYER } from './heatmap/modes/gridded'

--- a/packages/layer-composer/src/generators/user-context/user-context.ts
+++ b/packages/layer-composer/src/generators/user-context/user-context.ts
@@ -57,6 +57,7 @@ class UserContextGenerator {
           color: config.color,
           interactive: true,
           generatorId,
+          group: Group.OutlinePolygonsBackground,
           uniqueFeatureInteraction: true,
           legend: {
             type: 'colorramp',

--- a/packages/layer-composer/src/index.ts
+++ b/packages/layer-composer/src/index.ts
@@ -6,6 +6,7 @@ export {
   DEFAULT_HEATMAP_INTERVALS,
   TEMPORALGRID_SOURCE_LAYER,
   CONFIG_BY_INTERVAL,
+  COLOR_RAMP_DEFAULT_NUM_STEPS,
 } from './generators'
 export * from './types'
 export { frameToDate, quantizeOffsetToDate } from './generators/heatmap/util/time-chunks'

--- a/packages/layer-composer/src/types/index.ts
+++ b/packages/layer-composer/src/types/index.ts
@@ -37,7 +37,7 @@ export interface Generator {
 }
 
 /**
- * Defines groups for layer order
+ * Defines groups for layer order. See actual layer order in packages/layer-composer/src/transforms/sort/sort.ts
  */
 export enum Group {
   Background = 'background', // Solid bg color


### PR DESCRIPTION
Critical fixes:
- fixed an issue where env polygon layers could not be added to workspaces
- fixed an issue where env polygon layers with 'color by value' option would break map style 
- fixed an issue where context poly layers accepted could not be uploaded
- fixed an issue where context poly layers accepted wrong file type

Other fixes:
- made 'color by value' field mandatory with env polygon layers
- fixed z-order issue with env polygon layers (https://globalfishingwatch.atlassian.net/browse/MR-245)