### PR TITLE
MAP-456 Accept timebar locale prop

### DIFF
--- a/applications/fishing-map/CHANGELOG.md
+++ b/applications/fishing-map/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @globalfishingwatchapp/fishing-map
 
+## 1.1.5
+
+### Patch Changes
+
+- Timebar localization i18n
+- Updated dependencies [undefined]
+  - @globalfishingwatch/timebar@2.0.3
+
 ## 1.1.4
 
 ### Patch Changes

--- a/applications/fishing-map/package.json
+++ b/applications/fishing-map/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@globalfishingwatchapp/fishing-map",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "private": true,
   "scripts": {
     "start": "PORT=3003 react-scripts start",
@@ -25,7 +25,7 @@
     "@globalfishingwatch/pbf": "1.0.10",
     "@globalfishingwatch/react-hooks": "12.0.1",
     "@globalfishingwatch/react-map-gl": "5.2.9-gfw.17",
-    "@globalfishingwatch/timebar": "2.0.2",
+    "@globalfishingwatch/timebar": "2.0.3",
     "@globalfishingwatch/ui-components": "9.0.1",
     "@reduxjs/toolkit": "^1.5.0",
     "@researchgate/react-intersection-observer": "^1.3.5",

--- a/applications/fishing-map/src/features/timebar/Timebar.tsx
+++ b/applications/fishing-map/src/features/timebar/Timebar.tsx
@@ -212,6 +212,7 @@ const TimebarWrapper = () => {
         bookmarkPlacement="bottom"
         minimumRange={1}
         minimumRangeUnit={activityCategory === 'fishing' ? 'hour' : 'day'}
+        locale={i18n.language}
       >
         {!isSmallScreen ? (
           <Fragment>

--- a/applications/temporalgrid-demo/CHANGELOG.md
+++ b/applications/temporalgrid-demo/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @globalfishingwatchapp/temporalgrid-demo
 
+## 0.7.114
+
+### Patch Changes
+
+- Updated dependencies [undefined]
+  - @globalfishingwatch/timebar@2.0.3
+
 ## 0.7.113
 
 ### Patch Changes

--- a/applications/temporalgrid-demo/package.json
+++ b/applications/temporalgrid-demo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@globalfishingwatchapp/temporalgrid-demo",
-  "version": "0.7.113",
+  "version": "0.7.114",
   "private": true,
   "dependencies": {
     "@globalfishingwatch/layer-composer": "8.9.1",
@@ -8,7 +8,7 @@
     "@globalfishingwatch/react-map-gl": "5.2.9-gfw.17",
     "@globalfishingwatch/mapbox-gl": "1.12.0-gfw.22",
     "@globalfishingwatch/pbf": "^1.0.10",
-    "@globalfishingwatch/timebar": "2.0.2",
+    "@globalfishingwatch/timebar": "2.0.3",
     "@mapbox/tilebelt": "^1.0.2",
     "babel-polyfill": "^6.26.0",
     "classnames": "^2.3.1",

--- a/packages/timebar/CHANGELOG.md
+++ b/packages/timebar/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @globalfishingwatch/timebar
 
+## 2.0.3
+
+### Patch Changes
+
+- Timebar localization i18n
+
 ## 2.0.2
 
 ### Patch Changes

--- a/packages/timebar/package.json
+++ b/packages/timebar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@globalfishingwatch/timebar",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "GFW timebar",
   "author": "satellitestudio <contact@satellitestud.io>",
   "homepage": "https://github.com/GlobalFishingWatch/frontend#readme",

--- a/packages/timebar/src/timebar.js
+++ b/packages/timebar/src/timebar.js
@@ -5,6 +5,10 @@ import dayjs from 'dayjs'
 import memoize from 'memoize-one'
 import relativeTime from 'dayjs/plugin/relativeTime'
 import utc from 'dayjs/plugin/utc'
+import 'dayjs/locale/en'
+import 'dayjs/locale/es'
+import 'dayjs/locale/fr'
+import 'dayjs/locale/id'
 import ImmediateContext from './immediateContext'
 import {
   getTime,
@@ -86,9 +90,18 @@ class Timebar extends Component {
     return getRangeMs(minimumRange, minimumRangeUnit)
   })
 
-  componentDidMount() {
-    const { start, end } = this.props
+  componentDidUpdate(prevProps) {
+    const { locale: prevLocale } = prevProps
+    const { start, end, locale } = this.props
+    if (prevLocale !== locale) {
+      dayjs.locale(locale)
+      this.notifyChange(start, end, EVENT_SOURCE.TIME_RANGE_SELECTOR)
+    }
+  }
 
+  componentDidMount() {
+    const { start, end, locale } = this.props
+    dayjs.locale(locale)
     // TODO stick to day/hour here too
     this.notifyChange(start, end, EVENT_SOURCE.MOUNT)
   }
@@ -400,6 +413,7 @@ Timebar.propTypes = {
   maximumRange: PropTypes.number,
   maximumRangeUnit: PropTypes.string,
   showLastUpdate: PropTypes.bool,
+  locale: PropTypes.oneOf(['en', 'es', 'fr', 'id']),
 }
 
 Timebar.defaultProps = {
@@ -462,6 +476,7 @@ Timebar.defaultProps = {
   maximumRange: null,
   maximumRangeUnit: 'month',
   showLastUpdate: true,
+  locale: 'en',
 }
 
 export default Timebar

--- a/packages/timebar/src/timebar.js
+++ b/packages/timebar/src/timebar.js
@@ -90,18 +90,9 @@ class Timebar extends Component {
     return getRangeMs(minimumRange, minimumRangeUnit)
   })
 
-  componentDidUpdate(prevProps) {
-    const { locale: prevLocale } = prevProps
-    const { start, end, locale } = this.props
-    if (prevLocale !== locale) {
-      dayjs.locale(locale)
-      this.notifyChange(start, end, EVENT_SOURCE.TIME_RANGE_SELECTOR)
-    }
-  }
-
   componentDidMount() {
-    const { start, end, locale } = this.props
-    dayjs.locale(locale)
+    const { start, end } = this.props
+
     // TODO stick to day/hour here too
     this.notifyChange(start, end, EVENT_SOURCE.MOUNT)
   }
@@ -124,6 +115,8 @@ class Timebar extends Component {
     const { start, end, onBookmarkChange } = this.props
     onBookmarkChange !== null && onBookmarkChange(start, end)
   }
+
+  setLocale = memoize((locale) => dayjs.locale(locale))
 
   onTimeRangeSelectorSubmit = (start, end) => {
     this.notifyChange(start, end, EVENT_SOURCE.TIME_RANGE_SELECTOR)
@@ -232,6 +225,7 @@ class Timebar extends Component {
       bookmarkEnd,
       bookmarkPlacement,
       enablePlayback,
+      locale,
       minimumRange,
       minimumRangeUnit,
       maximumRange,
@@ -239,6 +233,7 @@ class Timebar extends Component {
     } = this.props
     const { immediate } = this.state
 
+    this.setLocale(locale)
     // state.absoluteEnd overrides the value set in props.absoluteEnd - see getDerivedStateFromProps
     const { showTimeRangeSelector, absoluteEnd } = this.state
 

--- a/packages/timebar/types/timebar.d.ts
+++ b/packages/timebar/types/timebar.d.ts
@@ -10,6 +10,7 @@ declare class Timebar extends Component<any, any, any> {
     getMinimumRangeMs: (this: any, minimumRange: any, minimumRangeUnit: any) => any;
     toggleTimeRangeSelector: () => void;
     setBookmark: () => void;
+    setLocale: (this: any, locale: any) => any;
     onTimeRangeSelectorSubmit: (start: any, end: any) => void;
     zoom: (zoom: any) => void;
     notifyChange: (start: any, end: any, source: any, clampToEnd?: boolean) => void;

--- a/packages/timebar/types/timebar.d.ts
+++ b/packages/timebar/types/timebar.d.ts
@@ -41,6 +41,7 @@ declare namespace Timebar {
         const maximumRange: any;
         const maximumRangeUnit: any;
         const showLastUpdate: any;
+        const locale: any;
     }
     namespace defaultProps {
         const latestAvailableDataDate_1: string;
@@ -112,6 +113,8 @@ declare namespace Timebar {
         export { maximumRangeUnit_1 as maximumRangeUnit };
         const showLastUpdate_1: boolean;
         export { showLastUpdate_1 as showLastUpdate };
+        const locale_1: string;
+        export { locale_1 as locale };
     }
 }
 import { Component } from "react";


### PR DESCRIPTION
- [x] Added optional `locale` prop to timebar to translate month names and day names in the timeline. Supported languages are: en, es, fr, id