### PR TITLE
filter search options with only datasets from workspace

### DIFF
--- a/applications/fishing-map/src/features/datasets/datasets.utils.ts
+++ b/applications/fishing-map/src/features/datasets/datasets.utils.ts
@@ -1,5 +1,5 @@
-import { intersection, lowerCase } from 'lodash'
-import { Dataset, Dataview, EventTypes } from '@globalfishingwatch/api-types'
+import { intersection, lowerCase, uniq } from 'lodash'
+import { Dataset, Dataview, DataviewInstance, EventTypes } from '@globalfishingwatch/api-types'
 import { UrlDataviewInstance } from '@globalfishingwatch/dataviews-client'
 import { capitalize, sortFields } from 'utils/shared'
 import { t } from 'features/i18n/i18n'
@@ -27,6 +27,17 @@ export const getDatasetLabel = (dataset: { id: string; name?: string }): string 
   if (!id) return name || ''
   const label = getDatasetNameTranslated(dataset)
   return isPrivateDataset(dataset) ? `🔒 ${label}` : label
+}
+
+export const getDatasetsInDataviews = (
+  dataviews: (Dataview | DataviewInstance | UrlDataviewInstance)[]
+) => {
+  return uniq(
+    dataviews?.flatMap((dataviews) => {
+      if (!dataviews.datasetsConfig) return []
+      return dataviews.datasetsConfig.map(({ datasetId }) => datasetId)
+    })
+  )
 }
 
 export const getEventsDatasetsInDataview = (dataview: UrlDataviewInstance) => {

--- a/applications/fishing-map/src/features/search/search.selectors.ts
+++ b/applications/fishing-map/src/features/search/search.selectors.ts
@@ -3,12 +3,25 @@ import { checkExistPermissionInList } from 'auth-middleware/src/utils'
 import { selectUserData } from 'features/user/user.slice'
 import { selectVesselsDatasets } from 'features/datasets/datasets.selectors'
 import { isGuestUser } from 'features/user/user.selectors'
-import { filterDatasetsByUserType } from 'features/datasets/datasets.utils'
+import { filterDatasetsByUserType, getDatasetsInDataviews } from 'features/datasets/datasets.utils'
+import { selectAllDataviewsInWorkspace } from 'features/dataviews/dataviews.selectors'
 import { SearchType } from './search.slice'
+
+export const selectSearchDatasetsInWorkspace = createSelector(
+  [selectAllDataviewsInWorkspace, selectVesselsDatasets],
+  (dataviews, vesselsDatasets) => {
+    const datasets = getDatasetsInDataviews(dataviews)
+    return vesselsDatasets.filter(
+      (dataset) =>
+        datasets.includes(dataset.id) ||
+        dataset.relatedDatasets?.some((related) => datasets.includes(related.id))
+    )
+  }
+)
 
 export const selectSearchDatasets = (type: SearchType) =>
   createSelector(
-    [selectVesselsDatasets, selectUserData, isGuestUser],
+    [selectSearchDatasetsInWorkspace, selectUserData, isGuestUser],
     (datasets, userData, guestUser) => {
       if (!userData || !datasets?.length) return
       const datasetsWithPermissions = datasets.filter((dataset) => {


### PR DESCRIPTION
Steps to reproduce issue:
1. Go to advance search and see only the datasets available for the current workspace:
![image](https://user-images.githubusercontent.com/10500650/130260176-d4759b2a-7a6a-4f31-ab6b-b6ae7db47e83.png)

2. Go to user panel (this will fetch all the datasets you have access)
3. Go back to search panel and now all the search datasets appears (soon it won't as PR fixes it)
![image](https://user-images.githubusercontent.com/10500650/130260387-2781dd92-4f1f-48fe-8082-fe2e8c0533b6.png)

This is normally an issue only for admin user which can read every dataset... but could happen for regular users too