### PR TITLE
Fishing map/4wings filter precision

### DIFF
--- a/.changeset/nasty-ants-shout.md
+++ b/.changeset/nasty-ants-shout.md
@@ -1,0 +1,8 @@
+---
+"@globalfishingwatch/fourwings-aggregate": patch
+"@globalfishingwatch/layer-composer": patch
+"@globalfishingwatch/react-hooks": patch
+"@globalfishingwatchapp/fishing-map": major
+---
+
+Fishing map/4wings filter precision

--- a/applications/fishing-map/src/features/map/Map.tsx
+++ b/applications/fishing-map/src/features/map/Map.tsx
@@ -161,10 +161,10 @@ const MapWrapper = (): React.ReactElement | null => {
         const gridArea = isSquareKm ? (legend.gridArea as number) / 1000000 : legend.gridArea
         const gridAreaFormatted = gridArea
           ? formatI18nNumber(gridArea, {
-              style: 'unit',
-              unit: isSquareKm ? 'kilometer' : 'meter',
-              unitDisplay: 'short',
-            })
+            style: 'unit',
+            unit: isSquareKm ? 'kilometer' : 'meter',
+            unitDisplay: 'short',
+          })
           : ''
         if (legend.unit === 'hours') {
           label = `${t('common.hour_plural', 'hours')} / ${gridAreaFormatted}²`

--- a/applications/fishing-map/src/features/map/map.hooks.ts
+++ b/applications/fishing-map/src/features/map/map.hooks.ts
@@ -11,7 +11,10 @@ import {
 import { ContextLayerType, Type } from '@globalfishingwatch/layer-composer/dist/generators/types'
 import type { Style } from '@globalfishingwatch/mapbox-gl'
 import { DataviewCategory } from '@globalfishingwatch/api-types/dist'
-import { useFeatureState } from '@globalfishingwatch/react-hooks/dist/use-map-interaction'
+import {
+  TemporalGridFeature,
+  useFeatureState,
+} from '@globalfishingwatch/react-hooks/dist/use-map-interaction'
 import GFWAPI from '@globalfishingwatch/api-client'
 import { ENCOUNTER_EVENTS_SOURCE_ID, PRESENCE_LAYER_ID } from 'features/dataviews/dataviews.utils'
 import { selectLocationType } from 'routes/routes.selectors'
@@ -192,6 +195,7 @@ export type TooltipEventFeature = {
     vessels: ExtendedFeatureVessel[]
   }
   event?: ExtendedFeatureEvent
+  temporalgrid?: TemporalGridFeature
   category: DataviewCategory
 }
 

--- a/applications/fishing-map/src/features/map/map.slice.ts
+++ b/applications/fishing-map/src/features/map/map.slice.ts
@@ -91,6 +91,7 @@ type SublayerVessels = {
 
 export const fetch4WingInteractionThunk = createAsyncThunk<
   { vessels: SublayerVessels[] } | undefined,
+  // TODO the whole function could be greatly simplified if only one temporalGridFeature was accepted, which is effecttively always the case
   { temporalGridFeatures: ExtendedFeature[]; timeRange: Range },
   {
     dispatch: AppDispatch
@@ -100,7 +101,20 @@ export const fetch4WingInteractionThunk = createAsyncThunk<
   async ({ temporalGridFeatures, timeRange }, { getState, signal, dispatch }) => {
     const state = getState() as RootState
     const temporalgridDataviews = selectActivityDataviews(state) || []
-    const { start, end } = timeRange || {}
+
+    if (!temporalGridFeatures.length) {
+      console.warn('fetchInteraction not possible, 0 features')
+      return
+    }
+
+
+    // use the first feature/dv for common parameters
+    const mainFeature = temporalGridFeatures[0]
+
+    // Currently only one timerange is supported, which is OK since we only need interaction on the activity heatmaps and all
+    // activity heatmaps use the same time intervals, This will need to be revised in case we support interactivity on environment layers
+    const start = mainFeature.temporalgrid?.visibleFramesStart
+    const end = mainFeature.temporalgrid?.visibleFramesEnd
 
     // get corresponding dataviews
     const featuresDataviews = temporalGridFeatures.flatMap((feature) => {
@@ -119,8 +133,6 @@ export const fetch4WingInteractionThunk = createAsyncThunk<
       return dv.config?.datasets || []
     })
 
-    // use the first feature/dv for common parameters
-    const mainFeature = temporalGridFeatures[0]
     const datasetConfig: DataviewDatasetConfig = {
       datasetId: fourWingsDataset.id,
       endpoint: EndpointId.FourwingsInteraction,

--- a/applications/fishing-map/src/features/map/map.slice.ts
+++ b/applications/fishing-map/src/features/map/map.slice.ts
@@ -107,14 +107,19 @@ export const fetch4WingInteractionThunk = createAsyncThunk<
       return
     }
 
-
     // use the first feature/dv for common parameters
     const mainFeature = temporalGridFeatures[0]
 
     // Currently only one timerange is supported, which is OK since we only need interaction on the activity heatmaps and all
     // activity heatmaps use the same time intervals, This will need to be revised in case we support interactivity on environment layers
-    const start = mainFeature.temporalgrid?.visibleFramesStart
-    const end = mainFeature.temporalgrid?.visibleFramesEnd
+    const start =
+      mainFeature.temporalgrid?.interval === '10days'
+        ? mainFeature.temporalgrid?.visibleFramesStart
+        : timeRange.start
+    const end =
+      mainFeature.temporalgrid?.interval === '10days'
+        ? mainFeature.temporalgrid?.visibleFramesEnd
+        : timeRange.end
 
     // get corresponding dataviews
     const featuresDataviews = temporalGridFeatures.flatMap((feature) => {

--- a/applications/fishing-map/src/features/map/popups/HeatmapLayers.tsx
+++ b/applications/fishing-map/src/features/map/popups/HeatmapLayers.tsx
@@ -9,9 +9,10 @@ import { getVesselDataviewInstance } from 'features/dataviews/dataviews.utils'
 import { getRelatedDatasetByType } from 'features/datasets/datasets.selectors'
 import I18nNumber from 'features/i18n/i18nNumber'
 import { TooltipEventFeature, useClickedEventConnect } from 'features/map/map.hooks'
+import { formatI18nDate } from 'features/i18n/i18nDate'
 import { ExtendedFeatureVessel } from 'features/map/map.slice'
-import { AsyncReducerStatus } from 'utils/async-slice'
 import { isUserLogged } from 'features/user/user.selectors'
+import { AsyncReducerStatus } from 'utils/async-slice'
 import styles from './Popup.module.css'
 
 // Translations by feature.unit static keys
@@ -52,7 +53,21 @@ function HeatmapTooltipRow({ feature, showFeaturesDetails }: HeatmapTooltipRowPr
     <div className={styles.popupSection}>
       <span className={styles.popupSectionColor} style={{ backgroundColor: feature.color }} />
       <div className={styles.popupSectionContent}>
-        {showFeaturesDetails && <h3 className={styles.popupSectionTitle}>{feature.title}</h3>}
+        {showFeaturesDetails && (
+          <h3 className={styles.popupSectionTitle}>
+            {feature.title}
+            {feature.temporalgrid && feature.temporalgrid.interval === '10days' && (
+              <span>
+                {' '}
+                {t('common.dateRange', {
+                  start: formatI18nDate(feature.temporalgrid.visibleFramesStart),
+                  end: formatI18nDate(feature.temporalgrid.visibleFramesEnd),
+                  defaultValue: 'between {{start}} and {{end}}',
+                })}
+              </span>
+            )}
+          </h3>
+        )}
         <div className={styles.row}>
           <span className={styles.rowText}>
             <I18nNumber number={feature.value} />{' '}

--- a/applications/fishing-map/src/features/map/popups/Popup.module.css
+++ b/applications/fishing-map/src/features/map/popups/Popup.module.css
@@ -65,7 +65,10 @@
 }
 
 .popupSectionTitle {
+  max-width: 30rem;
   opacity: var(--opacity-secondary);
+  line-height: 1.2;
+  margin-bottom: var(--space-XS);
 }
 
 .loading {

--- a/packages/fourwings-aggregate/test/test.mjs
+++ b/packages/fourwings-aggregate/test/test.mjs
@@ -1,0 +1,42 @@
+// import { aggregateCell, aggregateTile } from '@globalfishingwatch/fourwings-aggregate'
+// import tile from './tiles/inconsistency.mjs'
+
+// const BASE_CONFIG = {
+//   aggregationOperation: "sum",
+//   delta: 73,
+//   geomType: "rectangle",
+//   interactive: true,
+//   interval: "10days",
+//   quantizeOffset: 0,
+//   singleFrame: false,
+//   sublayerBreaks: [[0, 100, 200, 300, 400, 500, 600, 800, 900]],
+//   sublayerCombinationMode: "max",
+//   sublayerCount: 1,
+//   sublayerVisibility: [true],
+//   x: 68,
+//   y: 122,
+//   z: 8,
+//   tileBBox: [-84.375, 7.013667927566632, -82.96875, 8.407168163601074]
+// }
+
+// const FRAME = 1815
+
+// const agg = aggregateTile(tile, BASE_CONFIG)
+// const featAggTileCell = agg.main.features.find(
+//   (f) => f.id === 933534
+// )
+
+// const featAggTileRawCell = agg.interactive.features.find(
+//   (f) => f.id === 933534
+// )
+// const featAggTileRawCellFrame = aggregateCell({
+//   rawValues: JSON.stringify(featAggTileRawCell.properties.rawValues),
+//   frame: FRAME,
+//   delta: BASE_CONFIG.delta,
+//   quantizeOffset: BASE_CONFIG.quantizeOffset,
+//   sublayerCount: BASE_CONFIG.sublayerCount,
+// })
+
+
+// console.log(featAggTileCell)
+// console.log(JSON.stringify(featAggTileRawCell.properties.rawValues))

--- a/packages/layer-composer/src/generators/heatmap/modes/gridded.ts
+++ b/packages/layer-composer/src/generators/heatmap/modes/gridded.ts
@@ -17,11 +17,16 @@ export default function gridded(
 ) {
   const { colorRampBaseExpression } = getColorRampBaseExpression(config)
 
+  // TODO only active chunk needed?
   const layers: Layer[] = timeChunks.chunks.flatMap((timeChunk: TimeChunk) => {
     const pickValueAt = timeChunk.frame.toString()
     // TODO Coalesce to 0 will not work if we use divergent scale (because we would need the value < min value)
     const exprPick = ['coalesce', ['get', pickValueAt], 0]
-    const exprColorRamp = ['step', exprPick, 'transparent', ...colorRampBaseExpression]
+    
+    // TODO try with 'case' or 'match', might be faster than 'step'
+    const exprColorRamp = ['match', exprPick, ...colorRampBaseExpression, 'transparent']
+    // const exprColorRamp = ['step', exprPick, 'transparent', ...colorRampBaseExpression]
+    console.log(exprColorRamp)
 
     const paint = {
       'fill-color': timeChunk.active ? (exprColorRamp as any) : 'rgba(0,0,0,0)',

--- a/packages/layer-composer/src/generators/heatmap/modes/gridded.ts
+++ b/packages/layer-composer/src/generators/heatmap/modes/gridded.ts
@@ -23,10 +23,7 @@ export default function gridded(
     // TODO Coalesce to 0 will not work if we use divergent scale (because we would need the value < min value)
     const exprPick = ['coalesce', ['get', pickValueAt], 0]
     
-    // TODO try with 'case' or 'match', might be faster than 'step'
     const exprColorRamp = ['match', exprPick, ...colorRampBaseExpression, 'transparent']
-    // const exprColorRamp = ['step', exprPick, 'transparent', ...colorRampBaseExpression]
-    console.log(exprColorRamp)
 
     const paint = {
       'fill-color': timeChunk.active ? (exprColorRamp as any) : 'rgba(0,0,0,0)',

--- a/packages/layer-composer/src/generators/heatmap/util/time-chunks.ts
+++ b/packages/layer-composer/src/generators/heatmap/util/time-chunks.ts
@@ -224,7 +224,7 @@ export const getActiveTimeChunks = (
   const delta = +toDT(activeEnd) - +toDT(activeStart)
   const finalInterval: Interval =
     !interval || Array.isArray(interval) ? getInterval(delta, interval) : (interval as Interval)
-  
+
   const deltaInIntervalUnits = CONFIG_BY_INTERVAL[finalInterval].getFrame(delta)
 
   const timeChunks: TimeChunks = {

--- a/packages/react-hooks/src/use-map-interaction/index.ts
+++ b/packages/react-hooks/src/use-map-interaction/index.ts
@@ -1,8 +1,20 @@
 import type { Geometry } from 'geojson'
 import { ContextLayerType } from '@globalfishingwatch/layer-composer/dist/generators/types'
+import { Interval } from '@globalfishingwatch/layer-composer/dist/generators'
 import { PointerEvent } from '@globalfishingwatch/react-map-gl'
 
 export { useMapHover, useMapClick, useFeatureState } from './use-map-interaction'
+
+export type TemporalGridFeature = {
+  sublayerIndex: number
+  sublayerId: string
+  visible: boolean
+  col: number
+  row: number
+  interval: Interval
+  visibleFramesStart: string
+  visibleFramesEnd: string
+}
 
 export type ExtendedFeature = {
   properties: Record<string, any>
@@ -19,15 +31,7 @@ export type ExtendedFeature = {
     y: number
     z: number
   }
-  temporalgrid?: {
-    sublayerIndex: number
-    sublayerId: string
-    visible: boolean
-    col: number
-    row: number
-    visibleFramesStart: number
-    visibleFramesEnd: number
-  }
+  temporalgrid?: TemporalGridFeature
   uniqueFeatureInteraction?: boolean
   generatorContextLayer?: ContextLayerType | null
   geometry?: Geometry

--- a/packages/react-hooks/src/use-map-interaction/index.ts
+++ b/packages/react-hooks/src/use-map-interaction/index.ts
@@ -25,6 +25,8 @@ export type ExtendedFeature = {
     visible: boolean
     col: number
     row: number
+    visibleFramesStart: number
+    visibleFramesEnd: number
   }
   uniqueFeatureInteraction?: boolean
   generatorContextLayer?: ContextLayerType | null

--- a/packages/react-hooks/src/use-map-interaction/use-map-interaction.ts
+++ b/packages/react-hooks/src/use-map-interaction/use-map-interaction.ts
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef } from 'react'
 import { debounce } from 'lodash'
-import { Generators, ExtendedStyleMeta } from '@globalfishingwatch/layer-composer'
+import { Generators, ExtendedStyleMeta, CONFIG_BY_INTERVAL, Interval } from '@globalfishingwatch/layer-composer'
 import { aggregateCell } from '@globalfishingwatch/fourwings-aggregate'
 import type { Map, MapboxGeoJSONFeature } from '@globalfishingwatch/mapbox-gl'
 import { ExtendedFeature, InteractionEventCallback, InteractionEvent } from '.'
@@ -65,6 +65,12 @@ const getExtendedFeatures = (
         const timeChunks = generatorMetadata?.timeChunks
         const frame = timeChunks?.activeChunkFrame
         const activeTimeChunk = timeChunks?.chunks.find((c: any) => c.active)
+
+        // This is used when querying the interaction endpoint, so that start begins at the start of the frame (ie start of a 10days interval)
+        // This avoids querying a cell visible on the map, when its actual timerange is not included in the app-overall time range
+        const getDate = CONFIG_BY_INTERVAL[timeChunks.interval as Interval].getDate
+        const visibleFramesStart = getDate(activeTimeChunk.frame).toISOString()
+        const visibleFramesEnd = getDate(activeTimeChunk.frame + timeChunks.deltaInIntervalUnits).toISOString()
         const numSublayers = generatorMetadata?.numSublayers
         const values = aggregateCell({
           rawValues: properties.rawValues,
@@ -88,6 +94,8 @@ const getExtendedFeatures = (
               visible: visibleSublayers[i] === true,
               col: properties._col as number,
               row: properties._row as number,
+              visibleFramesStart,
+              visibleFramesEnd
             },
             value,
           }

--- a/packages/react-hooks/src/use-map-interaction/use-map-interaction.ts
+++ b/packages/react-hooks/src/use-map-interaction/use-map-interaction.ts
@@ -1,6 +1,11 @@
 import { useCallback, useEffect, useMemo, useRef } from 'react'
 import { debounce } from 'lodash'
-import { Generators, ExtendedStyleMeta, CONFIG_BY_INTERVAL, Interval } from '@globalfishingwatch/layer-composer'
+import {
+  Generators,
+  ExtendedStyleMeta,
+  CONFIG_BY_INTERVAL,
+  Interval,
+} from '@globalfishingwatch/layer-composer'
 import { aggregateCell } from '@globalfishingwatch/fourwings-aggregate'
 import type { Map, MapboxGeoJSONFeature } from '@globalfishingwatch/mapbox-gl'
 import { ExtendedFeature, InteractionEventCallback, InteractionEvent } from '.'
@@ -70,7 +75,9 @@ const getExtendedFeatures = (
         // This avoids querying a cell visible on the map, when its actual timerange is not included in the app-overall time range
         const getDate = CONFIG_BY_INTERVAL[timeChunks.interval as Interval].getDate
         const visibleFramesStart = getDate(activeTimeChunk.frame).toISOString()
-        const visibleFramesEnd = getDate(activeTimeChunk.frame + timeChunks.deltaInIntervalUnits).toISOString()
+        const visibleFramesEnd = getDate(
+          activeTimeChunk.frame + timeChunks.deltaInIntervalUnits
+        ).toISOString()
         const numSublayers = generatorMetadata?.numSublayers
         const values = aggregateCell({
           rawValues: properties.rawValues,
@@ -94,8 +101,9 @@ const getExtendedFeatures = (
               visible: visibleSublayers[i] === true,
               col: properties._col as number,
               row: properties._row as number,
+              interval: timeChunks.interval,
               visibleFramesStart,
-              visibleFramesEnd
+              visibleFramesEnd,
             },
             value,
           }


### PR DESCRIPTION
This is a fix for https://globalfishingwatch.atlassian.net/secure/RapidBoard.jspa?rapidView=9&projectKey=MR&modal=detail&selectedIssue=MR-314

Here's the problem as I explained it to Raul:
Tile 8/68/122 con interval 10days, celda 3534, el tile tiene:
`[..., 3534,1815,1815,100, ...]`
O sea: un solo valor en la frame 1815.
El start del timebar es 17 de septiembre.
Yo calculo hago una conversion de la fecha en frame para saber si mostrar la frame o no, asi:
`Math.floor(timestampMs / 1000 / 60 / 60 / 24 / 10)`
Lo que me devuelve exactemente 1815, con lo cual la celda se puede ver en el mapa, pero al llamar la API se manda el start **del timebar** (17 de septiembre), no **el start del periodo de 10 dias que corresponde a la frame 1815**, es decir 11 de septiembre.

This PR implements a fix suggested by him:
When calling the interaction API, the "real" start and end will be used, meaning start and end frames get converted back to dates, rather than using dates from the timebar (so 11 sept, not 17 sept).

TODO:
- [ ] Since we only do one API call, so only one timerange, this won't work with layers that use different chunks/intervals (ie if we had interaction on env layers with `month` interval). This is an hypothetical scenario but I believe `fetch4winginteractionThunk` should be refactored to use a single set of parameters with an array of datasets.
- [ ] This also raises a design issue:
![Screenshot 2021-05-28 at 14 49 23](https://user-images.githubusercontent.com/1583415/119986242-e5364880-bfc3-11eb-9bd5-c293fece3aa7.png)
The range displayed is actually incorrect for the heatmap (but correct for tracks, etc)
   - [ ] We could force the timebar to stick to the 10 days intervals, but it is weird in terms of UI and will conflict with already existing behaviour of sticking to calendar months
   - [ ] We could display a second ramge
   - [ ] Any other suggestion that actually doesn't suck
