### PR TITLE
last 30 days buttons behavior change

### DIFF
--- a/applications/fishing-map/src/data/config.ts
+++ b/applications/fishing-map/src/data/config.ts
@@ -24,7 +24,7 @@ export const FULL_SUFIX = 'full'
 export const PRIVATE_SUFIX = 'private'
 
 // used when no url data and no workspace data
-const end = DateTime.fromObject({ hour: 0, minute: 0, second: 0, zone: 'utc' })
+export const LAST_DATA_UPDATE = DateTime.fromObject({ hour: 0, minute: 0, second: 0, zone: 'utc' })
   .minus({ days: 3 })
   .toISO()
 
@@ -34,8 +34,8 @@ export const DEFAULT_VIEWPORT = {
   zoom: 1,
 }
 export const DEFAULT_TIME_RANGE = {
-  start: DateTime.fromISO(end).minus({ months: 3 }).toISO(),
-  end,
+  start: DateTime.fromISO(LAST_DATA_UPDATE).minus({ months: 3 }).toISO(),
+  end: LAST_DATA_UPDATE,
 }
 
 export const DEFAULT_ACTIVITY_CATEGORY = 'fishing'

--- a/applications/fishing-map/src/features/timebar/Timebar.tsx
+++ b/applications/fishing-map/src/features/timebar/Timebar.tsx
@@ -17,7 +17,7 @@ import {
   useHighlightEventConnect,
   useDisableHighlightTimeConnect,
 } from 'features/timebar/timebar.hooks'
-import { DEFAULT_WORKSPACE } from 'data/config'
+import { DEFAULT_WORKSPACE, LAST_DATA_UPDATE } from 'data/config'
 import { TimebarVisualisations, TimebarGraphs } from 'types'
 import useViewport from 'features/map/map-viewport.hooks'
 import { selectActivityCategory, selectTimebarGraph } from 'features/app/app.selectors'
