### PR TITLE
Linting/prettier

### DIFF
--- a/.changeset/thin-chairs-speak.md
+++ b/.changeset/thin-chairs-speak.md
@@ -1,0 +1,9 @@
+---
+"@globalfishingwatch/timebar": patch
+"@globalfishingwatchapp/fishing-map": patch
+"@globalfishingwatchapp/tile-inspector": patch
+"@globalfishingwatchapp/vessel-history": patch
+"@globalfishingwatch/linting": patch
+---
+
+Linting/prettier

--- a/applications/fishing-map/package.json
+++ b/applications/fishing-map/package.json
@@ -112,7 +112,6 @@
     "eslint-plugin-flowtype": "5.2.0",
     "eslint-plugin-import": "2.22.1",
     "eslint-plugin-jsx-a11y": "6.4.1",
-    "eslint-plugin-prettier": "3.1.4",
     "eslint-plugin-react": "7.21.5",
     "eslint-plugin-react-hooks": "4.2.0",
     "husky": "^4.3.0",

--- a/applications/fishing-map/package.json
+++ b/applications/fishing-map/package.json
@@ -118,7 +118,7 @@
     "i18next-parser": "^3.3.0",
     "imagemin-lint-staged": "^0.4.0",
     "lint-staged": "^10.4.0",
-    "prettier": "^2.1.2",
+    "prettier": "2.3.0",
     "react-test-renderer": "^17.0.1",
     "serve": "^11.3.2",
     "stylelint": "^13.7.1",

--- a/applications/tile-inspector/.lintstagedrc
+++ b/applications/tile-inspector/.lintstagedrc
@@ -2,7 +2,7 @@
   "*.css": ["prettier --write", "stylelint --fix"],
   "*.scss": ["prettier --write", "stylelint --syntax=scss --fix"],
   "*.{js,jsx,ts,tsx}": [
-    "eslint --fix"
+    "eslint --fix", "prettier --write"
   ],
   "*.{png,jpeg,jpg,gif,svg}": [
     "imagemin-lint-staged",

--- a/applications/vessel-history/package.json
+++ b/applications/vessel-history/package.json
@@ -103,7 +103,7 @@
     "i18next-parser": "^3.7.0",
     "imagemin-lint-staged": "^0.4.0",
     "lint-staged": "^10.4.0",
-    "prettier": "^2.1.2",
+    "prettier": "2.3.0",
     "react-test-renderer": "^17.0.1",
     "stylelint": "^13.7.1",
     "stylelint-config-css-modules": "^2.2.0",

--- a/linting/index.js
+++ b/linting/index.js
@@ -1,10 +1,5 @@
 module.exports = {
-  extends: [
-    'react-app',
-    'plugin:prettier/recommended',
-    'plugin:import/errors',
-    'plugin:import/warnings',
-  ],
+  extends: ['react-app', 'plugin:import/errors', 'plugin:import/warnings', 'prettier'],
   plugins: ['react', 'import'],
   rules: {
     'import/default': 0,

--- a/linting/package.json
+++ b/linting/package.json
@@ -39,7 +39,6 @@
     "eslint-plugin-flowtype": "^5.x",
     "eslint-plugin-import": "^2.x",
     "eslint-plugin-jsx-a11y": "^6.x",
-    "eslint-plugin-prettier": "^3.x",
     "eslint-plugin-react": "^7.x",
     "eslint-plugin-react-hooks": "^4.x",
     "prettier": "^2.x",

--- a/linting/package.json
+++ b/linting/package.json
@@ -41,7 +41,7 @@
     "eslint-plugin-jsx-a11y": "^6.x",
     "eslint-plugin-react": "^7.x",
     "eslint-plugin-react-hooks": "^4.x",
-    "prettier": "^2.x",
+    "prettier": "2.3.0",
     "prettier-eslint": "^12.0.0",
     "stylelint": "^13.x",
     "stylelint-config-css-modules": "^2.x",

--- a/linting/typescript.js
+++ b/linting/typescript.js
@@ -3,11 +3,10 @@ module.exports = {
   extends: [
     'plugin:@typescript-eslint/recommended',
     'react-app',
-    'prettier/@typescript-eslint',
-    'plugin:prettier/recommended',
     'plugin:import/errors',
     'plugin:import/warnings',
     'plugin:import/typescript',
+    'prettier',
   ],
   plugins: ['@typescript-eslint', 'react', 'import'],
   settings: {

--- a/package.json
+++ b/package.json
@@ -49,7 +49,6 @@
     "eslint-plugin-jest": "^24.1.3",
     "eslint-plugin-json": "^2.1.2",
     "eslint-plugin-jsx-a11y": "6.4.1",
-    "eslint-plugin-prettier": "^3.3.1",
     "eslint-plugin-react": "^7.22.0",
     "eslint-plugin-react-hooks": "4.2.0",
     "husky": "^4.2.5",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "mkdir": "^0.0.2",
     "mkdirp": "^1.0.4",
     "npm-run-all": "^4.1.5",
-    "prettier": "^2.2.1",
+    "prettier": "2.3.0",
     "prettier-eslint": "^12.0.0",
     "rimraf": "^3.0.2",
     "stylelint": "^13.11.0",

--- a/packages/timebar/package.json
+++ b/packages/timebar/package.json
@@ -65,7 +65,7 @@
     "geojson-validation": "^0.2.1",
     "jest": "^25.1.0",
     "npm-run-all": "^4.1.5",
-    "prettier": "^1.16.3",
+    "prettier": "2.3.0",
     "react-test-renderer": "^16.9.0",
     "rimraf": "^3.0.1",
     "rollup": "^1.22.0",


### PR DESCRIPTION
- removes using prettier as an eslint rule. This is the recommended approach as per: https://prettier.io/docs/en/integrating-with-linters.html
   - the advantage of this is that a prettier error will no longer break compilation
- sets a fixed version of prettier in dependencies ras recommended here: https://prettier.io/docs/en/install.html
   - this is probably the source of suddenly having prettier complain about stuff when running yarn/yarn clean
   
