### PR TITLE
Fishingmap/encounters review

### DIFF
--- a/.changeset/healthy-items-juggle.md
+++ b/.changeset/healthy-items-juggle.md
@@ -1,0 +1,5 @@
+---
+'@globalfishingwatch/layer-composer': minor
+---
+
+workaround for duplicated events in generator

--- a/.changeset/moody-rings-taste.md
+++ b/.changeset/moody-rings-taste.md
@@ -1,0 +1,5 @@
+---
+'@globalfishingwatch/layer-composer': minor
+---
+
+workaround for duplicated api events

--- a/applications/fishing-map/src/data/config.ts
+++ b/applications/fishing-map/src/data/config.ts
@@ -50,7 +50,7 @@ export const DEFAULT_WORKSPACE = {
   availableEnd: new Date(Date.UTC(new Date().getFullYear(), 11, 31)).toISOString(),
   dataviewInstances: undefined,
   timebarVisualisation: TimebarVisualisations.Heatmap,
-  timebarEvents: 'all',
+  visibleEvents: 'all',
   timebarGraph: TimebarGraphs.None,
   bivariateDataviews: undefined,
   analysis: undefined,

--- a/applications/fishing-map/src/data/dataviews.md
+++ b/applications/fishing-map/src/data/dataviews.md
@@ -15,6 +15,12 @@ Fetch them using this [API endpoint](https://gateway.api.globalfishingwatch.org/
 | MPA Restricted               | 100    | 180    |
 | Default (used on new layers) | 123    | 220    |
 
+## Events
+
+| Layer name | Dev id | Pro id |
+| ---------- | ------ | ------ |
+| Encounters | 140    | ---    |
+
 ## Environmental
 
 | Layer name                   | Dev id | Pro id |

--- a/applications/fishing-map/src/data/default-workspaces/workspace.development.ts
+++ b/applications/fishing-map/src/data/default-workspaces/workspace.development.ts
@@ -33,7 +33,7 @@ const workspace: Workspace<WorkspaceState> = {
     // bivariate: true,
     // sidebarOpen: false,
     // timebarVisualisation: '',
-    // timebarEvents: '',
+    // visibleEvents: 'all',
     // timebarGraph: '',
   },
   ownerId: 0,

--- a/applications/fishing-map/src/features/app/app.selectors.ts
+++ b/applications/fishing-map/src/features/app/app.selectors.ts
@@ -16,9 +16,9 @@ import {
 } from 'routes/routes.selectors'
 import {
   BivariateDataviews,
-  TimebarEvents,
   TimebarGraphs,
   TimebarVisualisations,
+  VisibleEvents,
   WorkspaceActivityCategory,
   WorkspaceAnalysis,
   WorkspaceState,
@@ -121,10 +121,10 @@ export const selectTimebarVisualisation = createSelector(
   }
 )
 
-export const selectTimebarEvents = createSelector(
-  [selectWorkspaceStateProperty('timebarEvents')],
-  (timebarEvents): TimebarEvents => {
-    return timebarEvents
+export const selectVisibleEvents = createSelector(
+  [selectWorkspaceStateProperty('visibleEvents')],
+  (visibleEvents): VisibleEvents => {
+    return visibleEvents
   }
 )
 
@@ -140,7 +140,7 @@ export const selectWorkspaceAppState = createSelector(
     selectBivariateDataviews,
     selectSidebarOpen,
     selectTimebarVisualisation,
-    selectTimebarEvents,
+    selectVisibleEvents,
     selectTimebarGraph,
     selectActivityCategory,
   ],
@@ -148,7 +148,7 @@ export const selectWorkspaceAppState = createSelector(
     bivariateDataviews,
     sidebarOpen,
     timebarVisualisation,
-    timebarEvents,
+    visibleEvents,
     timebarGraph,
     activityCategory
   ) => {
@@ -156,7 +156,7 @@ export const selectWorkspaceAppState = createSelector(
       bivariateDataviews,
       sidebarOpen,
       timebarVisualisation,
-      timebarEvents,
+      visibleEvents,
       timebarGraph,
       activityCategory,
     }

--- a/applications/fishing-map/src/features/map/Map.tsx
+++ b/applications/fishing-map/src/features/map/Map.tsx
@@ -190,8 +190,14 @@ const MapWrapper = (): React.ReactElement | null => {
     (state) => {
       // The default implementation of getCursor returns 'pointer' if isHovering, 'grabbing' if isDragging and 'grab' otherwise.
       if (state.isHovering && hoveredTooltipEvent) {
+        // Workaround to fix cluster events duplicated, only working for encounters and needs
+        // TODO if wanted to scale it to other layers
+        const clusterConfig = dataviews.find((d) => d.config?.type === Generators.Type.TileCluster)
+        const eventsCount = clusterConfig?.config?.duplicatedEventsWorkaround ? 2 : 1
+
         const isCluster = hoveredTooltipEvent.features.find(
-          (f) => f.type === Generators.Type.TileCluster && parseInt(f.properties.count) > 1
+          (f) =>
+            f.type === Generators.Type.TileCluster && parseInt(f.properties.count) > eventsCount
         )
         if (isCluster) {
           return encounterSourceLoaded ? 'zoom-in' : 'progress'
@@ -199,7 +205,7 @@ const MapWrapper = (): React.ReactElement | null => {
         const isVesselSingleFeatureEvent =
           hoveredTooltipEvent.features.find((f) => f.category === DataviewCategory.Vessels) !==
           undefined
-        if (isVesselSingleFeatureEvent && hoveredTooltipEvent.features?.length === 1) {
+        if (isVesselSingleFeatureEvent && hoveredTooltipEvent.features?.length === eventsCount) {
           return 'grab'
         }
         return 'pointer'
@@ -208,7 +214,7 @@ const MapWrapper = (): React.ReactElement | null => {
       }
       return 'grab'
     },
-    [hoveredTooltipEvent, encounterSourceLoaded]
+    [hoveredTooltipEvent, encounterSourceLoaded, dataviews]
   )
 
   useEffect(() => {

--- a/applications/fishing-map/src/features/map/map.hooks.ts
+++ b/applications/fishing-map/src/features/map/map.hooks.ts
@@ -35,7 +35,7 @@ import {
 import {
   setClickedEvent,
   selectClickedEvent,
-  MAX_TOOLTIP_VESSELS,
+  MAX_TOOLTIP_LIST,
   fetchEncounterEventThunk,
   SliceInteractionEvent,
   selectFishingInteractionStatus,
@@ -370,9 +370,9 @@ export const parseMapTooltipEvent = (
 
     if (feature.vessels) {
       tooltipEventFeature.vesselsInfo = {
-        vessels: feature.vessels.slice(0, MAX_TOOLTIP_VESSELS),
+        vessels: feature.vessels.slice(0, MAX_TOOLTIP_LIST),
         numVessels: feature.vessels.length,
-        overflow: feature.vessels.length > MAX_TOOLTIP_VESSELS,
+        overflow: feature.vessels.length > MAX_TOOLTIP_LIST,
       }
     }
     return tooltipEventFeature

--- a/applications/fishing-map/src/features/map/map.hooks.ts
+++ b/applications/fishing-map/src/features/map/map.hooks.ts
@@ -153,10 +153,11 @@ export const useClickedEventConnect = () => {
     }
 
     // When hovering in a vessel event we don't want to have clicked events
-    const isVesselSingleFeatureEvent =
-      event.features.find((f) => f.generatorType === Generators.Type.VesselEvents) !== undefined
+    const areAllFeaturesVesselEvents = event.features.every(
+      (f) => f.generatorType === Generators.Type.VesselEvents
+    )
 
-    if (isVesselSingleFeatureEvent && event.features?.length === 1) {
+    if (areAllFeaturesVesselEvents) {
       return
     }
 

--- a/applications/fishing-map/src/features/map/map.selectors.ts
+++ b/applications/fishing-map/src/features/map/map.selectors.ts
@@ -14,7 +14,8 @@ import {
   selectDefaultBasemapGenerator,
 } from 'features/dataviews/dataviews.selectors'
 import { selectCurrentWorkspacesList } from 'features/workspaces-list/workspaces-list.selectors'
-import { selectResources, ResourcesState } from 'features/resources/resources.slice'
+import { ResourcesState } from 'features/resources/resources.slice'
+import { selectVisibleResources } from 'features/resources/resources.selectors'
 import { DebugOptions, selectDebugOptions } from 'features/debug/debug.slice'
 import { selectRulers } from 'features/map/rulers/rulers.slice'
 import {
@@ -91,7 +92,7 @@ const getGeneratorsConfig = ({
 const selectMapGeneratorsConfig = createSelector(
   [
     selectDataviewInstancesResolvedVisible,
-    selectResources,
+    selectVisibleResources,
     selectRulers,
     selectDebugOptions,
     selectHighlightedTime,
@@ -123,7 +124,7 @@ const selectMapGeneratorsConfig = createSelector(
 const selectStaticGeneratorsConfig = createSelector(
   [
     selectDataviewInstancesResolvedVisible,
-    selectResources,
+    selectVisibleResources,
     selectRulers,
     selectDebugOptions,
     selectBivariateDataviews,

--- a/applications/fishing-map/src/features/map/map.slice.ts
+++ b/applications/fishing-map/src/features/map/map.slice.ts
@@ -23,7 +23,7 @@ import {
 import { fetchDatasetByIdThunk, selectDatasetById } from 'features/datasets/datasets.slice'
 import { selectUserLogged } from 'features/user/user.slice'
 
-export const MAX_TOOLTIP_VESSELS = 5
+export const MAX_TOOLTIP_LIST = 5
 
 export type ExtendedFeatureVessel = {
   id: string
@@ -169,7 +169,7 @@ export const fetchFishingActivityInteractionThunk = createAsyncThunk<
           return source
             .flatMap((source) => source)
             .sort((a, b) => b.hours - a.hours)
-            .slice(0, MAX_TOOLTIP_VESSELS)
+            .slice(0, MAX_TOOLTIP_LIST)
         })
         .flatMap((v) => v)
 

--- a/applications/fishing-map/src/features/map/popups/PopupWrapper.tsx
+++ b/applications/fishing-map/src/features/map/popups/PopupWrapper.tsx
@@ -123,7 +123,7 @@ function PopupWrapper({
               if (type === 'click') {
                 return null
               }
-              return <VesselEventsLayers features={features} />
+              return <VesselEventsLayers key={featureCategory} features={features} />
 
             default:
               return null

--- a/applications/fishing-map/src/features/map/popups/VesselEventsLayers.tsx
+++ b/applications/fishing-map/src/features/map/popups/VesselEventsLayers.tsx
@@ -13,7 +13,7 @@ type ContextTooltipRowProps = {
   features: TooltipEventFeature[]
 }
 
-function EnvironmentTooltipSection({ features }: ContextTooltipRowProps) {
+function VesselEventsTooltipSection({ features }: ContextTooltipRowProps) {
   const { t } = useTranslation()
   const featuresByType = groupBy(features, 'layerId')
   return (
@@ -30,7 +30,7 @@ function EnvironmentTooltipSection({ features }: ContextTooltipRowProps) {
                 .diff(DateTime.fromISO(feature.properties.start), ['hours', 'minutes', 'seconds'])
                 .toObject()
               return (
-                <Fragment>
+                <Fragment key={index}>
                   <div className={styles.row}>
                     <span className={styles.rowText}>
                       {formatI18nDate(feature.properties.start, { format: DateTime.DATETIME_FULL })}{' '}
@@ -58,4 +58,4 @@ function EnvironmentTooltipSection({ features }: ContextTooltipRowProps) {
   )
 }
 
-export default EnvironmentTooltipSection
+export default VesselEventsTooltipSection

--- a/applications/fishing-map/src/features/map/popups/VesselEventsLayers.tsx
+++ b/applications/fishing-map/src/features/map/popups/VesselEventsLayers.tsx
@@ -4,6 +4,7 @@ import { groupBy } from 'lodash'
 import { DateTime } from 'luxon'
 import { TooltipEventFeature } from 'features/map/map.hooks'
 import { formatI18nDate } from 'features/i18n/i18nDate'
+import { MAX_TOOLTIP_LIST } from '../map.slice'
 import styles from './Popup.module.css'
 
 // t('event.fishing', 'Fished for')
@@ -15,7 +16,9 @@ type ContextTooltipRowProps = {
 
 function VesselEventsTooltipSection({ features }: ContextTooltipRowProps) {
   const { t } = useTranslation()
-  const featuresByType = groupBy(features, 'layerId')
+  const overflows = features?.length > MAX_TOOLTIP_LIST
+  const maxFeatures = overflows ? features.slice(0, MAX_TOOLTIP_LIST) : features
+  const featuresByType = groupBy(maxFeatures, 'layerId')
   return (
     <Fragment>
       {Object.values(featuresByType).map((featureByType, index) => (
@@ -51,6 +54,12 @@ function VesselEventsTooltipSection({ features }: ContextTooltipRowProps) {
                 </Fragment>
               )
             })}
+
+            {overflows && (
+              <div className={styles.vesselsMore}>
+                + {features.length - MAX_TOOLTIP_LIST} {t('common.more', 'more')}
+              </div>
+            )}
           </div>
         </div>
       ))}

--- a/applications/fishing-map/src/features/resources/resources.selectors.ts
+++ b/applications/fishing-map/src/features/resources/resources.selectors.ts
@@ -9,6 +9,24 @@ import { Generators } from '@globalfishingwatch/layer-composer'
 import { selectDataviewInstancesResolved } from 'features/dataviews/dataviews.selectors'
 import { isGuestUser } from 'features/user/user.selectors'
 import { selectDebugOptions } from 'features/debug/debug.slice'
+import { selectVisibleEvents } from 'features/app/app.selectors'
+import { selectResources } from './resources.slice'
+
+export const selectVisibleResources = createSelector(
+  [selectResources, selectVisibleEvents],
+  (resources, visibleEvents) => {
+    if (visibleEvents === 'all') {
+      return resources
+    }
+    return Object.fromEntries(
+      Object.entries(resources).filter(([url, resource]) => {
+        return url.includes('events') && resource.dataset?.configuration?.type
+          ? visibleEvents.includes(resource.dataset.configuration.type)
+          : true
+      })
+    )
+  }
+)
 
 const getVesselResourceQuery = (
   dataview: UrlDataviewInstance<Generators.Type>,

--- a/applications/fishing-map/src/features/timebar/TimebarSettings.tsx
+++ b/applications/fishing-map/src/features/timebar/TimebarSettings.tsx
@@ -59,20 +59,28 @@ const TimebarSettings = () => {
         label: t('timebarSettings.eventOptions.fishing', 'Fishing'),
       },
       {
-        id: 'encounter',
-        label: t('timebarSettings.eventOptions.encounters', 'Encounters'),
-      },
-      {
         id: 'loitering',
         label: t('timebarSettings.eventOptions.loitering', 'Loitering'),
       },
       {
-        id: 'port',
-        label: t('timebarSettings.eventOptions.ports', 'Port visits'),
-      },
-      {
         id: 'none',
         label: t('timebarSettings.eventOptions.none', 'None'),
+      },
+      {
+        id: 'encounter',
+        label: `${t('timebarSettings.eventOptions.encounters', 'Encounters')} (${t(
+          'common.comingSoon',
+          'Coming soon'
+        )})`,
+        disabled: true,
+      },
+      {
+        id: 'port',
+        label: `${t('timebarSettings.eventOptions.ports', 'Port visits')} (${t(
+          'common.comingSoon',
+          'Coming soon'
+        )})`,
+        disabled: true,
       },
     ],
     [t]

--- a/applications/fishing-map/src/features/timebar/TimebarSettings.tsx
+++ b/applications/fishing-map/src/features/timebar/TimebarSettings.tsx
@@ -7,13 +7,13 @@ import IconButton from '@globalfishingwatch/ui-components/dist/icon-button'
 import Radio from '@globalfishingwatch/ui-components/dist/radio'
 import Select, { SelectOption } from '@globalfishingwatch/ui-components/dist/select'
 import useClickedOutside from 'hooks/use-clicked-outside'
-import { TimebarEvents, TimebarGraphs, TimebarVisualisations } from 'types'
+import { TimebarGraphs, TimebarVisualisations } from 'types'
 import {
   selectActiveActivityDataviews,
   selectActiveTrackDataviews,
   selectActiveVesselsDataviews,
 } from 'features/dataviews/dataviews.selectors'
-import { selectTimebarEvents, selectTimebarGraph } from 'features/app/app.selectors'
+import { selectTimebarGraph } from 'features/app/app.selectors'
 import { useLocationConnect } from 'routes/routes.hook'
 import { getEventLabel } from 'utils/analytics'
 import { useTimebarVisualisation } from './timebar.hooks'
@@ -25,7 +25,6 @@ const TimebarSettings = () => {
   const activeHeatmapDataviews = useSelector(selectActiveActivityDataviews)
   const activeTrackDataviews = useSelector(selectActiveTrackDataviews)
   const activeVesselsDataviews = useSelector(selectActiveVesselsDataviews)
-  const timebarEvents = useSelector(selectTimebarEvents)
   const timebarGraph = useSelector(selectTimebarGraph)
   const { dispatchQueryParams } = useLocationConnect()
   const { timebarVisualisation, dispatchTimebarVisualisation } = useTimebarVisualisation()
@@ -48,43 +47,6 @@ const TimebarSettings = () => {
     ],
     [t]
   )
-  const TIMEBAR_EVENT_OPTIONS: SelectOption<TimebarEvents>[] = useMemo(
-    () => [
-      {
-        id: 'all',
-        label: t('timebarSettings.eventOptions.all', 'All events'),
-      },
-      {
-        id: 'fishing',
-        label: t('timebarSettings.eventOptions.fishing', 'Fishing'),
-      },
-      {
-        id: 'loitering',
-        label: t('timebarSettings.eventOptions.loitering', 'Loitering'),
-      },
-      {
-        id: 'none',
-        label: t('timebarSettings.eventOptions.none', 'None'),
-      },
-      {
-        id: 'encounter',
-        label: `${t('timebarSettings.eventOptions.encounters', 'Encounters')} (${t(
-          'common.comingSoon',
-          'Coming soon'
-        )})`,
-        disabled: true,
-      },
-      {
-        id: 'port',
-        label: `${t('timebarSettings.eventOptions.ports', 'Port visits')} (${t(
-          'common.comingSoon',
-          'Coming soon'
-        )})`,
-        disabled: true,
-      },
-    ],
-    [t]
-  )
 
   const openOptions = () => {
     uaEvent({
@@ -103,16 +65,10 @@ const TimebarSettings = () => {
   const setVesselActive = () => {
     dispatchTimebarVisualisation(TimebarVisualisations.Vessel)
   }
-  const setEventsOption = (o: SelectOption) => {
-    dispatchQueryParams({ timebarEvents: o.id as TimebarEvents })
-  }
   const setGraphOption = (o: SelectOption) => {
     if (!o.label.includes('Coming soon')) {
       dispatchQueryParams({ timebarGraph: o.id as TimebarGraphs })
     }
-  }
-  const removeEventsOption = () => {
-    dispatchQueryParams({ timebarEvents: 'none' })
   }
   const removeGraphOption = () => {
     dispatchQueryParams({ timebarGraph: TimebarGraphs.None })
@@ -164,14 +120,6 @@ const TimebarSettings = () => {
               activeVesselsDataviews &&
               activeVesselsDataviews.length > 0 && (
                 <div className={styles.vesselTrackOptions}>
-                  <Select
-                    label={t('common.events', 'Events')}
-                    options={TIMEBAR_EVENT_OPTIONS}
-                    selectedOption={TIMEBAR_EVENT_OPTIONS.find((o) => o.id === timebarEvents)}
-                    onSelect={setEventsOption}
-                    onRemove={removeEventsOption}
-                    direction="top"
-                  />
                   {timebarGraphEnabled && (
                     <Select
                       label={t('timebarSettings.graph', 'Graph')}

--- a/applications/fishing-map/src/features/workspace/vessels/VesselEventsLegend.tsx
+++ b/applications/fishing-map/src/features/workspace/vessels/VesselEventsLegend.tsx
@@ -1,0 +1,89 @@
+import React, { useCallback } from 'react'
+import { uniqBy } from 'lodash'
+import { useTranslation } from 'react-i18next'
+import { useSelector } from 'react-redux'
+import type { UrlDataviewInstance } from '@globalfishingwatch/dataviews-client'
+import { EventType } from '@globalfishingwatch/api-types'
+import { EVENTS_COLORS } from 'data/config'
+import { selectVisibleEvents } from 'features/app/app.selectors'
+import styles from 'features/workspace/shared/Sections.module.css'
+import { getEventsDatasetsInDataview } from 'features/datasets/datasets.utils'
+import { useLocationConnect } from 'routes/routes.hook'
+import layerStyles from './VesselSection.module.css'
+
+type VesselEventsLegendProps = {
+  dataviews: UrlDataviewInstance[]
+}
+
+function VesselEventsLegend({ dataviews }: VesselEventsLegendProps): React.ReactElement | null {
+  const { t } = useTranslation()
+  const currentVisibleEvents = useSelector(selectVisibleEvents)
+  const { dispatchQueryParams } = useLocationConnect()
+  const eventDatasets = uniqBy(
+    dataviews.flatMap((dataview) => getEventsDatasetsInDataview(dataview)),
+    'id'
+  )
+  const allEventTypes = eventDatasets.flatMap((dataset) => dataset.configuration?.type || [])
+  const showLegend =
+    eventDatasets && eventDatasets?.length > 0 && dataviews.some((d) => d.config?.visible)
+
+  const onEventChange = useCallback(
+    (event: React.ChangeEvent<HTMLInputElement>) => {
+      // TODO add or remove depending on state
+      const checked = event.target.checked
+      const eventTypeChanged = event.target.id as EventType
+      if (checked) {
+        const visibleEvents =
+          currentVisibleEvents === 'all'
+            ? allEventTypes.filter((eventType) => eventType !== eventTypeChanged)
+            : [...currentVisibleEvents, eventTypeChanged]
+        dispatchQueryParams({ visibleEvents })
+      } else {
+        const currentVisibleEventsTypes =
+          currentVisibleEvents === 'all' ? allEventTypes : currentVisibleEvents
+        const visibleEvents = currentVisibleEventsTypes.filter(
+          (eventType) => eventTypeChanged !== eventType
+        )
+        dispatchQueryParams({ visibleEvents })
+      }
+    },
+    [dispatchQueryParams, allEventTypes, currentVisibleEvents]
+  )
+
+  if (!showLegend) {
+    return null
+  }
+
+  return (
+    <div className={styles.content}>
+      <ul className={layerStyles.eventsLegendContainer}>
+        {eventDatasets.map((dataset) => {
+          const eventType = dataset.configuration?.type
+          if (!eventType) return null
+          return (
+            <li
+              key={dataset.id}
+              className={layerStyles.eventsLegend}
+              style={{ color: EVENTS_COLORS[eventType] }}
+            >
+              <input
+                id={eventType}
+                type="checkbox"
+                onChange={onEventChange}
+                className={layerStyles.eventLegendCheckbox}
+                checked={
+                  currentVisibleEvents === 'all' ? true : currentVisibleEvents.includes(eventType)
+                }
+              />
+              <label className={layerStyles.eventLegendLabel} htmlFor={eventType}>
+                {t(`event.${eventType}` as any, eventType)}
+              </label>
+            </li>
+          )
+        })}
+      </ul>
+    </div>
+  )
+}
+
+export default VesselEventsLegend

--- a/applications/fishing-map/src/features/workspace/vessels/VesselSection.module.css
+++ b/applications/fishing-map/src/features/workspace/vessels/VesselSection.module.css
@@ -7,6 +7,22 @@
 .eventsLegend {
   display: flex;
   align-items: center;
+  position: relative;
+}
+
+.eventsLegend::before {
+  content: '';
+  position: absolute;
+  top: 0.4rem;
+  left: 0;
+  display: block;
+  width: 1rem;
+  height: 1rem;
+  z-index: 1;
+  border-radius: 1rem;
+  border: var(--border);
+  background-color: currentColor;
+  pointer-events: none;
 }
 
 .eventLegendIcon {
@@ -18,6 +34,20 @@
   border: var(--border);
 }
 
+.eventLegendCheckbox {
+  opacity: 0;
+  cursor: pointer;
+}
+
 .eventLegendLabel {
+  cursor: pointer;
+  position: relative;
+  padding-left: 0.5rem;
   font: var(--font-S);
+  text-transform: capitalize;
+}
+
+.eventLegendCheckbox:not(:checked) + .eventLegendLabel {
+  opacity: var(--opacity-secondary);
+  text-decoration: line-through;
 }

--- a/applications/fishing-map/src/features/workspace/vessels/VesselsSection.tsx
+++ b/applications/fishing-map/src/features/workspace/vessels/VesselsSection.tsx
@@ -1,18 +1,15 @@
 import React, { useCallback } from 'react'
 import { useSelector } from 'react-redux'
 import cx from 'classnames'
-import { uniqBy } from 'lodash'
 import { event as uaEvent } from 'react-ga'
 import { useTranslation } from 'react-i18next'
 import { IconButton } from '@globalfishingwatch/ui-components'
-import { EVENTS_COLORS } from 'data/config'
 import { useLocationConnect } from 'routes/routes.hook'
 import { selectVesselsDataviews } from 'features/dataviews/dataviews.selectors'
 import styles from 'features/workspace/shared/Sections.module.css'
 import { isBasicSearchAllowed } from 'features/search/search.selectors'
-import { getEventsDatasetsInDataview } from 'features/datasets/datasets.utils'
+import VesselEventsLegend from './VesselEventsLegend'
 import VesselLayerPanel from './VesselLayerPanel'
-import layerStyles from './VesselSection.module.css'
 
 function VesselsSection(): React.ReactElement {
   const { t } = useTranslation()
@@ -20,12 +17,6 @@ function VesselsSection(): React.ReactElement {
   const dataviews = useSelector(selectVesselsDataviews)
   const hasVisibleDataviews = dataviews?.some((dataview) => dataview.config?.visible === true)
   const searchAllowed = useSelector(isBasicSearchAllowed)
-  const eventDatasets = uniqBy(
-    dataviews.flatMap((dataview) => getEventsDatasetsInDataview(dataview)),
-    'id'
-  )
-  const showLegend =
-    eventDatasets && eventDatasets?.length > 0 && dataviews.some((d) => d.config?.visible)
 
   const onSearchClick = useCallback(() => {
     uaEvent({
@@ -57,33 +48,7 @@ function VesselsSection(): React.ReactElement {
       {dataviews?.map((dataview) => (
         <VesselLayerPanel key={dataview.id} dataview={dataview} />
       ))}
-      {showLegend && (
-        <div className={styles.content}>
-          <ul className={layerStyles.eventsLegendContainer}>
-            {eventDatasets.map((dataset) => {
-              const eventType = dataset.configuration?.type
-              if (!eventType) return null
-              return (
-                <li
-                  key={dataset.id}
-                  className={layerStyles.eventsLegend}
-                  style={{ color: EVENTS_COLORS[eventType] }}
-                >
-                  <input
-                    type="checkbox"
-                    defaultChecked
-                    className={layerStyles.eventLegendCheckbox}
-                    id={eventType}
-                  />
-                  <label className={layerStyles.eventLegendLabel} htmlFor={eventType}>
-                    {t(`event.${eventType}` as any, eventType)}
-                  </label>
-                </li>
-              )
-            })}
-          </ul>
-        </div>
-      )}
+      <VesselEventsLegend dataviews={dataviews} />
     </div>
   )
 }

--- a/applications/fishing-map/src/features/workspace/vessels/VesselsSection.tsx
+++ b/applications/fishing-map/src/features/workspace/vessels/VesselsSection.tsx
@@ -64,14 +64,20 @@ function VesselsSection(): React.ReactElement {
               const eventType = dataset.configuration?.type
               if (!eventType) return null
               return (
-                <li className={layerStyles.eventsLegend} key={dataset.id}>
-                  <span
-                    className={layerStyles.eventLegendIcon}
-                    style={{ backgroundColor: EVENTS_COLORS[eventType] }}
-                  ></span>
-                  <span className={layerStyles.eventLegendLabel}>
+                <li
+                  key={dataset.id}
+                  className={layerStyles.eventsLegend}
+                  style={{ color: EVENTS_COLORS[eventType] }}
+                >
+                  <input
+                    type="checkbox"
+                    defaultChecked
+                    className={layerStyles.eventLegendCheckbox}
+                    id={eventType}
+                  />
+                  <label className={layerStyles.eventLegendLabel} htmlFor={eventType}>
                     {t(`event.${eventType}` as any, eventType)}
-                  </span>
+                  </label>
                 </li>
               )
             })}

--- a/applications/fishing-map/src/types/index.ts
+++ b/applications/fishing-map/src/types/index.ts
@@ -18,7 +18,7 @@ export type WorkspaceStateProperty =
   | 'sidebarOpen'
   | 'dataviewInstances'
   | 'timebarVisualisation'
-  | 'timebarEvents'
+  | 'visibleEvents'
   | 'timebarGraph'
   | 'bivariateDataviews'
   | 'version'
@@ -49,7 +49,7 @@ export type WorkspaceState = {
   analysis?: WorkspaceAnalysis
   dataviewInstances?: Partial<UrlDataviewInstance[]>
   timebarVisualisation?: TimebarVisualisations
-  timebarEvents?: TimebarEvents
+  visibleEvents?: VisibleEvents
   timebarGraph?: TimebarGraphs
   bivariateDataviews?: BivariateDataviews
   activityCategory?: WorkspaceActivityCategory
@@ -68,7 +68,7 @@ export enum TimebarVisualisations {
   Vessel = 'vessel',
 }
 
-export type TimebarEvents = EventType | 'all' | 'none'
+export type VisibleEvents = EventType[] | 'all'
 
 export enum TimebarGraphs {
   Speed = 'speed',

--- a/packages/layer-composer/src/generators/tile-cluster/tile-cluster.ts
+++ b/packages/layer-composer/src/generators/tile-cluster/tile-cluster.ts
@@ -56,7 +56,7 @@ class TileClusterGenerator {
         type: 'circle',
         source: config.id,
         'source-layer': 'points',
-        filter: ['>', ['get', 'count'], 1],
+        filter: ['>', ['get', 'count'], config.duplicatedEventsWorkaround ? 2 : 1],
         paint: {
           'circle-radius': [
             'interpolate',
@@ -82,11 +82,13 @@ class TileClusterGenerator {
         type: 'symbol',
         source: config.id,
         'source-layer': 'points',
-        filter: ['>', ['get', 'count'], 1],
+        filter: ['>', ['get', 'count'], config.duplicatedEventsWorkaround ? 2 : 1],
         layout: {
           'text-size': 14,
           'text-offset': [0, 0.13],
-          'text-field': ['get', 'count'],
+          'text-field': config.duplicatedEventsWorkaround
+            ? ['to-string', ['/', ['number', ['get', 'count']], 2]]
+            : ['get', 'count'],
           'text-font': ['Roboto Medium'],
           'text-allow-overlap': true,
         },
@@ -103,7 +105,7 @@ class TileClusterGenerator {
         type: 'circle',
         source: config.id,
         'source-layer': 'points',
-        filter: ['==', ['get', 'count'], 1],
+        filter: ['<=', ['get', 'count'], config.duplicatedEventsWorkaround ? 2 : 1],
         paint: {
           'circle-color': config.color || '#FAE9A0',
           'circle-radius': 5,
@@ -113,6 +115,7 @@ class TileClusterGenerator {
         metadata: {
           interactive: true,
           generatorId: config.id,
+          uniqueFeatureInteraction: config.duplicatedEventsWorkaround ? true : false,
           group: Group.Cluster,
         },
       },

--- a/packages/layer-composer/src/generators/types.ts
+++ b/packages/layer-composer/src/generators/types.ts
@@ -165,6 +165,10 @@ export interface TileClusterGeneratorConfig extends GeneratorConfig {
    * List of datasets to retrieve the data from, optional to allow using resolved url params directly (eg: using resolve-endpoints)
    */
   dataset?: string
+  /**
+   * Uses a workaround when having duplicated events to show only 1 event
+   */
+  duplicatedEventsWorkaround?: boolean
 }
 
 /**


### PR DESCRIPTION
- Move events filtering interaction from timebar to the sidebar vessel section to also disable them in the map:
![image](https://user-images.githubusercontent.com/10500650/124615091-3532e580-de75-11eb-809c-06276f459c64.png)

- Include encounters workaround to fix the doubled event for every point
Before: 
![image](https://user-images.githubusercontent.com/10500650/124615367-7cb97180-de75-11eb-82ad-693caa903806.png)
![image](https://user-images.githubusercontent.com/10500650/124615363-7b884480-de75-11eb-9c86-9ef88fc527b1.png)
Now:
![image](https://user-images.githubusercontent.com/10500650/124615164-4976e280-de75-11eb-8011-a62d4979f4c9.png)
![image](https://user-images.githubusercontent.com/10500650/124615428-8e027e00-de75-11eb-9f41-8ef25c899e4a.png)

- Reuse `MAX_TOOLTIP_LIST` in vessel events to limit the number of events in the tooltip:
 
![image](https://user-images.githubusercontent.com/10500650/124615063-2cdaaa80-de75-11eb-9487-9d065aaae22e.png)