@@ -194,6 +194,7 @@ const TimebarWrapper = () => {
         end={internalRange ? internalRange.end : end}
         absoluteStart={DEFAULT_WORKSPACE.availableStart}
         absoluteEnd={DEFAULT_WORKSPACE.availableEnd}
+        latestAvailableDataDate={LAST_DATA_UPDATE}
         onChange={onChange}
         showLastUpdate={false}
         onMouseMove={onMouseMove}

--- a/packages/timebar/src/components/timeline.js
+++ b/packages/timebar/src/components/timeline.js
@@ -213,12 +213,17 @@ class Timeline extends PureComponent {
     const x = clientX - outerX
     const isMovingInside = this.node.contains(event.target) && x > innerStartPx && x < innerEndPx
     const isNodeInside = event.target.contains(this.node)
-    
+
     const isDraggingInner = dragging === DRAG_INNER
     const isDraggingZoomIn = this.isHandlerZoomInValid(x).isValid === true
     const isDraggingZoomOut = this.isHandlerZoomOutValid(x) === true
 
-    if ((isMovingInside || isNodeInside) && !isDraggingInner && !isDraggingZoomIn && !isDraggingZoomOut) {
+    if (
+      (isMovingInside || isNodeInside) &&
+      !isDraggingInner &&
+      !isDraggingZoomIn &&
+      !isDraggingZoomOut
+    ) {
       const isDay = !isMoreThanADay(start, end)
       this.throttledMouseMove(x, this.outerScale.invert, isDay)
     } else {
@@ -312,8 +317,8 @@ class Timeline extends PureComponent {
   }
 
   onLast30DaysClick() {
-    const { onChange } = this.props
-    const { start, end } = getLast30Days()
+    const { onChange, latestAvailableDataDate } = this.props
+    const { start, end } = getLast30Days(latestAvailableDataDate)
     onChange(start, end)
   }
 
@@ -354,7 +359,7 @@ class Timeline extends PureComponent {
     const svgTransform = this.getSvgTransform(overallScale, start, end, innerWidth, innerStartPx)
 
     const lastUpdatePosition = this.outerScale(new Date(absoluteEnd))
-    const isInTheFuture = new Date(start) > Date.now()
+    const isInTheFuture = new Date(start) > new Date(this.props.latestAvailableDataDate)
 
     return (
       <TimelineContext.Provider
@@ -522,6 +527,7 @@ Timeline.propTypes = {
   end: PropTypes.string.isRequired,
   absoluteStart: PropTypes.string.isRequired,
   absoluteEnd: PropTypes.string.isRequired,
+  latestAvailableDataDate: PropTypes.string.isRequired,
   onBookmarkChange: PropTypes.func,
   bookmarkStart: PropTypes.string,
   bookmarkEnd: PropTypes.string,

--- a/packages/timebar/src/components/timerange-selector.js
+++ b/packages/timebar/src/components/timerange-selector.js
@@ -64,8 +64,8 @@ class TimeRangeSelector extends Component {
   }
 
   last30days = () => {
-    const { onSubmit } = this.props
-    const { start, end } = getLast30Days()
+    const { onSubmit, latestAvailableDataDate } = this.props
+    const { start, end } = getLast30Days(latestAvailableDataDate)
     onSubmit(start, end)
   }
 
@@ -189,6 +189,7 @@ TimeRangeSelector.propTypes = {
   end: PropTypes.string.isRequired,
   absoluteStart: PropTypes.string.isRequired,
   absoluteEnd: PropTypes.string.isRequired,
+  latestAvailableDataDate: PropTypes.string.isRequired,
   onDiscard: PropTypes.func.isRequired,
   labels: PropTypes.shape({
     title: PropTypes.string,

--- a/packages/timebar/src/timebar.js
+++ b/packages/timebar/src/timebar.js
@@ -272,6 +272,7 @@ class Timebar extends Component {
                 absoluteEnd={absoluteEnd}
                 onSubmit={this.onTimeRangeSelectorSubmit}
                 onDiscard={this.toggleTimeRangeSelector}
+                latestAvailableDataDate={this.props.latestAvailableDataDate}
               />
             )}
             <div className={cx('print-hidden', styles.timeRangeContainer)}>
@@ -335,6 +336,7 @@ class Timebar extends Component {
             bookmarkEnd={bookmarkEnd}
             bookmarkPlacement={bookmarkPlacement}
             showLastUpdate={this.props.showLastUpdate}
+            latestAvailableDataDate={this.props.latestAvailableDataDate}
           />
         </div>
       </ImmediateContext.Provider>
@@ -390,6 +392,7 @@ Timebar.propTypes = {
   onBookmarkChange: PropTypes.func,
   absoluteStart: PropTypes.string.isRequired,
   absoluteEnd: PropTypes.string.isRequired,
+  latestAvailableDataDate: PropTypes.string,
   enablePlayback: PropTypes.bool,
   onTogglePlay: PropTypes.func,
   minimumRange: PropTypes.number,
@@ -400,6 +403,7 @@ Timebar.propTypes = {
 }
 
 Timebar.defaultProps = {
+  latestAvailableDataDate: new Date().toISOString(),
   labels: {
     playback: {
       playAnimation: 'Play animation',

--- a/packages/timebar/src/utils/index.js
+++ b/packages/timebar/src/utils/index.js
@@ -59,9 +59,9 @@ export const geoJSONTrackToTimebarFeatureSegments = ({ features = [] } = {}) => 
   return graph
 }
 
-export const getLast30Days = () => {
+export const getLast30Days = (latestAvailableDataDate) => {
   return {
-    start: dayjs(new Date()).utc().subtract(30, 'day').toISOString(),
-    end: dayjs(new Date()).utc().toISOString(),
+    start: dayjs(new Date(latestAvailableDataDate)).utc().subtract(30, 'day').toISOString(),
+    end: dayjs(new Date(latestAvailableDataDate)).utc().toISOString(),
   }
 }

--- a/packages/timebar/types/components/timeline.d.ts
+++ b/packages/timebar/types/components/timeline.d.ts
@@ -41,6 +41,7 @@ declare namespace Timeline {
         const end: any;
         const absoluteStart: any;
         const absoluteEnd: any;
+        const latestAvailableDataDate: any;
         const onBookmarkChange: any;
         const bookmarkStart: any;
         const bookmarkEnd: any;

--- a/packages/timebar/types/components/timerange-selector.d.ts
+++ b/packages/timebar/types/components/timerange-selector.d.ts
@@ -12,6 +12,7 @@ declare namespace TimeRangeSelector {
         const end: any;
         const absoluteStart: any;
         const absoluteEnd: any;
+        const latestAvailableDataDate: any;
         const onDiscard: any;
         const labels: any;
     }

--- a/packages/timebar/types/timebar.d.ts
+++ b/packages/timebar/types/timebar.d.ts
@@ -33,6 +33,7 @@ declare namespace Timebar {
         const onBookmarkChange: any;
         const absoluteStart: any;
         const absoluteEnd: any;
+        const latestAvailableDataDate: any;
         const enablePlayback: any;
         const onTogglePlay: any;
         const minimumRange: any;
@@ -42,6 +43,8 @@ declare namespace Timebar {
         const showLastUpdate: any;
     }
     namespace defaultProps {
+        const latestAvailableDataDate_1: string;
+        export { latestAvailableDataDate_1 as latestAvailableDataDate };
         export namespace labels_1 {
             namespace playback {
                 const playAnimation: string;

--- a/packages/timebar/types/utils/index.d.ts
+++ b/packages/timebar/types/utils/index.d.ts
@@ -10,7 +10,7 @@ export function getTimebarRangeByWorkspace(timeline: any): {
 export function geoJSONTrackToTimebarFeatureSegments({ features }?: {
     features?: any[];
 }): any[][];
-export function getLast30Days(): {
+export function getLast30Days(latestAvailableDataDate: any): {
     start: any;
     end: any;
 };


### PR DESCRIPTION
Allows changing 'last 30 days' button behavior in both time range modal and button in timebar, so that lats 30 days can be counted from another date than 'today'. In fishing-map's case, last 30 days from availability of data (today minus 3 days)

Related to https://globalfishingwatch.atlassian.net/browse/MR-240