### PR TITLE
fixed instable delta time

### DIFF
--- a/.changeset/blue-parrots-accept.md
+++ b/.changeset/blue-parrots-accept.md
@@ -1,0 +1,5 @@
+---
+"@globalfishingwatch/layer-composer": patch
+---
+
+fixed instable delta time

--- a/packages/layer-composer/src/generators/heatmap/heatmap-animated.ts
+++ b/packages/layer-composer/src/generators/heatmap/heatmap-animated.ts
@@ -144,10 +144,11 @@ class HeatmapAnimatedGenerator {
 
       return sourceParams.map((params: Record<string, string>) => {
         const url = new URL(`${tilesUrl}?${new URLSearchParams(params)}`)
+        const urlString = decodeURI(url.toString())
         const source = {
           id: params.id,
           type: 'temporalgrid',
-          tiles: [decodeURI(url.toString())],
+          tiles: [urlString],
           maxzoom: config.maxZoom,
         }
         return source

--- a/packages/layer-composer/src/generators/heatmap/util/time-chunks.ts
+++ b/packages/layer-composer/src/generators/heatmap/util/time-chunks.ts
@@ -38,9 +38,6 @@ const TIME_CHUNK_BUFFER_RELATIVE_SIZE = 0.2
 const getVisibleStartFrame = (rawFrame: number) => {
   return Math.floor(rawFrame)
 }
-const getVisibleEndFrame = (rawFrame: number) => {
-  return Math.ceil(rawFrame)
-}
 
 export const CONFIG_BY_INTERVAL: Record<Interval, Record<string, any>> = {
   hour: {
@@ -237,9 +234,8 @@ export const getActiveTimeChunks = (
   const visibleStartFrameRaw = finalIntervalConfig.getRawFrame(+toDT(activeStart))
   const visibleStartFrame = getVisibleStartFrame(visibleStartFrameRaw)
   const visibleEndFrameRaw = finalIntervalConfig.getRawFrame(+toDT(activeEnd))
-  const visibleEndFrame = getVisibleEndFrame(visibleEndFrameRaw)
-
-  const deltaInIntervalUnits = visibleEndFrame - visibleStartFrame
+  const deltaInIntervalUnits = Math.round(visibleEndFrameRaw - visibleStartFrameRaw)
+  const visibleEndFrame = visibleStartFrame + deltaInIntervalUnits
 
   const timeChunks: TimeChunks = {
     activeStart,


### PR DESCRIPTION
This is a fix to bug introduced in https://github.com/GlobalFishingWatch/frontend/commit/8d73b5205645965caa61c3443cbba4d9d8bef38d
Which resulted in integer delta between start/end varying between eg 311 and 312. 
Now integer start is computed, then integer delta, then integer end - which result in end being effectively the result of `round`, not `ceil`