### PR TITLE
various timebar fixes

### DIFF
--- a/applications/fishing-map/src/features/timebar/Timebar.tsx
+++ b/applications/fishing-map/src/features/timebar/Timebar.tsx
@@ -191,7 +191,7 @@ const TimebarWrapper = () => {
     return timebarVisualisation === TimebarVisualisations.Vessel && showGraph && tracksGraphs
       ? tracksGraphs
       : null
-  }, [timebarVisualisation, timebarGraph, tracksGraphs])
+  }, [timebarVisualisation, showGraph, tracksGraphs])
 
   const { syncedTracks, syncedTracksEvents } = useMemo<{
     syncedTracks: (TimebarTrack | null)[] | undefined

--- a/applications/fishing-map/src/features/timebar/timebar.selectors.ts
+++ b/applications/fishing-map/src/features/timebar/timebar.selectors.ts
@@ -26,7 +26,7 @@ type TimebarTrackSegment = {
   end: number
 }
 
-type TimebarTrack = {
+export type TimebarTrack = {
   segments: TimebarTrackSegment[]
   color: string
 }
@@ -36,14 +36,14 @@ export const selectTracksData = createSelector(
   (trackDataviews, resources) => {
     if (!trackDataviews || !resources) return
 
-    const tracksSegments: TimebarTrack[] = trackDataviews.flatMap((dataview) => {
+    const tracksSegments: (TimebarTrack | null)[] = trackDataviews.flatMap((dataview) => {
       const { url } = resolveDataviewDatasetResource(dataview, [
         DatasetTypes.Tracks,
         DatasetTypes.UserTracks,
       ])
-      if (!url) return []
+      if (!url) return null
       const track = resources[url] as Resource<TrackResourceData>
-      if (!track?.data) return []
+      if (!track?.data) return null
 
       const segments = (track.data as any).features
         ? geoJSONToSegments(track.data as any)
@@ -139,7 +139,7 @@ const selectEventsForTracks = createSelector(
   }
 )
 
-interface RenderedEvent extends ApiEvent {
+export interface RenderedEvent extends ApiEvent {
   color: string
   description: string
   descriptionGeneric: string


### PR DESCRIPTION
- synchronize tracks and tracks events display (wait for both to be loaded for each track) to avoid weird offsets
- fixed an issue where tracks would not appear again when graph not set to 'none' and added more than one track
- only show graph when there's only one track, not two