### PR TITLE
Fix perf issue on track events hover

### DIFF
--- a/.changeset/stale-hounds-search.md
+++ b/.changeset/stale-hounds-search.md
@@ -1,0 +1,6 @@
+---
+"@globalfishingwatch/dataviews-client": patch
+"@globalfishingwatch/layer-composer": patch
+---
+
+Fix perf issue on track events hover

--- a/packages/dataviews-client/src/resolve-dataviews-generators.ts
+++ b/packages/dataviews-client/src/resolve-dataviews-generators.ts
@@ -127,6 +127,7 @@ export function getGeneratorConfig(
         eventsResources?.length && eventsResources.some(({ url }) => resources?.[url]?.data)
       // const { url: eventsUrl } = resolveDataviewDatasetResource(dataview, DatasetTypes.Events)
       if (hasEventData) {
+        // TODO This flatMap will prevent the corresponding generator to memoize correctly
         const data = eventsResources.flatMap(({ url }) => (url ? resources?.[url]?.data : []))
         const eventsGenerator = {
           id: `${dataview.id}${MULTILAYER_SEPARATOR}vessel_events`,
@@ -134,9 +135,7 @@ export function getGeneratorConfig(
           showIcons: dataview.config?.showIcons,
           data: data,
           color: dataview.config?.color,
-          ...(generator.data && {
-            track: generator.data,
-          }),
+          track: generator.data,
           ...(highlightedEvent && { currentEventId: highlightedEvent.id }),
         }
         return [generator, eventsGenerator]

--- a/packages/layer-composer/src/generators/vessel-events/vessel-events.ts
+++ b/packages/layer-composer/src/generators/vessel-events/vessel-events.ts
@@ -12,9 +12,10 @@ import { DEFAULT_LANDMASS_COLOR } from '../basemap/basemap-layers'
 import { memoizeByLayerId, memoizeCache } from '../../utils'
 import {
   getVesselEventsGeojson,
-  getVesselSegmentsGeojson,
+  getVesselEventsSegmentsGeojson,
   filterGeojsonByTimerange,
   filterFeaturesByTimerange,
+  getVesselEventsSegmentsGeojsonMemoizeEqualityCheck,
 } from './vessel-events.utils'
 
 interface VesselsEventsSource extends GeoJSONSourceRaw {
@@ -59,7 +60,7 @@ class VesselsEventsGenerator {
       return [pointsSource]
     }
 
-    const segments = memoizeCache[config.id].getVesselSegmentsGeojson(
+    const segments = memoizeCache[config.id].getVesselEventsSegmentsGeojson(
       track,
       data
     ) as FeatureCollection
@@ -159,7 +160,11 @@ class VesselsEventsGenerator {
   getStyle = (config: GlobalVesselEventsGeneratorConfig) => {
     memoizeByLayerId(config.id, {
       getVesselEventsGeojson: memoizeOne(getVesselEventsGeojson),
-      getVesselSegmentsGeojson: memoizeOne(getVesselSegmentsGeojson),
+      getVesselEventsSegmentsGeojson: memoizeOne(
+        getVesselEventsSegmentsGeojson,
+        // This is a hack needed because the events array mutates constantly in resolve-dataviews-generators
+        getVesselEventsSegmentsGeojsonMemoizeEqualityCheck
+      ),
       filterGeojsonByTimerange: memoizeOne(filterGeojsonByTimerange),
       filterFeaturesByTimerange: memoizeOne(filterFeaturesByTimerange),
     })

--- a/packages/layer-composer/src/generators/vessel-events/vessel-events.utils.ts
+++ b/packages/layer-composer/src/generators/vessel-events/vessel-events.utils.ts
@@ -115,19 +115,29 @@ export const filterGeojsonByTimerange = (
   return geojsonFiltered
 }
 
-export const getVesselSegmentsGeojson = (track: any, data: RawEvent[]): FeatureCollection => {
+export const getVesselEventsSegmentsGeojsonMemoizeEqualityCheck = (
+  newArgs: any[],
+  lastArgs: any[]
+) => {
+  return newArgs[0].length === lastArgs[0].length && newArgs[1].length === lastArgs[1].length
+}
+
+export const getVesselEventsSegmentsGeojson = (
+  track: any,
+  events: RawEvent[]
+): FeatureCollection => {
   const featureCollection: FeatureCollection = {
     type: 'FeatureCollection',
     features: [],
   }
 
-  if (!track || !data) return featureCollection
+  if (!track || !events) return featureCollection
 
   const geojson = (track as FeatureCollection).type
     ? (track as FeatureCollection)
     : segmentsToGeoJSON(track as Segment[])
   if (!geojson) return featureCollection
-  featureCollection.features = data.flatMap((event: RawEvent) => {
+  featureCollection.features = events.flatMap((event: RawEvent) => {
     return filterTrackByTimerange(geojson, event.start, event.end).features.map((feature) => {
       const authorizationStatus = event.encounter
         ? event.encounter.authorizationStatus


### PR DESCRIPTION
Fix for Enrique's comment:
> one question about fishing event performance, I'm looking into this workspace. When I'm at the zoom level where the fishing events become part of the track the map became really unresponsive to me

This is due to merging all events datasets in https://github.com/GlobalFishingWatch/frontend/compare/fishing-map/fix-perf-issue-on-track-events-hover?expand=1#diff-f9708754c8ace51fecd0d6922da43e4dfa2044b5729a1f605a99b98043104df7R130, which generates a new array for events every time generators are reinstanciated. Fix is a semi-hack where the generator uses a custome memoizeOne equality check.

This is a bit unsatisfying and reveals larger underlying issues that we should look at fixing post-release:
- `getVesselEventsSegmentsGeojson` is very slow, around two seconds - will need to be optimized
- we should start thinking of a mechanism so that the entire `resolve dataviews -> instanciate generators -> run generators` cycle does not run. 
   - at every highlighted time update
   - at every current frame update
   The `memoizeById` stuff was good enough until now, but it happens too late in the process,  and it overcomplicates generators. And, stuff happening in `dataviews-client` and app selectors will get slower and slower.
   
As a side note: do we still use `highlightedEvent` in the track generator? https://github.com/GlobalFishingWatch/frontend/pull/669/files#diff-d426994ad6a0cd7c1064563fb7860319bee5408c0c333fd33a4b8be62f8adc15R132