### PR TITLE
fixed issue with 4w time range + more greedy

### DIFF
--- a/.changeset/quiet-mugs-boil.md
+++ b/.changeset/quiet-mugs-boil.md
@@ -1,0 +1,7 @@
+---
+"@globalfishingwatch/layer-composer": minor
+"@globalfishingwatch/react-hooks": major
+"@globalfishingwatchapp/fishing-map": patch
+---
+
+fixed issue with 4w time range + more greedy

--- a/applications/fishing-map/src/features/map/map.slice.ts
+++ b/applications/fishing-map/src/features/map/map.slice.ts
@@ -114,14 +114,8 @@ export const fetch4WingInteractionThunk = createAsyncThunk<
 
     // Currently only one timerange is supported, which is OK since we only need interaction on the activity heatmaps and all
     // activity heatmaps use the same time intervals, This will need to be revised in case we support interactivity on environment layers
-    const start =
-      mainFeature.temporalgrid?.interval === '10days'
-        ? mainFeature.temporalgrid?.visibleStartFrame
-        : timeRange.start
-    const end =
-      mainFeature.temporalgrid?.interval === '10days'
-        ? mainFeature.temporalgrid?.visibleEndFrame
-        : timeRange.end
+    const start = mainFeature.temporalgrid?.visibleStartDate
+    const end = mainFeature.temporalgrid?.visibleEndDate
 
     // get corresponding dataviews
     const featuresDataviews = temporalGridFeatures.flatMap((feature) => {

--- a/applications/fishing-map/src/features/map/map.slice.ts
+++ b/applications/fishing-map/src/features/map/map.slice.ts
@@ -116,11 +116,11 @@ export const fetch4WingInteractionThunk = createAsyncThunk<
     // activity heatmaps use the same time intervals, This will need to be revised in case we support interactivity on environment layers
     const start =
       mainFeature.temporalgrid?.interval === '10days'
-        ? mainFeature.temporalgrid?.visibleFramesStart
+        ? mainFeature.temporalgrid?.visibleStartFrame
         : timeRange.start
     const end =
       mainFeature.temporalgrid?.interval === '10days'
-        ? mainFeature.temporalgrid?.visibleFramesEnd
+        ? mainFeature.temporalgrid?.visibleEndFrame
         : timeRange.end
 
     // get corresponding dataviews

--- a/applications/fishing-map/src/features/map/popups/HeatmapLayers.tsx
+++ b/applications/fishing-map/src/features/map/popups/HeatmapLayers.tsx
@@ -60,8 +60,8 @@ function HeatmapTooltipRow({ feature, showFeaturesDetails }: HeatmapTooltipRowPr
               <span>
                 {' '}
                 {t('common.dateRange', {
-                  start: formatI18nDate(feature.temporalgrid.visibleStartFrame),
-                  end: formatI18nDate(feature.temporalgrid.visibleEndFrame),
+                  start: formatI18nDate(feature.temporalgrid.visibleStartDate),
+                  end: formatI18nDate(feature.temporalgrid.visibleEndDate),
                   defaultValue: 'between {{start}} and {{end}}',
                 })}
               </span>

--- a/applications/fishing-map/src/features/map/popups/HeatmapLayers.tsx
+++ b/applications/fishing-map/src/features/map/popups/HeatmapLayers.tsx
@@ -60,8 +60,8 @@ function HeatmapTooltipRow({ feature, showFeaturesDetails }: HeatmapTooltipRowPr
               <span>
                 {' '}
                 {t('common.dateRange', {
-                  start: formatI18nDate(feature.temporalgrid.visibleFramesStart),
-                  end: formatI18nDate(feature.temporalgrid.visibleFramesEnd),
+                  start: formatI18nDate(feature.temporalgrid.visibleStartFrame),
+                  end: formatI18nDate(feature.temporalgrid.visibleEndFrame),
                   defaultValue: 'between {{start}} and {{end}}',
                 })}
               </span>

--- a/packages/layer-composer/src/generators/heatmap/util/time-chunks.ts
+++ b/packages/layer-composer/src/generators/heatmap/util/time-chunks.ts
@@ -98,9 +98,9 @@ export const CONFIG_BY_INTERVAL: Record<Interval, Record<string, any>> = {
   month: {
     getRawFrame: (start: number) => {
       return LuxonInterval.fromDateTimes(
-          DateTime.fromMillis(0).toUTC(),
-          DateTime.fromMillis(start).toUTC()
-        ).toDuration('month').months
+        DateTime.fromMillis(0).toUTC(),
+        DateTime.fromMillis(start).toUTC()
+      ).toDuration('month').months
     },
     getDate: (frame: number) => {
       const year = 1970 + Math.floor(frame / 12)
@@ -187,7 +187,7 @@ const getTimeChunks = (
     const dataEnd = chunkDataEnd.toString()
 
     // we will substract every timestamp with this to end up with shorter arrays indexes
-    const quantizeOffset = config.getFrame(+chunkStart)
+    const quantizeOffset = config.getRawFrame(+chunkStart)
 
     const activeStartDT = +toDT(activeStart)
     const isActive = activeStartDT > +chunkStart && activeStartDT <= chunkViewEnd
@@ -314,7 +314,7 @@ const toQuantizedFrame = (date: string, quantizeOffset: number, interval: Interv
   const config = CONFIG_BY_INTERVAL[interval]
   // TODO Use Luxon to use UTC!!!!
   const ms = new Date(date).getTime()
-  const frame = config.getVisibleStartFrame(config.getRawFrame(ms))
+  const frame = getVisibleStartFrame(config.getRawFrame(ms))
   return frame - quantizeOffset
 }
 

--- a/packages/layer-composer/src/generators/heatmap/util/time-chunks.ts
+++ b/packages/layer-composer/src/generators/heatmap/util/time-chunks.ts
@@ -187,7 +187,7 @@ const getTimeChunks = (
     const dataEnd = chunkDataEnd.toString()
 
     // we will substract every timestamp with this to end up with shorter arrays indexes
-    const quantizeOffset = config.getRawFrame(+chunkStart)
+    const quantizeOffset = getVisibleStartFrame(config.getRawFrame(+chunkStart))
 
     const activeStartDT = +toDT(activeStart)
     const isActive = activeStartDT > +chunkStart && activeStartDT <= chunkViewEnd

--- a/packages/react-hooks/src/use-map-interaction/index.ts
+++ b/packages/react-hooks/src/use-map-interaction/index.ts
@@ -12,8 +12,8 @@ export type TemporalGridFeature = {
   col: number
   row: number
   interval: Interval
-  visibleStartFrame: string
-  visibleEndFrame: string
+  visibleStartDate: string
+  visibleEndDate: string
 }
 
 export type ExtendedFeature = {

--- a/packages/react-hooks/src/use-map-interaction/index.ts
+++ b/packages/react-hooks/src/use-map-interaction/index.ts
@@ -12,8 +12,8 @@ export type TemporalGridFeature = {
   col: number
   row: number
   interval: Interval
-  visibleFramesStart: string
-  visibleFramesEnd: string
+  visibleStartFrame: string
+  visibleEndFrame: string
 }
 
 export type ExtendedFeature = {

--- a/packages/react-hooks/src/use-map-interaction/use-map-interaction.ts
+++ b/packages/react-hooks/src/use-map-interaction/use-map-interaction.ts
@@ -74,8 +74,8 @@ const getExtendedFeatures = (
         // This is used when querying the interaction endpoint, so that start begins at the start of the frame (ie start of a 10days interval)
         // This avoids querying a cell visible on the map, when its actual timerange is not included in the app-overall time range
         const getDate = CONFIG_BY_INTERVAL[timeChunks.interval as Interval].getDate
-        const visibleStartFrame = getDate(timeChunks.visibleStartFrame).toISOString()
-        const visibleEndFrame = getDate(timeChunks.visibleEndFrame).toISOString()
+        const visibleStartDate = getDate(timeChunks.visibleStartFrame).toISOString()
+        const visibleEndDate = getDate(timeChunks.visibleEndFrame).toISOString()
         const numSublayers = generatorMetadata?.numSublayers
         const values = aggregateCell({
           rawValues: properties.rawValues,
@@ -100,8 +100,8 @@ const getExtendedFeatures = (
               col: properties._col as number,
               row: properties._row as number,
               interval: timeChunks.interval,
-              visibleStartFrame,
-              visibleEndFrame,
+              visibleStartDate,
+              visibleEndDate,
             },
             value,
           }

--- a/packages/react-hooks/src/use-map-interaction/use-map-interaction.ts
+++ b/packages/react-hooks/src/use-map-interaction/use-map-interaction.ts
@@ -74,10 +74,8 @@ const getExtendedFeatures = (
         // This is used when querying the interaction endpoint, so that start begins at the start of the frame (ie start of a 10days interval)
         // This avoids querying a cell visible on the map, when its actual timerange is not included in the app-overall time range
         const getDate = CONFIG_BY_INTERVAL[timeChunks.interval as Interval].getDate
-        const visibleFramesStart = getDate(activeTimeChunk.frame).toISOString()
-        const visibleFramesEnd = getDate(
-          activeTimeChunk.frame + timeChunks.deltaInIntervalUnits
-        ).toISOString()
+        const visibleStartFrame = getDate(timeChunks.visibleStartFrame).toISOString()
+        const visibleEndFrame = getDate(timeChunks.visibleEndFrame).toISOString()
         const numSublayers = generatorMetadata?.numSublayers
         const values = aggregateCell({
           rawValues: properties.rawValues,
@@ -102,8 +100,8 @@ const getExtendedFeatures = (
               col: properties._col as number,
               row: properties._row as number,
               interval: timeChunks.interval,
-              visibleFramesStart,
-              visibleFramesEnd,
+              visibleStartFrame,
+              visibleEndFrame,
             },
             value,
           }


### PR DESCRIPTION
![Screenshot 2021-06-16 at 17 54 04](https://user-images.githubusercontent.com/1583415/122254458-6bf88a00-cecd-11eb-8582-17329478049e.png)

- fixes an issue where the last frame was missing in both map and popup
- delta is now calculated using `ceil` for time range end, which can result in another extra frame queried