### PR TITLE
fetch viirs interaction technical refactos

### DIFF
--- a/.changeset/violet-games-drum.md
+++ b/.changeset/violet-games-drum.md
@@ -1,0 +1,7 @@
+---
+'@globalfishingwatch/dataviews-client': minor
+'@globalfishingwatch/layer-composer': minor
+'@globalfishingwatch/react-hooks': minor
+---
+
+add sublayerInteractionType

--- a/applications/fishing-map/src/features/map/map.hooks.ts
+++ b/applications/fishing-map/src/features/map/map.hooks.ts
@@ -141,7 +141,8 @@ export const useClickedEventConnect = () => {
     }
 
     // Cancel all pending promises
-    [fishingPromiseRef, viirsPromiseRef, eventsPromiseRef].forEach(ref => {
+    const promisesRef = [fishingPromiseRef, viirsPromiseRef, eventsPromiseRef]
+    promisesRef.forEach((ref) => {
       if (ref.current) {
         ref.current.abort()
       }
@@ -187,8 +188,8 @@ export const useClickedEventConnect = () => {
         return false
       }
       const isFeatureVisible = feature.temporalgrid.visible
-      const isFishingFeature = feature.temporalgrid.sublayerInteractionType === 'viirs'
-      return isFeatureVisible && isFishingFeature
+      const isViirsFeature = feature.temporalgrid.sublayerInteractionType === 'viirs'
+      return isFeatureVisible && isViirsFeature
     })
 
     if (viirsFeature) {

--- a/applications/fishing-map/src/features/map/map.hooks.ts
+++ b/applications/fishing-map/src/features/map/map.hooks.ts
@@ -176,14 +176,14 @@ export const useClickedEventConnect = () => {
           return false
         }
         const isFeatureVisible = feature.temporalgrid.visible
-        const isFishingFeature = feature.temporalgrid.sublayerId.startsWith(FISHING_LAYER_PREFIX)
+        const isFishingFeature = feature.temporalgrid.sublayerInteractionType === 'fishing-effort'
         return isFeatureVisible && isFishingFeature
       })
       .sort((feature) => feature.temporalgrid?.sublayerIndex ?? 0)
 
-    if (fishingActivityFeatures?.length && timeRange) {
+    if (fishingActivityFeatures?.length) {
       fishingPromiseRef.current = dispatch(
-        fetchFishingActivityInteractionThunk({ fishingActivityFeatures, timeRange })
+        fetchFishingActivityInteractionThunk({ fishingActivityFeatures })
       )
     }
 
@@ -192,7 +192,7 @@ export const useClickedEventConnect = () => {
         return false
       }
       const isFeatureVisible = feature.temporalgrid.visible
-      const isFishingFeature = feature.temporalgrid.sublayerId.startsWith('viirs')
+      const isFishingFeature = feature.temporalgrid.sublayerInteractionType === 'viirs'
       return isFeatureVisible && isFishingFeature
     })
 

--- a/applications/fishing-map/src/features/map/map.hooks.ts
+++ b/applications/fishing-map/src/features/map/map.hooks.ts
@@ -140,17 +140,12 @@ export const useClickedEventConnect = () => {
       }
     }
 
