### PR TITLE
Fishing map/refacto cleanup of staticTime

### DIFF
--- a/applications/fishing-map/src/features/analysis/Analysis.tsx
+++ b/applications/fishing-map/src/features/analysis/Analysis.tsx
@@ -12,7 +12,6 @@ import { useFeatureState } from '@globalfishingwatch/react-hooks/dist/use-map-in
 import { DEFAULT_CONTEXT_SOURCE_LAYER } from '@globalfishingwatch/layer-composer/dist/generators'
 import { useLocationConnect } from 'routes/routes.hook'
 import sectionStyles from 'features/workspace/shared/Sections.module.css'
-import { selectStaticTime } from 'features/timebar/timebar.slice'
 import { selectWorkspaceStatus } from 'features/workspace/workspace.selectors'
 import { selectUserData } from 'features/user/user.slice'
 import { AsyncReducerStatus } from 'utils/async-slice'
@@ -56,7 +55,7 @@ function Analysis() {
   const timeoutRef = useRef<NodeJS.Timeout>()
   const { dispatchQueryParams } = useLocationConnect()
   const { updateFeatureState, cleanFeatureState } = useFeatureState(useMapInstance())
-  const staticTime = useSelector(selectStaticTime)
+  const { timerange } = useTimerangeConnect()
   const dataviews = useSelector(selectActiveActivityDataviews) || []
   const analysisGeometry = useSelector(selectAnalysisGeometry)
   const analysisBounds = useSelector(selectAnalysisBounds)
@@ -176,7 +175,7 @@ function Analysis() {
     const reportName = Array.from(new Set(dataviews.map((dataview) => dataview.name))).join(',')
     const createReport: CreateReport = {
       name: `${reportName} - ${t('common.report', 'Report')}`,
-      dateRange: staticTime as DateRange,
+      dateRange: timerange as DateRange,
       dataviews: reportDataviews,
       geometry: analysisGeometry as ReportGeometry,
     }

--- a/applications/fishing-map/src/features/analysis/AnalysisItem.tsx
+++ b/applications/fishing-map/src/features/analysis/AnalysisItem.tsx
@@ -7,7 +7,7 @@ import { getFlagsByIds } from 'utils/flags'
 import { t } from 'features/i18n/i18n'
 import { formatI18nDate } from 'features/i18n/i18nDate'
 import { isFishingDataview, isPresenceDataview } from 'features/workspace/heatmaps/heatmaps.utils'
-import { selectStaticTime } from 'features/timebar/timebar.slice'
+import { useTimerangeConnect } from 'features/timebar/timebar.hooks'
 import AnalysisLayerPanel from './AnalysisLayerPanel'
 import AnalysisItemGraph, { AnalysisGraphProps } from './AnalysisItemGraph'
 import styles from './AnalysisItem.module.css'
@@ -85,7 +85,7 @@ function AnalysisItem({
   analysisAreaName: string
 }) {
   const { t } = useTranslation()
-  const staticTime = useSelector(selectStaticTime)
+  const { start, end } = useTimerangeConnect()
   const dataviewsIds = useMemo(() => {
     return graphData.sublayers.map((s) => s.id)
   }, [graphData])
@@ -97,10 +97,10 @@ function AnalysisItem({
   let description = analysisAreaName
     ? `${title} ${t('common.in', 'in')} ${analysisAreaName}`
     : title
-  if (staticTime) {
+  if (start && end) {
     description = `${description} ${t('common.dateRange', {
-      start: formatI18nDate(staticTime.start),
-      end: formatI18nDate(staticTime.end),
+      start: formatI18nDate(start),
+      end: formatI18nDate(end),
       defaultValue: 'between {{start}} and {{end}}',
     })}.`
   }
@@ -125,7 +125,7 @@ function AnalysisItem({
           {t('analysis.empty', 'Your selected datasets will appear here')}
         </p>
       )}
-      {staticTime && <AnalysisItemGraph graphData={graphData} timeRange={staticTime} />}
+      {start && end && <AnalysisItemGraph graphData={graphData} start={start} end={end} />}
     </div>
   )
 }

--- a/applications/fishing-map/src/features/analysis/AnalysisItemGraph.tsx
+++ b/applications/fishing-map/src/features/analysis/AnalysisItemGraph.tsx
@@ -135,10 +135,10 @@ const AnalysisGraphTooltip = (props: any) => {
   return null
 }
 
-const AnalysisItemGraph: React.FC<{ graphData: AnalysisGraphProps; timeRange: Range }> = (
+const AnalysisItemGraph: React.FC<{ graphData: AnalysisGraphProps; start: string; end: string }> = (
   props
 ) => {
-  const { start, end } = props.timeRange
+  const { start, end } = props
   const { timeseries, interval = '10days', sublayers } = props.graphData
 
   const dataFormated = useMemo(() => {

--- a/applications/fishing-map/src/features/analysis/AnalysisItemGraph.tsx
+++ b/applications/fishing-map/src/features/analysis/AnalysisItemGraph.tsx
@@ -16,7 +16,6 @@ import { DateTime } from 'luxon'
 import { Interval } from '@globalfishingwatch/layer-composer/dist/generators/heatmap/util/time-chunks'
 import { formatI18nNumber } from 'features/i18n/i18nNumber'
 import i18n from 'features/i18n/i18n'
-import { Range } from 'features/timebar/timebar.slice'
 import { toFixed } from 'utils/shared'
 import styles from './AnalysisGraph.module.css'
 

--- a/applications/fishing-map/src/features/app/app.selectors.ts
+++ b/applications/fishing-map/src/features/app/app.selectors.ts
@@ -4,13 +4,11 @@ import { APP_NAME, DEFAULT_WORKSPACE } from 'data/config'
 import {
   selectWorkspace,
   selectWorkspaceState,
-  selectWorkspaceTimeRange,
   selectWorkspaceViewport,
 } from 'features/workspace/workspace.selectors'
 import {
   selectQueryParam,
   selectUrlViewport,
-  selectUrlTimeRange,
   selectLocationCategory,
   selectActivityCategory,
 } from 'routes/routes.selectors'
@@ -36,16 +34,6 @@ export const selectViewport = createSelector(
       latitude: urlViewport?.latitude || workspaceViewport?.latitude || DEFAULT_WORKSPACE.latitude,
       longitude:
         urlViewport?.longitude || workspaceViewport?.longitude || DEFAULT_WORKSPACE.longitude,
-    }
-  }
-)
-
-export const selectTimeRange = createSelector(
-  [selectUrlTimeRange, selectWorkspaceTimeRange],
-  ({ start, end }, workspaceTimerange) => {
-    return {
-      start: start || workspaceTimerange?.start,
-      end: end || workspaceTimerange?.end,
     }
   }
 )
@@ -140,19 +128,11 @@ export const selectCustomWorkspace = createSelector(
   [
     selectWorkspace,
     selectViewport,
-    selectTimeRange,
     selectLocationCategory,
     selectWorkspaceAppState,
     selectDataviewInstancesMerged,
   ],
-  (
-    workspace,
-    viewport,
-    timerange,
-    category,
-    state,
-    dataviewInstances
-  ): WorkspaceUpsert<WorkspaceState> => {
+  (workspace, viewport, category, state, dataviewInstances): WorkspaceUpsert<WorkspaceState> => {
     return {
       ...workspace,
       app: APP_NAME,
@@ -161,8 +141,6 @@ export const selectCustomWorkspace = createSelector(
       aoi: undefined,
       dataviews: workspace?.dataviews?.map(({ id }) => id as number),
       viewport,
-      startAt: timerange.start,
-      endAt: timerange.end,
       state,
       dataviewInstances: dataviewInstances as DataviewInstance<any>[],
     }

--- a/applications/fishing-map/src/features/app/app.selectors.ts
+++ b/applications/fishing-map/src/features/app/app.selectors.ts
@@ -4,13 +4,16 @@ import { APP_NAME, DEFAULT_WORKSPACE } from 'data/config'
 import {
   selectWorkspace,
   selectWorkspaceState,
+  selectWorkspaceTimeRange,
   selectWorkspaceViewport,
 } from 'features/workspace/workspace.selectors'
+import { Range } from 'features/timebar/timebar.slice'
 import {
   selectQueryParam,
   selectUrlViewport,
   selectLocationCategory,
   selectActivityCategory,
+  selectUrlTimeRange,
 } from 'routes/routes.selectors'
 import {
   BivariateDataviews,
@@ -35,6 +38,16 @@ export const selectViewport = createSelector(
       longitude:
         urlViewport?.longitude || workspaceViewport?.longitude || DEFAULT_WORKSPACE.longitude,
     }
+  }
+)
+
+export const selectTimeRange = createSelector(
+  [selectUrlTimeRange, selectWorkspaceTimeRange],
+  ({ start, end }, workspaceTimerange) => {
+    return {
+      start: start || workspaceTimerange?.start,
+      end: end || workspaceTimerange?.end,
+    } as Range
   }
 )
 
@@ -128,11 +141,19 @@ export const selectCustomWorkspace = createSelector(
   [
     selectWorkspace,
     selectViewport,
+    selectTimeRange,
     selectLocationCategory,
     selectWorkspaceAppState,
     selectDataviewInstancesMerged,
   ],
-  (workspace, viewport, category, state, dataviewInstances): WorkspaceUpsert<WorkspaceState> => {
+  (
+    workspace,
+    viewport,
+    timerange,
+    category,
+    state,
+    dataviewInstances
+  ): WorkspaceUpsert<WorkspaceState> => {
     return {
       ...workspace,
       app: APP_NAME,
@@ -141,6 +162,8 @@ export const selectCustomWorkspace = createSelector(
       aoi: undefined,
       dataviews: workspace?.dataviews?.map(({ id }) => id as number),
       viewport,
+      startAt: timerange.start,
+      endAt: timerange.end,
       state,
       dataviewInstances: dataviewInstances as DataviewInstance<any>[],
     }

--- a/applications/fishing-map/src/features/map/map.hooks.ts
+++ b/applications/fishing-map/src/features/map/map.hooks.ts
@@ -1,6 +1,6 @@
 import { useSelector, useDispatch } from 'react-redux'
 import { Geometry } from 'geojson'
-import { useRef } from 'react'
+import { useMemo, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
 import { InteractionEvent } from '@globalfishingwatch/react-hooks'
 import { Generators } from '@globalfishingwatch/layer-composer'
@@ -12,6 +12,7 @@ import { ContextLayerType, Type } from '@globalfishingwatch/layer-composer/dist/
 import type { Style } from '@globalfishingwatch/mapbox-gl'
 import { DataviewCategory } from '@globalfishingwatch/api-types/dist'
 import { useFeatureState } from '@globalfishingwatch/react-hooks/dist/use-map-interaction'
+import GFWAPI from '@globalfishingwatch/api-client'
 import { ENCOUNTER_EVENTS_SOURCE_ID } from 'features/dataviews/dataviews.utils'
 import { selectLocationType } from 'routes/routes.selectors'
 import { HOME, USER, WORKSPACE, WORKSPACES_LIST } from 'routes/routes'
@@ -22,9 +23,9 @@ import {
   selectActivityDataviews,
   selectDataviewInstancesResolved,
 } from 'features/dataviews/dataviews.selectors'
+import { useTimerangeConnect } from 'features/timebar/timebar.hooks'
 import {
   selectDefaultMapGeneratorsConfig,
-  selectGlobalGeneratorsConfig,
   WORKSPACES_POINTS_TYPE,
   WORKSPACE_GENERATOR_ID,
 } from './map.selectors'
@@ -46,10 +47,21 @@ import { useHasSourceLoaded, useHaveAllSourcesLoaded } from './map-features.hook
 // This is a convenience hook that returns at the same time the portions of the store we interested in
 // as well as the functions we need to update the same portions
 export const useGeneratorsConnect = () => {
-  return {
-    generatorsConfig: useSelector(selectDefaultMapGeneratorsConfig),
-    globalConfig: useSelector(selectGlobalGeneratorsConfig),
-  }
+  const { start, end } = useTimerangeConnect()
+  const { viewport } = useViewport()
+  const generatorsConfig = useSelector(selectDefaultMapGeneratorsConfig)
+
+  return useMemo(() => {
+    return {
+      generatorsConfig,
+      globalConfig: {
+        zoom: viewport.zoom,
+        start,
+        end,
+        token: GFWAPI.getToken(),
+      },
+    }
+  }, [generatorsConfig, viewport.zoom, start, end])
 }
 
 export const useClickedEventConnect = () => {
@@ -210,7 +222,7 @@ export const useMapTooltip = (event?: SliceInteractionEvent | null) => {
         return []
       }
 
-      dataview = temporalgridDataviews?.find(dataview => dataview.id === temporalgrid.sublayerId)
+      dataview = temporalgridDataviews?.find((dataview) => dataview.id === temporalgrid.sublayerId)
     } else {
       dataview = dataviews?.find((dataview) => {
         // Needed to get only the initial part to support multiple generator

--- a/applications/fishing-map/src/features/map/map.selectors.ts
+++ b/applications/fishing-map/src/features/map/map.selectors.ts
@@ -1,6 +1,5 @@
 import { createSelector } from '@reduxjs/toolkit'
 import type { CircleLayer } from '@globalfishingwatch/mapbox-gl'
-import GFWAPI from '@globalfishingwatch/api-client'
 import { AnyGeneratorConfig } from '@globalfishingwatch/layer-composer/dist/generators/types'
 import { Generators } from '@globalfishingwatch/layer-composer'
 import {
@@ -17,27 +16,12 @@ import { selectCurrentWorkspacesList } from 'features/workspaces-list/workspaces
 import { selectResources, ResourcesState } from 'features/resources/resources.slice'
 import { DebugOptions, selectDebugOptions } from 'features/debug/debug.slice'
 import { selectRulers } from 'features/map/rulers/rulers.slice'
-import { selectHighlightedTime, selectStaticTime, Range } from 'features/timebar/timebar.slice'
-import {
-  selectViewport,
-  selectTimeRange,
-  selectBivariateDataviews,
-} from 'features/app/app.selectors'
+import { selectHighlightedTime, Range } from 'features/timebar/timebar.slice'
+import { selectBivariateDataviews } from 'features/app/app.selectors'
 import { isWorkspaceLocation } from 'routes/routes.selectors'
 import { WorkspaceCategories } from 'data/workspaces'
 import { AsyncReducerStatus } from 'utils/async-slice'
-import { DEFAULT_TIME_RANGE } from 'data/config'
 import { BivariateDataviews } from 'types'
-
-export const selectGlobalGeneratorsConfig = createSelector(
-  [selectViewport, selectTimeRange],
-  ({ zoom }, { start, end }) => ({
-    zoom,
-    start: start || DEFAULT_TIME_RANGE.start,
-    end: end || DEFAULT_TIME_RANGE.end,
-    token: GFWAPI.getToken(),
-  })
-)
 
 type GetGeneratorConfigParams = {
   dataviews: UrlDataviewInstance[] | undefined
@@ -45,7 +29,6 @@ type GetGeneratorConfigParams = {
   rulers: Generators.Ruler[]
   debugOptions: DebugOptions
   highlightedTime?: Range
-  staticTime: Range
   bivariateDataviews?: BivariateDataviews
 }
 const getGeneratorsConfig = ({
@@ -54,7 +37,6 @@ const getGeneratorsConfig = ({
   rulers,
   debugOptions,
   highlightedTime,
-  staticTime,
   bivariateDataviews,
 }: GetGeneratorConfigParams) => {
   const animatedHeatmapDataviews = dataviews.filter((dataview) => {
@@ -79,7 +61,6 @@ const getGeneratorsConfig = ({
   const generatorOptions = {
     heatmapAnimatedMode,
     highlightedTime,
-    timeRange: staticTime,
     debug: debugOptions.debug,
     mergedActivityGeneratorId: MERGED_ACTIVITY_ANIMATED_HEATMAP_GENERATOR_ID,
   }
@@ -106,26 +87,15 @@ const selectMapGeneratorsConfig = createSelector(
     selectRulers,
     selectDebugOptions,
     selectHighlightedTime,
-    selectStaticTime,
     selectBivariateDataviews,
   ],
-  (
-    dataviews = [],
-    resources,
-    rulers,
-    debugOptions,
-    highlightedTime,
-    staticTime,
-    bivariateDataviews
-  ) => {
-    if (!staticTime) return
+  (dataviews = [], resources, rulers, debugOptions, highlightedTime, bivariateDataviews) => {
     const generators = getGeneratorsConfig({
       dataviews,
       resources,
       rulers,
       debugOptions,
       highlightedTime,
-      staticTime,
       bivariateDataviews,
     })
     return generators
@@ -138,18 +108,15 @@ const selectStaticGeneratorsConfig = createSelector(
     selectResources,
     selectRulers,
     selectDebugOptions,
-    selectStaticTime,
     selectBivariateDataviews,
   ],
-  (dataviews = [], resources, rulers, debugOptions, staticTime, bivariateDataviews) => {
-    if (!staticTime) return
+  (dataviews = [], resources, rulers, debugOptions, bivariateDataviews) => {
     // We don't want highlightedTime here to avoid re-computing on mouse timebar hovering
     return getGeneratorsConfig({
       dataviews,
       resources,
       rulers,
       debugOptions,
-      staticTime,
       bivariateDataviews,
     })
   }

--- a/applications/fishing-map/src/features/map/map.slice.ts
+++ b/applications/fishing-map/src/features/map/map.slice.ts
@@ -22,7 +22,7 @@ import {
   selectActivityDataviews,
 } from 'features/dataviews/dataviews.selectors'
 import { fetchDatasetByIdThunk, selectDatasetById } from 'features/datasets/datasets.slice'
-import { selectTimeRange } from 'features/app/app.selectors'
+import { useTimerangeConnect } from 'features/timebar/timebar.hooks'
 
 export const MAX_TOOLTIP_VESSELS = 5
 
@@ -100,11 +100,15 @@ export const fetch4WingInteractionThunk = createAsyncThunk<
   async (temporalGridFeatures: ExtendedFeature[], { getState, signal, dispatch }) => {
     const state = getState() as RootState
     const temporalgridDataviews = selectActivityDataviews(state) || []
-    const { start, end } = selectTimeRange(state)
+    const { start, end } = useTimerangeConnect()
 
     // get corresponding dataviews
     const featuresDataviews = temporalGridFeatures.flatMap((feature) => {
-      return feature.temporalgrid ? temporalgridDataviews.find(dataview => dataview.id === feature?.temporalgrid?.sublayerId) || [] : []
+      return feature.temporalgrid
+        ? temporalgridDataviews.find(
+            (dataview) => dataview.id === feature?.temporalgrid?.sublayerId
+          ) || []
+        : []
     })
 
     const fourWingsDataset = featuresDataviews[0].datasets?.find(
@@ -345,8 +349,7 @@ const slice = createSlice({
       action.payload.vessels.forEach((sublayerVessels) => {
         const sublayer = state.clicked?.features?.find(
           (feature) =>
-            feature.temporalgrid &&
-            feature.temporalgrid.sublayerId === sublayerVessels.sublayerId
+            feature.temporalgrid && feature.temporalgrid.sublayerId === sublayerVessels.sublayerId
         )
         if (!sublayer) return
         sublayer.vessels = sublayerVessels.vessels

--- a/applications/fishing-map/src/features/map/popups/TileClusterLayers.tsx
+++ b/applications/fishing-map/src/features/map/popups/TileClusterLayers.tsx
@@ -1,5 +1,4 @@
 import React, { Fragment, useEffect } from 'react'
-import { useSelector } from 'react-redux'
 import { useTranslation } from 'react-i18next'
 import { stringify } from 'qs'
 import Spinner from '@globalfishingwatch/ui-components/dist/spinner'
@@ -10,12 +9,12 @@ import { TooltipEventFeature, useClickedEventConnect } from 'features/map/map.ho
 import { AsyncReducerStatus } from 'utils/async-slice'
 import I18nDate from 'features/i18n/i18nDate'
 import { getVesselDataviewInstance } from 'features/dataviews/dataviews.utils'
-import { selectTimeRange } from 'features/app/app.selectors'
 import { formatInfoField } from 'utils/info'
 import { useDataviewInstancesConnect } from 'features/workspace/workspace.hook'
 import { getRelatedDatasetByType } from 'features/datasets/datasets.selectors'
 import { CARRIER_PORTAL_URL } from 'data/config'
 import { useCarrierLatestConnect } from 'features/datasets/datasets.hook'
+import { useTimerangeConnect } from 'features/timebar/timebar.hooks'
 import useViewport from '../map-viewport.hooks'
 import styles from './Popup.module.css'
 
@@ -27,7 +26,7 @@ function TileClusterTooltipRow({ features }: UserContextLayersProps) {
   const { t } = useTranslation()
   const { upsertDataviewInstance } = useDataviewInstancesConnect()
   const { apiEventStatus } = useClickedEventConnect()
-  const { start, end } = useSelector(selectTimeRange)
+  const { start, end } = useTimerangeConnect()
   const { viewport } = useViewport()
   const { carrierLatest, carrierLatestStatus, dispatchFetchLatestCarrier } =
     useCarrierLatestConnect()

--- a/applications/fishing-map/src/features/sidebar/SidebarHeader.tsx
+++ b/applications/fishing-map/src/features/sidebar/SidebarHeader.tsx
@@ -21,9 +21,10 @@ import { DEFAULT_WORKSPACE_ID, WorkspaceCategories } from 'data/workspaces'
 import { useAppDispatch } from 'features/app/app.hooks'
 import { pickDateFormatByRange } from 'features/map/controls/MapInfo'
 import { formatI18nDate } from 'features/i18n/i18nDate'
-import { selectTimeRange, selectViewport } from 'features/app/app.selectors'
+import { selectViewport } from 'features/app/app.selectors'
 import { selectUserData } from 'features/user/user.slice'
 import { isGuestUser } from 'features/user/user.selectors'
+import { useTimerangeConnect } from 'features/timebar/timebar.hooks'
 import styles from './SidebarHeader.module.css'
 import { useClipboardNotification } from './sidebar.hooks'
 
@@ -33,7 +34,7 @@ function SaveWorkspaceButton() {
   const dispatch = useAppDispatch()
   const guestUser = useSelector(isGuestUser)
   const viewport = useSelector(selectViewport)
-  const timerange = useSelector(selectTimeRange)
+  const timerange = useTimerangeConnect()
   const userData = useSelector(selectUserData)
   const workspaceStatus = useSelector(selectWorkspaceStatus)
   const workspaceCustomStatus = useSelector(selectWorkspaceCustomStatus)

--- a/applications/fishing-map/src/features/timebar/Timebar.tsx
+++ b/applications/fishing-map/src/features/timebar/Timebar.tsx
@@ -39,7 +39,6 @@ export const TIMEBAR_HEIGHT = 72
 const TimebarWrapper = () => {
   const { ready, i18n } = useTranslation()
   const labels = ready ? (i18n?.getDataByLanguage(i18n.language) as any)?.timebar : undefined
-  // const { start, end, dispatchTimeranges } = useTimerangeConnect()
   const { start, end, onTimebarChange } = useTimerangeConnect()
   const highlightedTime = useSelector(selectHighlightedTime)
   const { timebarVisualisation } = useTimebarVisualisation()

--- a/applications/fishing-map/src/features/timebar/Timebar.tsx
+++ b/applications/fishing-map/src/features/timebar/Timebar.tsx
@@ -24,7 +24,12 @@ import { useMapBounds } from 'features/map/map-viewport.hooks'
 import { filterByViewport } from 'features/map/map.utils'
 import { useActivityTemporalgridFeatures } from 'features/map/map-features.hooks'
 import { selectActivityCategory } from 'routes/routes.selectors'
-import { setHighlightedTime, disableHighlightedTime, selectHighlightedTime } from './timebar.slice'
+import {
+  setHighlightedTime,
+  disableHighlightedTime,
+  selectHighlightedTime,
+  Range,
+} from './timebar.slice'
 import TimebarSettings from './TimebarSettings'
 import { selectTracksData, selectTracksGraphs } from './timebar.selectors'
 import styles from './Timebar.module.css'
@@ -129,30 +134,46 @@ const TimebarWrapper = () => {
 
   const activityCategory = useSelector(selectActivityCategory)
 
-  if (!start || !end) return null
-
-  const onMouseMove = (clientX: number, scale: (arg: number) => Date) => {
-    if (clientX === null) {
-      if (highlightedTime !== undefined) {
-        dispatch(disableHighlightedTime())
+  const onMouseMove = useCallback(
+    (clientX: number, scale: (arg: number) => Date) => {
+      if (clientX === null) {
+        if (highlightedTime !== undefined) {
+          dispatch(disableHighlightedTime())
+        }
+      } else {
+        const start = scale(clientX - 10).toISOString()
+        const end = scale(clientX + 10).toISOString()
+        dispatch(setHighlightedTime({ start, end }))
       }
-    } else {
-      const start = scale(clientX - 10).toISOString()
-      const end = scale(clientX + 10).toISOString()
-      dispatch(setHighlightedTime({ start, end }))
-    }
-  }
+    },
+    [dispatch, highlightedTime]
+  )
+
+  const [internalRange, setInternalRange] = useState<Range | null>(null)
+  const onChange = useCallback(
+    (e) => {
+      if (e.source === 'ZOOM_OUT_MOVE') {
+        setInternalRange({ ...e })
+        return
+      }
+      setInternalRange(null)
+      onTimebarChange(e.start, e.end)
+    },
+    [setInternalRange, onTimebarChange]
+  )
+
+  if (!start || !end) return null
 
   return (
     <div>
       <TimebarComponent
         enablePlayback={true}
         labels={labels}
-        start={start}
-        end={end}
+        start={internalRange ? internalRange.start : start}
+        end={internalRange ? internalRange.end : end}
         absoluteStart={DEFAULT_WORKSPACE.availableStart}
         absoluteEnd={DEFAULT_WORKSPACE.availableEnd}
-        onChange={onTimebarChange}
+        onChange={onChange}
         showLastUpdate={false}
         onMouseMove={onMouseMove}
         onBookmarkChange={onBookmarkChange}

--- a/applications/fishing-map/src/features/timebar/Timebar.tsx
+++ b/applications/fishing-map/src/features/timebar/Timebar.tsx
@@ -34,7 +34,8 @@ export const TIMEBAR_HEIGHT = 72
 const TimebarWrapper = () => {
   const { ready, i18n } = useTranslation()
   const labels = ready ? (i18n?.getDataByLanguage(i18n.language) as any)?.timebar : undefined
-  const { start, end, dispatchTimeranges } = useTimerangeConnect()
+  // const { start, end, dispatchTimeranges } = useTimerangeConnect()
+  const { start, end, onTimebarChange } = useTimerangeConnect()
   const highlightedTime = useSelector(selectHighlightedTime)
   const { timebarVisualisation } = useTimebarVisualisation()
   const timebarGraph = useSelector(selectTimebarGraph)
@@ -151,7 +152,7 @@ const TimebarWrapper = () => {
         end={end}
         absoluteStart={DEFAULT_WORKSPACE.availableStart}
         absoluteEnd={DEFAULT_WORKSPACE.availableEnd}
-        onChange={dispatchTimeranges}
+        onChange={onTimebarChange}
         showLastUpdate={false}
         onMouseMove={onMouseMove}
         onBookmarkChange={onBookmarkChange}

--- a/applications/fishing-map/src/features/timebar/timebar.hooks.ts
+++ b/applications/fishing-map/src/features/timebar/timebar.hooks.ts
@@ -2,9 +2,8 @@ import { useDispatch, useSelector } from 'react-redux'
 import { useCallback, useEffect, useMemo } from 'react'
 import { atom, useRecoilState } from 'recoil'
 import { debounce } from 'lodash'
-import { createSelector } from 'reselect'
 import { TimebarVisualisations } from 'types'
-import { selectTimebarVisualisation } from 'features/app/app.selectors'
+import { selectTimeRange, selectTimebarVisualisation } from 'features/app/app.selectors'
 import { useLocationConnect } from 'routes/routes.hook'
 import {
   selectActiveActivityDataviews,
@@ -12,19 +11,7 @@ import {
 } from 'features/dataviews/dataviews.selectors'
 import { DEFAULT_TIME_RANGE } from 'data/config'
 import store, { RootState } from 'store'
-import { selectUrlTimeRange } from 'routes/routes.selectors'
-import { selectWorkspaceTimeRange } from 'features/workspace/workspace.selectors'
 import { selectHasChangedSettingsOnce, changeSettings, Range } from './timebar.slice'
-
-const selectTimeRange = createSelector(
-  [selectUrlTimeRange, selectWorkspaceTimeRange],
-  ({ start, end }, workspaceTimerange) => {
-    return {
-      start: start || workspaceTimerange?.start || DEFAULT_TIME_RANGE.start,
-      end: end || workspaceTimerange?.end || DEFAULT_TIME_RANGE.end,
-    } as Range
-  }
-)
 
 export const TimeRangeAtom = atom<Range>({
   key: 'timerange',

--- a/applications/fishing-map/src/features/timebar/timebar.slice.ts
+++ b/applications/fishing-map/src/features/timebar/timebar.slice.ts
@@ -28,20 +28,15 @@ const slice = createSlice({
     disableHighlightedTime: (state) => {
       state.highlightedTime = undefined
     },
-    setStaticTime: (state, action: PayloadAction<Range>) => {
-      state.staticTime = action.payload
-    },
     changeSettings: (state) => {
       state.hasChangedSettingsOnce = true
     },
   },
 })
 
-export const { setHighlightedTime, disableHighlightedTime, setStaticTime, changeSettings } =
-  slice.actions
+export const { setHighlightedTime, disableHighlightedTime, changeSettings } = slice.actions
 export default slice.reducer
 
 export const selectHighlightedTime = (state: RootState) => state.timebar.highlightedTime
-export const selectStaticTime = (state: RootState) => state.timebar.staticTime
 export const selectHasChangedSettingsOnce = (state: RootState) =>
   state.timebar.hasChangedSettingsOnce

--- a/applications/fishing-map/src/features/workspace/common/FitBounds.tsx
+++ b/applications/fishing-map/src/features/workspace/common/FitBounds.tsx
@@ -22,7 +22,7 @@ type FitBoundsProps = {
 const FitBounds = ({ className, trackResource, hasError }: FitBoundsProps) => {
   const { t } = useTranslation()
   const fitBounds = useMapFitBounds()
-  const { dispatchTimeranges, start, end } = useTimerangeConnect()
+  const { setTimerange, start, end } = useTimerangeConnect()
   const onFitBoundsClick = useCallback(() => {
     if (trackResource?.data && start && end) {
       const segments = (trackResource.data as FeatureCollection).features
@@ -50,17 +50,16 @@ const FitBounds = ({ className, trackResource, hasError }: FitBoundsProps) => {
               if (pt.timestamp && pt.timestamp > maxTimestamp) maxTimestamp = pt.timestamp
             })
           })
-          dispatchTimeranges({
+          setTimerange({
             start: new Date(minTimestamp).toISOString(),
             end: new Date(maxTimestamp).toISOString(),
-            source: '',
           })
           const fullBBox = segmentsToBbox(segments)
           fitBounds(fullBBox as Bbox)
         }
       }
     }
-  }, [fitBounds, trackResource, start, end, t, dispatchTimeranges])
+  }, [fitBounds, trackResource, start, end, t, setTimerange])
   return (
     <IconButton
       size="small"

--- a/packages/dataviews-client/src/resolve-dataviews-generators.ts
+++ b/packages/dataviews-client/src/resolve-dataviews-generators.ts
@@ -207,8 +207,8 @@ export function getGeneratorConfig(
         ...(extentStart && { datasetsStart: extentStart }),
         ...(extentEnd && { datasetsEnd: extentEnd }),
         // TODO Talk about this
-        // staticStart: timeRange?.start,
-        // staticEnd: timeRange?.end,
+        staticStart: timeRange?.start,
+        staticEnd: timeRange?.end,
       }
       break
     }

--- a/packages/dataviews-client/src/resolve-dataviews-generators.ts
+++ b/packages/dataviews-client/src/resolve-dataviews-generators.ts
@@ -206,9 +206,6 @@ export function getGeneratorConfig(
         // breaksAPI,
         ...(extentStart && { datasetsStart: extentStart }),
         ...(extentEnd && { datasetsEnd: extentEnd }),
-        // TODO Talk about this
-        staticStart: timeRange?.start,
-        staticEnd: timeRange?.end,
       }
       break
     }

--- a/packages/layer-composer/src/generators/heatmap/heatmap-animated.ts
+++ b/packages/layer-composer/src/generators/heatmap/heatmap-animated.ts
@@ -209,8 +209,13 @@ class HeatmapAnimatedGenerator {
       finalConfig.interval
     )
 
-    if (timeChunks.deltaInIntervalUnits === 0 && config.aggregationOperation !== AggregationOperation.Avg) {
-      console.error('Trying to show less than 1 interval worth of data for this heatmap layer. This could result in showing misleading information when aggregation mode is not set to avg.')
+    if (
+      timeChunks.deltaInIntervalUnits === 0 &&
+      config.aggregationOperation !== AggregationOperation.Avg
+    ) {
+      console.error(
+        'Trying to show less than 1 interval worth of data for this heatmap layer. This could result in showing misleading information when aggregation mode is not set to avg.'
+      )
     }
 
     const breaksConfig = {

--- a/packages/layer-composer/src/generators/heatmap/heatmap-animated.ts
+++ b/packages/layer-composer/src/generators/heatmap/heatmap-animated.ts
@@ -202,8 +202,8 @@ class HeatmapAnimatedGenerator {
 
     const timeChunks: TimeChunks = memoizeCache[finalConfig.id].getActiveTimeChunks(
       finalConfig.id,
-      finalConfig.staticStart || finalConfig.start,
-      finalConfig.staticEnd || finalConfig.end,
+      finalConfig.start,
+      finalConfig.end,
       finalConfig.datasetsStart,
       finalConfig.datasetsEnd,
       finalConfig.interval

--- a/packages/layer-composer/src/generators/types.ts
+++ b/packages/layer-composer/src/generators/types.ts
@@ -277,8 +277,6 @@ export interface HeatmapAnimatedGeneratorConfig extends GeneratorConfig {
   datasetsStart?: string
   datasetsEnd?: string
   interactive?: boolean
-  staticStart?: string
-  staticEnd?: string
   /**
    * Defines a fixed or a supported list of intervals in an Array format
    */


### PR DESCRIPTION
- fixes spamming the 4w API when expanding timeline delta
- deprecates use of staticTime in both app and generator and move time to its own atom 