### PR TITLE
Handle user context layers with line features

### DIFF
--- a/.changeset/silver-planets-train.md
+++ b/.changeset/silver-planets-train.md
@@ -1,0 +1,6 @@
+---
+'@globalfishingwatch/dataviews-client': minor
+'@globalfishingwatch/layer-composer': minor
+---
+
+Handle user context layers with line features

--- a/applications/fishing-map/src/features/datasets/NewDataset.tsx
+++ b/applications/fishing-map/src/features/datasets/NewDataset.tsx
@@ -282,7 +282,7 @@ function NewDataset(): React.ReactElement {
         label: userTrackGeoJSONFile?.name ?? file.name,
       })
       setLoading(true)
-      console.log(metadata)
+
       const { payload, error: createDatasetError } = await dispatchCreateDataset({
         dataset: {
           ...metadata,

--- a/applications/fishing-map/src/features/datasets/NewDataset.tsx
+++ b/applications/fishing-map/src/features/datasets/NewDataset.tsx
@@ -109,17 +109,30 @@ function NewDataset(): React.ReactElement {
         }
         if (geojson !== undefined) {
           setFileData(geojson)
+          const configuration = {
+            geometryType: datasetGeometryType,
+            // TODO when supporting multiple files upload
+            // ...(geojson?.fileName && { file: geojson.fileName }),
+            ...(isGeojson && { format: 'geojson' }),
+          } as DatasetConfiguration
+
+          // Set disableInteraction flag when not all features are polygons
+          if (datasetCategory === 'context') {
+            if (
+              !geojson.features.every((feature) =>
+                ['Polygon', 'MultiPolygon'].includes(feature.geometry.type)
+              )
+            ) {
+              configuration.disableInteraction = true
+            }
+          }
+
           setMetadata((metadata) => ({
             ...metadata,
             name: metadataName,
             type: DatasetTypes.Context,
             category: datasetCategory,
-            configuration: {
-              geometryType: datasetGeometryType,
-              // TODO when supporting multiple files upload
-              // ...(geojson?.fileName && { file: geojson.fileName }),
-              ...(isGeojson && { format: 'geojson' }),
-            } as DatasetConfiguration,
+            configuration,
           }))
         } else {
           setFileData(undefined)
@@ -269,8 +282,11 @@ function NewDataset(): React.ReactElement {
         label: userTrackGeoJSONFile?.name ?? file.name,
       })
       setLoading(true)
+      console.log(metadata)
       const { payload, error: createDatasetError } = await dispatchCreateDataset({
-        dataset: { ...metadata },
+        dataset: {
+          ...metadata,
+        },
         file: userTrackGeoJSONFile || file,
       })
       setLoading(false)

--- a/packages/dataviews-client/src/resolve-dataviews-generators.ts
+++ b/packages/dataviews-client/src/resolve-dataviews-generators.ts
@@ -283,6 +283,11 @@ export function getGeneratorConfig(
             .map((_, i) => parseFloat((i / (numSteps - 1))?.toFixed(2)))
             .map((value) => parseFloat((rampScale(value) as number)?.toFixed(3)))
           generator.steps = steps
+        } else if (
+          dataset.category === DatasetCategory.Context &&
+          dataview.config?.type === Generators.Type.UserContext
+        ) {
+          generator.disableInteraction = dataset.configuration?.disableInteraction
         }
       }
       if (!generator.tilesUrl) {

--- a/packages/layer-composer/src/generators/types.ts
+++ b/packages/layer-composer/src/generators/types.ts
@@ -114,6 +114,10 @@ export interface UserContextGeneratorConfig extends GeneratorConfig {
    * Property to get value to display the ramp
    */
   pickValueAt?: string
+  /**
+   * Disable interaction (needed when user uploaded a non-polygon layer)
+   */
+  disableInteraction?: boolean
 }
 
 /**

--- a/packages/layer-composer/src/generators/user-context/user-context.ts
+++ b/packages/layer-composer/src/generators/user-context/user-context.ts
@@ -35,6 +35,8 @@ class UserContextGenerator {
       'source-layer': DEFAULT_CONTEXT_SOURCE_LAYER,
     }
 
+    const interactive = !config.disableInteraction
+
     if (config.steps?.length && config.colorRamp) {
       const originalColorRamp = HEATMAP_COLOR_RAMPS[config.colorRamp]
       const legendRamp = zip(config.steps, originalColorRamp)
@@ -54,7 +56,7 @@ class UserContextGenerator {
         },
         metadata: {
           color: config.color,
-          interactive: true,
+          interactive,
           generatorId,
           group: Group.OutlinePolygonsFill,
           uniqueFeatureInteraction: true,
@@ -96,7 +98,7 @@ class UserContextGenerator {
         ...getFillPaintWithFeatureState('transparent'),
       },
       metadata: {
-        interactive: true,
+        interactive,
         generatorId: generatorId,
         group: Group.OutlinePolygonsFill,
       },


### PR DESCRIPTION
Fix for https://globalfishingwatch.atlassian.net/browse/MAP-455

This will disable interaction on user-submitted context layers, whenever the geojson or shapefile does not contain only polygons or multipolygons.