-    if (fishingPromiseRef.current) {
-      fishingPromiseRef.current.abort()
-    }
-
-    if (viirsPromiseRef.current) {
-      viirsPromiseRef.current.abort()
-    }
-
-    if (eventsPromiseRef.current) {
-      eventsPromiseRef.current.abort()
-    }
+    // Cancel all pending promises
+    [fishingPromiseRef, viirsPromiseRef, eventsPromiseRef].forEach(ref => {
+      if (ref.current) {
+        ref.current.abort()
+      }
+    })
 
     if (!event || !event.features) {
       if (clickedEvent) {

--- a/applications/fishing-map/src/features/map/map.slice.ts
+++ b/applications/fishing-map/src/features/map/map.slice.ts
@@ -151,7 +151,7 @@ const getInteractionEndpointDatasetConfig = (getState: () => any, features: Exte
 
 export const fetchFishingActivityInteractionThunk = createAsyncThunk<
   { vessels: SublayerVessels[] } | undefined,
-  { fishingActivityFeatures: ExtendedFeature[]; timeRange: Range },
+  { fishingActivityFeatures: ExtendedFeature[] },
   {
     dispatch: AppDispatch
   }

--- a/packages/dataviews-client/src/resolve-dataviews-generators.ts
+++ b/packages/dataviews-client/src/resolve-dataviews-generators.ts
@@ -1,4 +1,5 @@
 import { scaleLinear } from 'd3-scale'
+import { uniq } from 'lodash'
 import {
   Resource,
   TrackResourceData,
@@ -21,6 +22,7 @@ import {
 import type {
   ColorRampsIds,
   HeatmapAnimatedGeneratorSublayer,
+  HeatmapAnimatedInteractionType,
 } from '@globalfishingwatch/layer-composer/dist/generators/types'
 import { AggregationOperation, VALUE_MULTIPLIER } from '@globalfishingwatch/fourwings-aggregate'
 import { resolveDataviewDatasetResource, UrlDataviewInstance } from './resolve-dataviews'
@@ -319,8 +321,14 @@ export function getDataviewsGeneratorConfigs(
       const { config, datasetsConfig } = dataview
       if (!config || !datasetsConfig || !datasetsConfig.length) return []
       const datasets = config.datasets || datasetsConfig.map((dc) => dc.datasetId)
-      // TODO Take unit from first dataset -> are we sure activity sublayers always use 'hours'?
-      const unit = dataview.datasets?.[0]?.unit
+      const units = uniq(dataview.datasets?.map(dataset => dataset.unit))
+      if (units.length !== 1) {
+        throw new Error('Shouldnt have distinct units for the same heatmap layer')
+      }
+      const interactionTypes = uniq(dataview.datasets?.map(dataset => dataset.configuration?.type || 'fishing-effort'))
+      if (interactionTypes.length !== 1) {
+        throw new Error(`Shouldnt have distinct dataset config types for the same heatmap layer: ${interactionTypes.toString()}`)
+      }
       const sublayer: HeatmapAnimatedGeneratorSublayer = {
         id: dataview.id,
         datasets,
@@ -330,9 +338,10 @@ export function getDataviewsGeneratorConfigs(
         visible: config.visible,
         legend: {
           label: dataview.name,
-          unit,
+          unit: units[0],
           color: dataview?.config?.color,
         },
+        interactionType: interactionTypes[0] as HeatmapAnimatedInteractionType, // TODO I don't understand why dataset.configuration?.type is of type EventTypes? 
       }
 
       return sublayer

--- a/packages/layer-composer/src/generators/types.ts
+++ b/packages/layer-composer/src/generators/types.ts
@@ -356,6 +356,8 @@ export type Ruler = {
   isNew?: boolean
 }
 
+export type HeatmapAnimatedInteractionType = 'presence' | 'viirs' | 'fishing-effort'
+
 export interface HeatmapAnimatedGeneratorSublayer {
   id: string
   datasets: string[]
@@ -365,6 +367,7 @@ export interface HeatmapAnimatedGeneratorSublayer {
   visible?: boolean
   breaks?: number[]
   legend?: GeneratorLegend
+  interactionType?: HeatmapAnimatedInteractionType
 }
 
 // ---- Heatmap Generator color ramps types

--- a/packages/react-hooks/src/use-map-interaction/index.ts
+++ b/packages/react-hooks/src/use-map-interaction/index.ts
@@ -1,5 +1,5 @@
 import type { Geometry } from 'geojson'
-import { ContextLayerType } from '@globalfishingwatch/layer-composer/dist/generators/types'
+import { ContextLayerType, HeatmapAnimatedInteractionType } from '@globalfishingwatch/layer-composer/dist/generators/types'
 import { Interval } from '@globalfishingwatch/layer-composer/dist/generators'
 import { PointerEvent } from '@globalfishingwatch/react-map-gl'
 
@@ -8,6 +8,7 @@ export { useMapHover, useMapClick, useFeatureState } from './use-map-interaction
 export type TemporalGridFeature = {
   sublayerIndex: number
   sublayerId: string
+  sublayerInteractionType: HeatmapAnimatedInteractionType
   visible: boolean
   col: number
   row: number

--- a/packages/react-hooks/src/use-map-interaction/use-map-interaction.ts
+++ b/packages/react-hooks/src/use-map-interaction/use-map-interaction.ts
@@ -45,6 +45,7 @@ const getExtendedFeatures = (
       generatorMetadata = feature.layer.metadata
     }
 
+    // TODO Throw error if unit difer?
     const unit = generatorMetadata?.sublayers?.[0].legend.unit ?? null
     const uniqueFeatureInteraction = feature.layer?.metadata?.uniqueFeatureInteraction ?? false
     const properties = feature.properties || {}
@@ -96,6 +97,7 @@ const getExtendedFeatures = (
             temporalgrid: {
               sublayerIndex: i,
               sublayerId: sublayers[i].id,
+              sublayerInteractionType: sublayers[i].interactionType,
               visible: visibleSublayers[i] === true,
               col: properties._col as number,
               row: properties._row as number,


### PR DESCRIPTION
- merged code to prepare fishing and viirs interaction endpoints, only viirs is an array of one
- pass `dataset.config.type` to sublayer metadata in order to determine type of endpoint to call, rather than using`temporalgrid.sublayerId.startsWith` which seem unreliable to me
- some more fluff