### PR TITLE
Fishing map/timebar graph worker

### DIFF
--- a/applications/fishing-map/src/features/analysis/Analysis.module.css
+++ b/applications/fishing-map/src/features/analysis/Analysis.module.css
@@ -81,8 +81,13 @@
   color: var(--color-secondary-blue);
 }
 
-.error {
+.error,
+.experimental {
   color: var(--color-danger-red);
+}
+
+.experimental {
+  margin-left: 0.5rem;
 }
 
 .footer {

--- a/applications/fishing-map/src/features/analysis/Analysis.tsx
+++ b/applications/fishing-map/src/features/analysis/Analysis.tsx
@@ -140,12 +140,22 @@ function Analysis() {
   const layersTimeseriesFiltered = useFilteredTimeSeries()
   const analysisGeometryLoaded = useAnalysisGeometry()
 
+  let downloadTooltip = ''
+  if (timeRangeTooLong) {
+    downloadTooltip = t(
+      'analysis.timeRangeTooLong',
+      'Reports are only allowed for time ranges up to a year'
+    )
+  } else if (!AISInDatasetsReport) {
+    downloadTooltip = t('analysis.onlyAISAllowed', 'Only AIS datasets are allowed to download')
+  }
+
   return (
     <div className={styles.container}>
       <div className={styles.header}>
         <h2 className={styles.sectionTitle}>
           {t('analysis.title', 'Analysis')}
-          <span className={styles.error}>{t('analysis.experimental', 'Experimental')}</span>
+          <span className={styles.experimental}>{t('analysis.experimental', 'Experimental')}</span>
         </h2>
         <div className={cx('print-hidden', sectionStyles.sectionButtons)}>
           <IconButton
@@ -223,16 +233,7 @@ function Analysis() {
                   className={styles.saveBtn}
                   onClick={onDownloadClick}
                   loading={reportStatus === AsyncReducerStatus.LoadingCreate}
-                  tooltip={
-                    timeRangeTooLong
-                      ? t(
-                          'analysis.timeRangeTooLong',
-                          'Reports are only allowed for time ranges up to a year'
-                        )
-                      : AISInDatasetsReport
-                      ? ''
-                      : t('analysis.onlyAISAllowed', 'Only AIS datasets are allowed to download')
-                  }
+                  tooltip={downloadTooltip}
                   tooltipPlacement="top"
                   disabled={
                     timeRangeTooLong ||

--- a/applications/fishing-map/src/features/timebar/TimebarActivityGraph.worker.ts
+++ b/applications/fishing-map/src/features/timebar/TimebarActivityGraph.worker.ts
@@ -1,0 +1,51 @@
+import { MapboxGeoJSONFeature } from "@globalfishingwatch/mapbox-gl"
+import { MiniglobeBounds } from "@globalfishingwatch/ui-components/dist/miniglobe"
+import { getTimeSeries } from '@globalfishingwatch/fourwings-aggregate'
+import { Interval, quantizeOffsetToDate } from '@globalfishingwatch/layer-composer'
+import { filterByViewport } from 'features/map/map.utils'
+
+export const getTimeseries = (
+  allChunksFeatures: { features: MapboxGeoJSONFeature[],
+  quantizeOffset: number }[],
+  bounds: MiniglobeBounds,
+  numSublayers: number,
+  interval: Interval,
+  visibleSublayers: boolean[]
+) => {
+  let prevMaxFrame: number
+  const allChunksValues = allChunksFeatures.flatMap((chunk: { features: MapboxGeoJSONFeature[], quantizeOffset: number }) => {
+    const chunkQuantizeOffset = chunk.quantizeOffset
+    const filteredFeatures = filterByViewport(chunk.features, bounds)
+    if (filteredFeatures?.length > 0) {
+      const { values, maxFrame } = getTimeSeries(
+        filteredFeatures as any,
+        numSublayers,
+        chunkQuantizeOffset
+      )
+
+      const valuesTimeChunkOverlapFramesFiltered = prevMaxFrame
+        ? values.filter((frameValues) => frameValues.frame > prevMaxFrame)
+        : values
+
+      prevMaxFrame = maxFrame
+
+      const finalValues = valuesTimeChunkOverlapFramesFiltered.map((frameValues) => {
+        // Ideally we don't have the features not visible in 4wings but we have them
+        // so this needs to be filtered by the current active ones
+        const activeFrameValues = Object.fromEntries(
+          Object.entries(frameValues).map(([key, value]) => {
+            const cleanValue =
+              key === 'frame' || visibleSublayers[parseInt(key)] === true ? value : 0
+            return [key, cleanValue]
+          })
+        )
+        return {
+          ...activeFrameValues,
+          date: quantizeOffsetToDate(frameValues.frame, interval).getTime(),
+        }
+      })
+      return finalValues
+    } else return []
+  })
+  return allChunksValues
+}


### PR DESCRIPTION
Avoid UI lock:
- move calculation needed to render the timebar graph to a worker
- increased debounce delays
