### PR TITLE
Fishing map/improve vessel events highlight

### DIFF
--- a/.changeset/wet-adults-drop.md
+++ b/.changeset/wet-adults-drop.md
@@ -1,0 +1,7 @@
+---
+"@globalfishingwatch/layer-composer": patch
+"@globalfishingwatch/timebar": patch
+"@globalfishingwatchapp/fishing-map": patch
+---
+
+Fishing map/improve vessel events highlight

--- a/applications/fishing-map/src/features/timebar/Timebar.tsx
+++ b/applications/fishing-map/src/features/timebar/Timebar.tsx
@@ -62,7 +62,7 @@ const TimebarWrapper = () => {
   const { highlightedEvent, dispatchHighlightedEvent } = useHighlightEventConnect()
   const { dispatchDisableHighlightedTime } = useDisableHighlightTimeConnect()
   const { timebarVisualisation } = useTimebarVisualisation()
-  const { setMapCoordinates } = useViewport()
+  const { setMapCoordinates, viewport } = useViewport()
   const timebarGraph = useSelector(selectTimebarGraph)
   const tracks = useSelector(selectTracksData)
   const tracksGraphs = useSelector(selectTracksGraphs)
@@ -168,6 +168,7 @@ const TimebarWrapper = () => {
       setMapCoordinates({
         latitude: event.position.lat,
         longitude: event.position.lon,
+        zoom: viewport.zoom < 8 ? 8 : viewport.zoom,
       })
     },
     [setMapCoordinates]

--- a/packages/layer-composer/src/generators/vessel-events/vessel-events.ts
+++ b/packages/layer-composer/src/generators/vessel-events/vessel-events.ts
@@ -96,7 +96,17 @@ class VesselsEventsGenerator {
         ...(showTrackSegments && { maxzoom: POINTS_TO_SEGMENTS_ZOOM_LEVEL_SWITCH }),
         paint: {
           'circle-color': ['get', 'color'],
-          'circle-stroke-width': ['interpolate', ['linear'], ['zoom'], 2, 0, 8, 1, 14, 3],
+          'circle-stroke-width': [
+            'interpolate',
+            ['linear'],
+            ['zoom'],
+            2,
+            [...activeFilter, 2, 0],
+            8,
+            [...activeFilter, 2, 1],
+            14,
+            [...activeFilter, 2, 3],
+          ],
           'circle-stroke-color': [
             ...activeFilter,
             config.color || DEFAULT_STROKE_COLOR,

--- a/packages/timebar/src/charts/tracks-events.module.css
+++ b/packages/timebar/src/charts/tracks-events.module.css
@@ -11,6 +11,7 @@
   transform: translateY(-50%);
   border-radius: 7px;
   border: 2px solid transparent;
+  cursor: pointer;
 }
 
 .event:hover,


### PR DESCRIPTION
Shows a border around hovered event
<img width="1440" alt="Screenshot 2021-07-19 at 15 40 20" src="https://user-images.githubusercontent.com/38662877/126179507-b98938a6-cd23-4ebb-b679-356e50d97cab.png">

and zooms in when clicking on the event on the timebar