### PR TITLE
use entire mapLoaded instead of sourcesLoaded to ensure reliability

### DIFF
--- a/applications/fishing-map/src/features/map/Map.tsx
+++ b/applications/fishing-map/src/features/map/Map.tsx
@@ -29,9 +29,10 @@ import PopupWrapper from './popups/PopupWrapper'
 import useViewport, { useMapBounds } from './map-viewport.hooks'
 import styles from './Map.module.css'
 import { SliceInteractionEvent } from './map.slice'
-import { useHasSourceLoaded, useHaveAllSourcesLoaded } from './map-features.hooks'
-import '@globalfishingwatch/mapbox-gl/dist/mapbox-gl.css'
+import { useHaveSourcesLoaded, useMapLoaded, useSetMapIdleAtom } from './map-features.hooks'
 import useRulers from './rulers/rulers.hooks'
+
+import '@globalfishingwatch/mapbox-gl/dist/mapbox-gl.css'
 
 const clickRadiusScale = scaleLinear().domain([4, 12, 17]).rangeRound([1, 2, 8]).clamp(true)
 
@@ -56,9 +57,10 @@ const handleError = ({ error }: any) => {
 }
 
 const MapWrapper = (): React.ReactElement | null => {
+  // Used it only once here to attach the listener only once
+  useSetMapIdleAtom()
   const map = useMapInstance()
   const { t } = useTranslation()
-
   const { generatorsConfig, globalConfig } = useGeneratorsConnect()
 
   // useLayerComposer is a convenience hook to easily generate a Mapbox GL style (see https://docs.mapbox.com/mapbox-gl-js/style-spec/) from
@@ -135,10 +137,8 @@ const MapWrapper = (): React.ReactElement | null => {
 
   const debugOptions = useSelector(selectDebugOptions)
 
-  // TODO handle also in case of error
-  // https://docs.mapbox.com/mapbox-gl-js/api/map/#map.event:sourcedataloading
-  const allSourcesLoaded = useHaveAllSourcesLoaded()
-  const encounterSourceLoaded = useHasSourceLoaded(ENCOUNTER_EVENTS_SOURCE_ID)
+  const mapLoaded = useMapLoaded()
+  const encounterSourceLoaded = useHaveSourcesLoaded(ENCOUNTER_EVENTS_SOURCE_ID)
 
   const getCursor = useCallback(
     (state) => {
@@ -215,10 +215,7 @@ const MapWrapper = (): React.ReactElement | null => {
           <MapInfo center={hoveredEvent} />
         </InteractiveMap>
       )}
-      <MapControls
-        onMouseEnter={resetHoverState}
-        mapLoading={!allSourcesLoaded || layerComposerLoading}
-      />
+      <MapControls onMouseEnter={resetHoverState} mapLoading={!mapLoaded || layerComposerLoading} />
       {legendsTranslated?.map((legend: any) => {
         const legendDomElement = document.getElementById(legend.id as string)
         if (legendDomElement) {

--- a/applications/fishing-map/src/features/map/MapScreenshot.tsx
+++ b/applications/fishing-map/src/features/map/MapScreenshot.tsx
@@ -7,6 +7,7 @@ import type { Map } from '@globalfishingwatch/mapbox-gl'
 import { getCSSVarValue } from 'utils/dom'
 import styles from './Map.module.css'
 import { selectEditing } from './rulers/rulers.slice'
+import { useMapIdle } from './map-features.hooks'
 
 type PrintSize = {
   px: number
@@ -37,6 +38,7 @@ export const getMapImage = (map: Map): Promise<string> => {
 }
 
 function MapScreenshot({ map }: { map?: Map }) {
+  const idle = useMapIdle()
   const [screenshotImage, setScreenshotImage] = useState<string | null>(null)
   const rulersEditing = useSelector(selectEditing)
   const printSize = useRef<{ width: PrintSize; height: PrintSize } | undefined>()
@@ -59,7 +61,7 @@ function MapScreenshot({ map }: { map?: Map }) {
   }, [])
 
   useEffect(() => {
-    const handleIdle = debounce(() => {
+    const onMapIdle = debounce(() => {
       if (map) {
         getMapImage(map).then((image) => {
           setScreenshotImage(image)
@@ -67,16 +69,10 @@ function MapScreenshot({ map }: { map?: Map }) {
       }
     }, 800)
 
-    if (map && !rulersEditing) {
-      map.on('idle', handleIdle)
+    if (map && idle && !rulersEditing) {
+      onMapIdle()
     }
-    return () => {
-      if (map) {
-        map.off('idle', handleIdle)
-      }
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [map, rulersEditing])
+  }, [map, idle, rulersEditing])
 
   if (!screenshotImage) return null
 

--- a/applications/fishing-map/src/features/map/map-features.hooks.ts
+++ b/applications/fishing-map/src/features/map/map-features.hooks.ts
@@ -11,69 +11,6 @@ import {
   selectGeneratorConfigsById,
 } from './map.selectors'
 
-// const sourcesLoadingState = atom<{ [key: string]: boolean }>({
-//   key: 'sourcesState',
-//   default: {},
-// })
-
-// let listenerAttached = false
-// export const useSourcesLoadingState = () => {
-//   const [sourcesState, setSourcesState] = useRecoilState(sourcesLoadingState)
-//   const map = useMapInstance()
-//   const idledAttached = useRef<boolean>(true)
-//   useEffect(() => {
-//     if (!map || listenerAttached) return
-//     const sourceEventCallback = (e: any) => {
-//       const currentSources = map.getStyle().sources || {}
-//       const sourcesLoaded = Object.entries(currentSources)
-//         .map(([sourceId, source]) => {
-//           // Ignore geojson sources that already have their data included in the style
-//           if (source.type === 'geojson' && !(typeof source?.data === 'string')) {
-//             return []
-//           }
-//           return [sourceId, map.isSourceLoaded(sourceId)]
-//         })
-//         .filter((entry) => entry.length)
-
-//       const allSourcesLoaded = sourcesLoaded.every(([id, loaded]) => loaded)
-//       if (allSourcesLoaded && e.type === 'idle') {
-//         map.off('idle', sourceEventCallback)
-//         idledAttached.current = false
-//       } else if (!idledAttached.current) {
-//         map.on('idle', sourceEventCallback)
-//         idledAttached.current = true
-//       }
-//       setSourcesState(Object.fromEntries(sourcesLoaded))
-//     }
-//     if (map && !listenerAttached) {
-//       map.on('sourcedata', sourceEventCallback)
-//       map.on('sourcedataloading', sourceEventCallback)
-//       map.on('idle', sourceEventCallback)
-//       map.on('error', sourceEventCallback)
-
-//       // TODO: improve this workaroud to avoid attaching listeners on every hook instance
-//       listenerAttached = true
-//     }
-//     const detachListeners = () => {
-//       map.off('sourcedata', sourceEventCallback)
-//       map.off('sourcedataloading', sourceEventCallback)
-//       map.off('idle', sourceEventCallback)
-//       map.off('error', sourceEventCallback)
-//     }
-
-//     return detachListeners
-//   }, [map, setSourcesState])
-
-//   const serializedSourcesState = Object.entries(sourcesState)
-//     .map((s) => s.join('_'))
-//     .join('__')
-
-//   return useMemo(() => {
-//     return sourcesState
-//     // eslint-disable-next-line react-hooks/exhaustive-deps
-//   }, [serializedSourcesState])
-// }
-
 export const mapIdleAtom = atom<boolean>({
   key: 'mapIdle',
   default: false,

--- a/applications/fishing-map/src/features/map/map.hooks.ts
+++ b/applications/fishing-map/src/features/map/map.hooks.ts
@@ -41,7 +41,7 @@ import {
   ExtendedFeatureEvent,
 } from './map.slice'
 import useViewport from './map-viewport.hooks'
-import { useHasSourceLoaded, useHaveAllSourcesLoaded } from './map-features.hooks'
+import { useHaveSourcesLoaded, useMapLoaded } from './map-features.hooks'
 
 // This is a convenience hook that returns at the same time the portions of the store we interested in
 // as well as the functions we need to update the same portions
@@ -62,7 +62,7 @@ export const useClickedEventConnect = () => {
   const { dispatchLocation } = useLocationConnect()
   const { cleanFeatureState } = useFeatureState(map)
   const { setMapCoordinates } = useViewport()
-  const encounterSourceLoaded = useHasSourceLoaded(ENCOUNTER_EVENTS_SOURCE_ID)
+  const encounterSourceLoaded = useHaveSourcesLoaded(ENCOUNTER_EVENTS_SOURCE_ID)
   const fourWingsPromiseRef = useRef<any>()
   const eventsPromiseRef = useRef<any>()
 
@@ -210,7 +210,7 @@ export const useMapTooltip = (event?: SliceInteractionEvent | null) => {
         return []
       }
 
-      dataview = temporalgridDataviews?.find(dataview => dataview.id === temporalgrid.sublayerId)
+      dataview = temporalgridDataviews?.find((dataview) => dataview.id === temporalgrid.sublayerId)
     } else {
       dataview = dataviews?.find((dataview) => {
         // Needed to get only the initial part to support multiple generator
@@ -298,7 +298,7 @@ export const useMapStyle = () => {
 
   // Used to ensure the style is refreshed on load finish
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const haveAllSourcesLoaded = useHaveAllSourcesLoaded()
+  const mapLoaded = useMapLoaded()
 
   if (!map) return null
 


### PR DESCRIPTION
Using multiple checks 
```
mapInstanceReady && mapFirstLoad && (idle || areTilesLoaded || mapStyleLoad
```
to ensure the map is loaded instead of checking by source because the source events are not reliable enough and we have a lot of errors with the timebar and the analysis