### PR TITLE
Tokenize urls

### DIFF
--- a/applications/fishing-map/src/routes/routes.ts
+++ b/applications/fishing-map/src/routes/routes.ts
@@ -43,6 +43,9 @@ const PARAMS_TO_ABBREVIATED = {
   params: 'pms',
   config: 'cfg',
   visible: 'vis',
+  query: 'qry',
+  value: 'val',
+  color: 'clr',
 }
 const ABBREVIATED_TO_PARAMS = invert(PARAMS_TO_ABBREVIATED)
 


### PR DESCRIPTION
This reduces URL length by approx 30% on a typical workspace with tracks. It detects repeated tokens, stores them apart in the URL, and replaces them with a prefix + index (so something like `~42`).

Not 100% sure about using `~` as token prefix. But it looks like a nice little wave 🌊

Also, we might want to add unit tests and/or double check a lot of workspaces before pushing that to prod a few days before release.

Example URL (see `tk` values at the end):
> ```?latitude=1.1958885602302823e-12&longitude=-37&zoom=1.3575518912508981&start=2021-04-09T00%3A00%3A00.000Z&end=2021-07-09T00%3A00%3A00.000Z&dvIn[0][id]=vessel-~2&dvIn[0][dvId]=92&dvIn[0][cfg][color]=%2367FBFE&dvIn[0][dsC][0][dsId]=~0&dvIn[0][dsC][0][pms][0][id]=~1&dvIn[0][dsC][0][pms][0][value]=~2&dvIn[0][dsC][0][ept]=~3&dvIn[0][dsC][1][dsId]=~4&dvIn[0][dsC][1][pms][0][id]=~1&dvIn[0][dsC][1][pms][0][value]=~2&dvIn[0][dsC][1][ept]=~5&dvIn[0][dsC][2][dsId]=~6&dvIn[0][dsC][2][query][0][id]=~7&dvIn[0][dsC][2][query][0][value]=~2&dvIn[0][dsC][2][ept]=~8&dvIn[0][dsC][3][dsId]=~9&dvIn[0][dsC][3][query][0][id]=~7&dvIn[0][dsC][3][query][0][value]=~2&dvIn[0][dsC][3][ept]=~8&dvIn[1][id]=vessel-~10&dvIn[1][dvId]=92&dvIn[1][cfg][color]=%230B8043&dvIn[1][dsC][0][dsId]=~0&dvIn[1][dsC][0][pms][0][id]=~1&dvIn[1][dsC][0][pms][0][value]=~10&dvIn[1][dsC][0][ept]=~3&dvIn[1][dsC][1][dsId]=~4&dvIn[1][dsC][1][pms][0][id]=~1&dvIn[1][dsC][1][pms][0][value]=~10&dvIn[1][dsC][1][ept]=~5&dvIn[1][dsC][2][dsId]=~6&dvIn[1][dsC][2][query][0][id]=~7&dvIn[1][dsC][2][query][0][value]=~10&dvIn[1][dsC][2][ept]=~8&dvIn[1][dsC][3][dsId]=~9&dvIn[1][dsC][3][query][0][id]=~7&dvIn[1][dsC][3][query][0][value]=~10&dvIn[1][dsC][3][ept]=~8&dvIn[2][id]=vessel-~11&dvIn[2][dvId]=92&dvIn[2][cfg][color]=%23FBFF8B&dvIn[2][dsC][0][dsId]=~0&dvIn[2][dsC][0][pms][0][id]=~1&dvIn[2][dsC][0][pms][0][value]=~11&dvIn[2][dsC][0][ept]=~3&dvIn[2][dsC][1][dsId]=~4&dvIn[2][dsC][1][pms][0][id]=~1&dvIn[2][dsC][1][pms][0][value]=~11&dvIn[2][dsC][1][ept]=~5&dvIn[2][dsC][2][dsId]=~6&dvIn[2][dsC][2][query][0][id]=~7&dvIn[2][dsC][2][query][0][value]=~11&dvIn[2][dsC][2][ept]=~8&dvIn[2][dsC][3][dsId]=~9&dvIn[2][dsC][3][query][0][id]=~7&dvIn[2][dsC][3][query][0][value]=~11&dvIn[2][dsC][3][ept]=~8&dvIn[3][id]=vessel-~12&dvIn[3][dvId]=92&dvIn[3][cfg][color]=%2333B679&dvIn[3][dsC][0][dsId]=~0&dvIn[3][dsC][0][pms][0][id]=~1&dvIn[3][dsC][0][pms][0][value]=~12&dvIn[3][dsC][0][ept]=~3&dvIn[3][dsC][1][dsId]=~4&dvIn[3][dsC][1][pms][0][id]=~1&dvIn[3][dsC][1][pms][0][value]=~12&dvIn[3][dsC][1][ept]=~5&dvIn[3][dsC][2][dsId]=~6&dvIn[3][dsC][2][query][0][id]=~7&dvIn[3][dsC][2][query][0][value]=~12&dvIn[3][dsC][2][ept]=~8&dvIn[3][dsC][3][dsId]=~9&dvIn[3][dsC][3][query][0][id]=~7&dvIn[3][dsC][3][query][0][value]=~12&dvIn[3][dsC][3][ept]=~8&dvIn[4][id]=vessel-~13&dvIn[4][dvId]=92&dvIn[4][cfg][color]=%23F95E5E&dvIn[4][dsC][0][dsId]=~0&dvIn[4][dsC][0][pms][0][id]=~1&dvIn[4][dsC][0][pms][0][value]=~13&dvIn[4][dsC][0][ept]=~3&dvIn[4][dsC][1][dsId]=~4&dvIn[4][dsC][1][pms][0][id]=~1&dvIn[4][dsC][1][pms][0][value]=~13&dvIn[4][dsC][1][ept]=~5&dvIn[4][dsC][2][dsId]=~6&dvIn[4][dsC][2][query][0][id]=~7&dvIn[4][dsC][2][query][0][value]=~13&dvIn[4][dsC][2][ept]=~8&dvIn[4][dsC][3][dsId]=~9&dvIn[4][dsC][3][query][0][id]=~7&dvIn[4][dsC][3][query][0][value]=~13&dvIn[4][dsC][3][ept]=~8&timebarVisualisation=vessel&tk[0]=public-global-fishing-tracks%3Av20201001&tk[1]=vesselId&tk[2]=adc4015e8-8d6f-bf19-e0d1-c662f5b616e7&tk[3]=carriers-tracks&tk[4]=public-global-fishing-vessels%3Av20201001&tk[5]=carriers-vessel&tk[6]=public-global-fishing-events%3Av20201001&tk[7]=vessels&tk[8]=carriers-events&tk[9]=public-global-loitering-events-carriers%3Av20201001&tk[10]=26f0e4bac-c122-7d19-f564-f810ddf3aaa0&tk[11]=8372af007-7b7f-f7fa-4ee4-c5227c164207&tk[12]=4811cfddd-d964-2414-0ac8-c2a70e013fa4&tk[13]=18f738de2-2165-3df3-b84c-5f26c4b2f3ed```

