### PR TITLE
Breaks review

### DIFF
--- a/.changeset/strange-carrots-fetch.md
+++ b/.changeset/strange-carrots-fetch.md
@@ -1,0 +1,5 @@
+---
+"@globalfishingwatch/layer-composer": patch
+---
+
+Breaks fixes

--- a/applications/fishing-map/src/features/app/ErrorBoundary.tsx
+++ b/applications/fishing-map/src/features/app/ErrorBoundary.tsx
@@ -4,8 +4,8 @@ import { Button } from '@globalfishingwatch/ui-components'
 import styles from './ErrorBoundary.module.css'
 
 class ErrorBoundary extends Component<any, { error: Error | null }> {
-  constructor() {
-    super({})
+  constructor(props: any) {
+    super(props)
     this.state = { error: null }
   }
 

--- a/packages/layer-composer/src/generators/heatmap/heatmap-animated.ts
+++ b/packages/layer-composer/src/generators/heatmap/heatmap-animated.ts
@@ -221,7 +221,6 @@ class HeatmapAnimatedGenerator {
       ? config.sublayers.map(({ breaks }) => breaks || [])
       : getSublayersBreaks(finalConfig, this.breaksCache[cacheKey]?.breaks)
     const legends = getLegends(finalConfig, breaks || [])
-
     const style = {
       id: finalConfig.id,
       sources: this._getStyleSources(finalConfig, timeChunks, breaks),

--- a/packages/layer-composer/src/generators/heatmap/util/fetch-breaks.ts
+++ b/packages/layer-composer/src/generators/heatmap/util/fetch-breaks.ts
@@ -1,5 +1,4 @@
 import 'abortcontroller-polyfill/dist/abortcontroller-polyfill-only'
-import uniq from 'lodash/uniq'
 import { API_GATEWAY, API_GATEWAY_VERSION } from '../../../layer-composer'
 import { API_ENDPOINTS } from '../config'
 import { GlobalHeatmapAnimatedGeneratorConfig } from '../heatmap-animated'
@@ -31,11 +30,9 @@ const getBreaksBaseUrl = (config: FetchBreaksParams): string => {
 }
 
 const getDatasets = (config: FetchBreaksParams): string[] => {
-  const datasets = uniq(
-    config.sublayers
-      .filter((sublayer) => sublayer.visible)
-      .flatMap((s) => s.datasets.flatMap((d) => d))
-  )
+  const datasets = config.sublayers
+    .filter((sublayer) => sublayer.visible)
+    .flatMap((s) => s.datasets.flatMap((d) => d))
   return datasets
 }
 


### PR DESCRIPTION
- [x] Fetch all dataset breaks
- [x] Use breaks hardcoded as fallback for apis errors
- [x] Fix when bivariate first load and back to compare undefined ramps