### PR TITLE
added analysis common fields labels

### DIFF
--- a/applications/fishing-map/public/locales/source/translations.json
+++ b/applications/fishing-map/public/locales/source/translations.json
@@ -12,7 +12,8 @@
     "onlyAISAllowed": "Only AIS datasets are allowed to download",
     "timeRangeTooLong": "Reports are only allowed for time ranges up to one year",
     "title": "Analysis",
-    "vesselFlags": "by vessels flagged by"
+    "vesselFlags": "by vessels flagged by",
+    "filteredBy": "filtered by"
   },
   "common": {
     "active_after": "Active after",

--- a/applications/fishing-map/src/features/analysis/AnalysisLayerPanel.tsx
+++ b/applications/fishing-map/src/features/analysis/AnalysisLayerPanel.tsx
@@ -9,6 +9,7 @@ import DatasetSchemaField from 'features/workspace/shared/DatasetSchemaField'
 import DatasetFilterSource from 'features/workspace/shared/DatasetSourceField'
 import DatasetFlagField from 'features/workspace/shared/DatasetFlagsField'
 import layerPanelStyles from 'features/workspace/shared/LayerPanel.module.css'
+import { SupportedDatasetSchema } from 'features/datasets/datasets.utils'
 import styles from './AnalysisLayerPanel.module.css'
 
 const allAvailableProperties = ['dataset', 'source', 'flag']
@@ -17,9 +18,10 @@ type LayerPanelProps = {
   index: number
   dataview: UrlDataviewInstance
   hiddenProperties?: string[]
+  availableFields: string[][]
 }
 
-function AnalysisLayerPanel({ dataview, hiddenProperties }: LayerPanelProps) {
+function AnalysisLayerPanel({ dataview, hiddenProperties, availableFields }: LayerPanelProps) {
   const { t } = useTranslation()
 
   const fishignDataview = isFishingDataview(dataview)
@@ -41,7 +43,8 @@ function AnalysisLayerPanel({ dataview, hiddenProperties }: LayerPanelProps) {
     hiddenProperties?.includes('flag')
 
   if (areAllPropertiesHidden) {
-    return null
+    // TODO I don't understand that logic
+    // return null
   }
 
   return (
@@ -62,26 +65,16 @@ function AnalysisLayerPanel({ dataview, hiddenProperties }: LayerPanelProps) {
         {!hiddenProperties?.includes('flag') && (
           <DatasetFlagField dataview={dataview} showWhenEmpty />
         )}
-        <DatasetSchemaField
-          dataview={dataview}
-          field={'geartype'}
-          label={t('layer.gearType_plural', 'Gear types')}
-        />
-        <DatasetSchemaField
-          dataview={dataview}
-          field={'fleet'}
-          label={t('layer.fleet_plural', 'Fleets')}
-        />
-        <DatasetSchemaField
-          dataview={dataview}
-          field={'origin'}
-          label={t('vessel.origin', 'Origin')}
-        />
-        <DatasetSchemaField
-          dataview={dataview}
-          field={'vessel_type'}
-          label={t('vessel.vesselType_plural', 'Vessel types')}
-        />
+        {availableFields.map((field) => {
+          return hiddenProperties?.includes(field[0]) ? null : (
+            <DatasetSchemaField
+              key={field[0]}
+              dataview={dataview}
+              field={field[0] as SupportedDatasetSchema}
+              label={t(field[1] as any, field[2])}
+            />
+          )
+        })}
         {/* <AnalysisFilter
           label={t('analysis.area', 'Area')}
           taglist={areaItems}


### PR DESCRIPTION
This is a fix for https://globalfishingwatch.atlassian.net/browse/MAP-442

The cause of the issue was this bit which I don't understand and commented out:
https://github.com/GlobalFishingWatch/frontend/compare/fishing-map/analysis-common-fields-label?expand=1#diff-6494bf998853643b876cd3ae5dbe02207faf17844b865eaf48f9254a496aaa40R45-R48

Which resulted in:

![Screenshot 2021-07-13 at 11 50 00](https://user-images.githubusercontent.com/1583415/125431294-b9640644-2f0d-4148-91e4-fb09d3b4fab5.png)
![Screenshot 2021-07-13 at 11 50 03](https://user-images.githubusercontent.com/1583415/125431303-5a7f09aa-09e9-4b8b-baa9-7455710f9930.png)

And then added logic to display generic common  filter fields in the main title:

![Screenshot 2021-07-13 at 11 49 28](https://user-images.githubusercontent.com/1583415/125431404-b541f9ce-b959-497b-a4b1-03fb621e69b6.png)
![Screenshot 2021-07-13 at 11 49 32](https://user-images.githubusercontent.com/1583415/125431410-4a520799-b417-42ee-a8e9-b090391e0976.png)
