### PR TITLE
Vessel Viewer - Fix build cache issue on credentials

### DIFF
--- a/applications/vessel-history/Dockerfile
+++ b/applications/vessel-history/Dockerfile
@@ -41,6 +41,8 @@ RUN yarn build
 FROM appsoa/docker-alpine-htpasswd as htpasswd
 ARG BASIC_AUTH_USER=gfw
 ARG BASIC_AUTH_PASS=default
+ENV BASIC_AUTH_USER $BASIC_AUTH_USER
+ENV BASIC_AUTH_PASS $BASIC_AUTH_PASS
 RUN htpasswd -Bbn "${BASIC_AUTH_USER}" "${BASIC_AUTH_PASS}" > /tmp/.htpasswd
 
 #################################################################################


### PR DESCRIPTION
- Fixed wrong Basic Auth credentials being set on VV images deploy because of cache not being invalidated when `--build-arg` variable changes