### PR TITLE
Fishing map/more timebar fixes

### DIFF
--- a/.changeset/sixty-buses-smash.md
+++ b/.changeset/sixty-buses-smash.md
@@ -1,0 +1,6 @@
+---
+"@globalfishingwatch/timebar": patch
+"@globalfishingwatchapp/fishing-map": patch
+---
+
+Fishing map/more timebar fixes

--- a/applications/fishing-map/src/features/timebar/TimebarActivityGraph.tsx
+++ b/applications/fishing-map/src/features/timebar/TimebarActivityGraph.tsx
@@ -10,7 +10,7 @@ import {
 } from '@globalfishingwatch/layer-composer/dist/generators/heatmap/util/time-chunks'
 import { getTimeSeries } from '@globalfishingwatch/fourwings-aggregate'
 import { MiniglobeBounds } from '@globalfishingwatch/ui-components/dist/miniglobe'
-import { MapSourceDataEvent } from '@globalfishingwatch/mapbox-gl'
+import { MapboxEvent, MapSourceDataEvent } from '@globalfishingwatch/mapbox-gl'
 import { MERGED_ACTIVITY_ANIMATED_HEATMAP_GENERATOR_ID } from '@globalfishingwatch/dataviews-client'
 import { useMapBounds, mglToMiniGlobeBounds } from 'features/map/map-viewport.hooks'
 import { filterByViewport } from 'features/map/map.utils'
@@ -122,7 +122,14 @@ const TimebarActivityGraph = () => {
       const { isActive } = isEventSourceActiveChunk(e)
       if (isActive) setLoading(true)
     })
-    map.on('idle', () => {
+    map.on('idle', (e: MapboxEvent) => {
+      if (!isNaN(sourcesLoadedTimeout.current)) {
+        window.clearTimeout(sourcesLoadedTimeout.current)
+      }
+      const style = (e.target as any).style.stylesheet
+      const metadata = getMetadata(style)
+
+      computeStackedActivity(metadata, mglToMiniGlobeBounds(map.getBounds()))
       setLoading(false)
     })
   }, [map, computeStackedActivity, isSmallScreen])

--- a/packages/timebar/src/components/playback.js
+++ b/packages/timebar/src/components/playback.js
@@ -40,7 +40,7 @@ class Playback extends Component {
   })
 
   update = (deltaMultiplicatorMs) => {
-    const { onTick, start, end, absoluteStart, absoluteEnd } = this.props
+    const { onTick, start, end, absoluteStart } = this.props
     const { speedStep, loop } = this.state
     const deltaMs = this.getStep(start, end, speedStep) * deltaMultiplicatorMs
 
@@ -52,12 +52,14 @@ class Playback extends Component {
     const newStart = new Date(newStartMs).toISOString()
     const newEnd = new Date(newEndMs).toISOString()
 
+    const playbackAbsoluteEnd = new Date(Date.now()).toISOString()
+
     const { newStartClamped, newEndClamped, clamped } = clampToAbsoluteBoundaries(
       newStart,
       newEnd,
       currentStartEndDeltaMs,
       absoluteStart,
-      absoluteEnd
+      playbackAbsoluteEnd
     )
 
     onTick(newStartClamped, newEndClamped)


### PR DESCRIPTION
- do not allow playback in the future (https://globalfishingwatch.atlassian.net/secure/RapidBoard.jspa?rapidView=9&projectKey=MR&modal=detail&selectedIssue=MR-283)
- skip graph render timeout and render immediately on idle 