### PR TITLE
support showAuthorizationStatus dataview config in encounter events

### DIFF
--- a/.changeset/metal-dryers-warn.md
+++ b/.changeset/metal-dryers-warn.md
@@ -1,0 +1,6 @@
+---
+'@globalfishingwatch/dataviews-client': minor
+'@globalfishingwatch/layer-composer': minor
+---
+
+support showAuthorizationStatus dataview config in encounter events

--- a/applications/fishing-map/src/features/map/popups/Popup.module.css
+++ b/applications/fishing-map/src/features/map/popups/Popup.module.css
@@ -72,6 +72,7 @@
 }
 
 .loading {
+  width: 100%;
   height: 17.9rem;
   padding: var(--space-XS);
 }

--- a/applications/fishing-map/src/features/timebar/timebar.selectors.ts
+++ b/applications/fishing-map/src/features/timebar/timebar.selectors.ts
@@ -116,7 +116,7 @@ const selectEventsForTracks = createSelector(
         !tracksResourceResolved ||
         (Array.isArray(visibleEvents) && visibleEvents?.length === 0)
       ) {
-        return []
+        return { dataview, data: [] }
       }
 
       const eventsResourcesFiltered = eventsResources.filter(({ dataset }) => {
@@ -131,9 +131,9 @@ const selectEventsForTracks = createSelector(
           return []
         }
 
-        return resources[url].data
+        return resources[url].data as ApiEvent[]
       })
-      return data as ApiEvent[]
+      return { dataview, data }
     })
     return vesselsEvents
   }
@@ -148,73 +148,70 @@ interface RenderedEvent extends ApiEvent {
 export const selectEventsWithRenderingInfo = createSelector(
   [selectEventsForTracks],
   (eventsForTrack) => {
-    const eventsWithRenderingInfo: RenderedEvent[][] = eventsForTrack.map(
-      (trackEvents: ApiEvent[]) => {
-        return (trackEvents || []).map((event: ApiEvent, index) => {
-          const vesselName = event.vessel.name || event.vessel.id
+    const eventsWithRenderingInfo: RenderedEvent[][] = eventsForTrack.map(({ dataview, data }) => {
+      return (data || []).map((event: ApiEvent, index) => {
+        const vesselName = event.vessel.name || event.vessel.id
 
-          let description
-          let descriptionGeneric
-          switch (event.type) {
-            case 'encounter':
-              if (event.encounter) {
-                description = `${vesselName} ${t(
-                  'event.encounterActionWith',
-                  'had an encounter with'
-                )} ${
-                  event.encounter.vessel.name
-                    ? event.encounter.vessel.name
-                    : t('event.encounterAnotherVessel', 'another vessel')
-                } `
-              }
-              descriptionGeneric = `${vesselName} ${t('event.encounter')}`
-              break
-            case 'port':
-              if (event.port && event.port.name) {
-                description = `${vesselName} ${t('event.portAt')} ${event.port.name}`
-              } else {
-                description = `${vesselName} ${t('event.portAction')}`
-              }
-              descriptionGeneric = `${vesselName} ${t('event.port')}`
-              break
-            case 'loitering':
-              description = `${vesselName} ${t('event.loiteringAction')}`
-              descriptionGeneric = `${vesselName} ${t('event.loitering')}`
-              break
-            case 'fishing':
-              description = `${vesselName} ${t('event.fishingAction')}`
-              descriptionGeneric = `${vesselName} ${t('event.fishing')}`
-              break
-            default:
-              description = 'Unknown event'
-              descriptionGeneric = 'Unknown event'
-          }
-          const duration = DateTime.fromMillis(event.end as number)
-            .diff(DateTime.fromMillis(event.start as number), ['hours', 'minutes'])
-            .toObject()
+        let description
+        let descriptionGeneric
+        switch (event.type) {
+          case 'encounter':
+            if (event.encounter) {
+              description = `${vesselName} ${t(
+                'event.encounterActionWith',
+                'had an encounter with'
+              )} ${
+                event.encounter.vessel.name
+                  ? event.encounter.vessel.name
+                  : t('event.encounterAnotherVessel', 'another vessel')
+              } `
+            }
+            descriptionGeneric = `${vesselName} ${t('event.encounter')}`
+            break
+          case 'port':
+            if (event.port && event.port.name) {
+              description = `${vesselName} ${t('event.portAt')} ${event.port.name}`
+            } else {
+              description = `${vesselName} ${t('event.portAction')}`
+            }
+            descriptionGeneric = `${vesselName} ${t('event.port')}`
+            break
+          case 'loitering':
+            description = `${vesselName} ${t('event.loiteringAction')}`
+            descriptionGeneric = `${vesselName} ${t('event.loitering')}`
+            break
+          case 'fishing':
+            description = `${vesselName} ${t('event.fishingAction')}`
+            descriptionGeneric = `${vesselName} ${t('event.fishing')}`
+            break
+          default:
+            description = 'Unknown event'
+            descriptionGeneric = 'Unknown event'
+        }
+        const duration = DateTime.fromMillis(event.end as number)
+          .diff(DateTime.fromMillis(event.start as number), ['hours', 'minutes'])
+          .toObject()
 
-          // TODO i18n
-          description = `${description} ${duration.hours}hrs ${Math.round(
-            duration.minutes as number
-          )}mns`
+        description = `${description} ${duration.hours}hrs ${Math.round(
+          duration.minutes as number
+        )}mns`
 
-          let colorKey = event.type as string
-          if (event.type === 'encounter') {
-            colorKey = `${colorKey}${event.encounter?.authorizationStatus}`
-          }
-          const color = EVENTS_COLORS[colorKey]
-          const colorLabels = EVENTS_COLORS[`${colorKey}Labels`]
+        let colorKey = event.type as string
+        if (event.type === 'encounter' && dataview.config?.showAuthorizationStatus) {
+          colorKey = `${colorKey}${event.encounter?.authorizationStatus}`
+        }
+        const color = EVENTS_COLORS[colorKey]
+        const colorLabels = EVENTS_COLORS[`${colorKey}Labels`]
 
-          return {
-            ...event,
-            color,
-            colorLabels,
-            description,
-            descriptionGeneric,
-          }
-        })
-      }
-    )
+        return {
+          ...event,
+          color,
+          colorLabels,
+          description,
+          descriptionGeneric,
+        }
+      })
+    })
     return eventsWithRenderingInfo
   }
 )

--- a/packages/dataviews-client/src/resolve-dataviews-generators.ts
+++ b/packages/dataviews-client/src/resolve-dataviews-generators.ts
@@ -136,6 +136,7 @@ export function getGeneratorConfig(
           id: `${dataview.id}${MULTILAYER_SEPARATOR}vessel_events`,
           type: Generators.Type.VesselEvents,
           showIcons: dataview.config?.showIcons,
+          showAuthorizationStatus: dataview.config?.showAuthorizationStatus,
           data: data,
           color: dataview.config?.color,
           track: generator.data,

--- a/packages/layer-composer/src/generators/types.ts
+++ b/packages/layer-composer/src/generators/types.ts
@@ -245,6 +245,7 @@ export interface VesselEventsGeneratorConfig extends GeneratorConfig {
   color?: string
   track?: TrackGeneratorConfigData
   showIcons?: boolean
+  showAuthorizationStatus?: boolean
   currentEventId?: string
 }
 

--- a/packages/layer-composer/src/generators/vessel-events/vessel-events.ts
+++ b/packages/layer-composer/src/generators/vessel-events/vessel-events.ts
@@ -35,18 +35,21 @@ class VesselsEventsGenerator {
   }
 
   _getStyleSources = (config: GlobalVesselEventsGeneratorConfig): VesselsEventsSource[] => {
-    const { id, data, track, start, end } = config
+    const { id, data, track, start, end, showAuthorizationStatus } = config
 
     if (!data) {
       // console.warn(`${VESSEL_EVENTS_TYPE} source generator needs geojson data`, config)
       return []
     }
 
-    const geojson = memoizeCache[config.id].getVesselEventsGeojson(data) as FeatureCollection
+    const geojson = memoizeCache[config.id].getVesselEventsGeojson(
+      data,
+      showAuthorizationStatus
+    ) as FeatureCollection
     const featuresFiltered = memoizeCache[config.id].filterFeaturesByTimerange(
       geojson.features,
-      config.start,
-      config.end
+      start,
+      end
     )
 
     const pointsSource: VesselsEventsSource = {
@@ -62,7 +65,8 @@ class VesselsEventsGenerator {
 
     const segments = memoizeCache[config.id].getVesselEventsSegmentsGeojson(
       track,
-      data
+      data,
+      showAuthorizationStatus
     ) as FeatureCollection
 
     const segmentsFiltered = memoizeCache[config.id].filterGeojsonByTimerange(segments, start, end)

--- a/packages/layer-composer/src/generators/vessel-events/vessel-events.utils.ts
+++ b/packages/layer-composer/src/generators/vessel-events/vessel-events.utils.ts
@@ -31,7 +31,10 @@ const getDateTimeDate = (date: string | number) => {
   return typeof date === 'number' ? DateTime.fromMillis(date) : DateTime.fromISO(date)
 }
 
-export const getVesselEventsGeojson = (trackEvents: RawEvent[] | null): FeatureCollection => {
+export const getVesselEventsGeojson = (
+  trackEvents: RawEvent[] | null,
+  showAuthorizationStatus = true
+): FeatureCollection => {
   const featureCollection: FeatureCollection = {
     type: 'FeatureCollection',
     features: [],
@@ -57,16 +60,18 @@ export const getVesselEventsGeojson = (trackEvents: RawEvent[] | null): FeatureC
         timestamp: event.start,
         start: getDateTimeDate(event.start).toUTC().toISO(),
         end: getDateTimeDate(event.end).toUTC().toISO(),
-        ...(isEncounterEvent && {
-          authorized,
-          authorizationStatus,
-          encounterVesselId: event.encounter?.vessel?.id,
-          encounterVesselName: event.encounter?.vessel?.name,
-        }),
+        ...(isEncounterEvent &&
+          showAuthorizationStatus && {
+            authorized,
+            authorizationStatus,
+            encounterVesselId: event.encounter?.vessel?.id,
+            encounterVesselName: event.encounter?.vessel?.name,
+          }),
         icon: `carrier_portal_${event.type}`,
-        color: isEncounterEvent
-          ? getEncounterAuthColor(authorizationStatus)
-          : EVENTS_COLORS[event.type],
+        color:
+          isEncounterEvent && showAuthorizationStatus
+            ? getEncounterAuthColor(authorizationStatus)
+            : EVENTS_COLORS[event.type],
       },
       geometry: {
         type: 'Point',
@@ -128,7 +133,8 @@ export const getVesselEventsSegmentsGeojsonMemoizeEqualityCheck = (
 
 export const getVesselEventsSegmentsGeojson = (
   track: any,
-  events: RawEvent[]
+  events: RawEvent[],
+  showAuthorizationStatus = true
 ): FeatureCollection => {
   const featureCollection: FeatureCollection = {
     type: 'FeatureCollection',
@@ -155,19 +161,21 @@ export const getVesselEventsSegmentsGeojson = (
           type: event.type,
           start: getDateTimeDate(event.start).toUTC().toISO(),
           end: getDateTimeDate(event.end).toUTC().toISO(),
-          color: isEncounterEvent
-            ? getEncounterAuthColor(authorizationStatus)
-            : EVENTS_COLORS[event.type],
+          color:
+            isEncounterEvent && showAuthorizationStatus
+              ? getEncounterAuthColor(authorizationStatus)
+              : EVENTS_COLORS[event.type],
           ...(event.vessel && {
             vesselId: event.vessel.id,
             vesselName: event.vessel.name,
           }),
-          ...(isEncounterEvent && {
-            authorized,
-            authorizationStatus,
-            encounterVesselId: event.encounter?.vessel.id,
-            encounterVesselName: event.encounter?.vessel.name,
-          }),
+          ...(isEncounterEvent &&
+            showAuthorizationStatus && {
+              authorized,
+              authorizationStatus,
+              encounterVesselId: event.encounter?.vessel.id,
+              encounterVesselName: event.encounter?.vessel.name,
+            }),
         },
       }
     })


### PR DESCRIPTION
Include new config in vessel dataview called `showAuthorizationStatus` to allow hiding the authorisation status in events layer and timebar. [Thread](https://globalfishingwatch.slack.com/archives/C0149CPE97U/p1626186020287800)
