### PR TITLE
Fishingmap/multiples vessels interaction info

### DIFF
--- a/.changeset/old-elephants-begin.md
+++ b/.changeset/old-elephants-begin.md
@@ -1,0 +1,5 @@
+---
+'@globalfishingwatch/api-types': minor
+---
+
+add dataset definition in vessel type

--- a/applications/fishing-map/src/features/map/popups/FishingLayers.tsx
+++ b/applications/fishing-map/src/features/map/popups/FishingLayers.tsx
@@ -1,16 +1,12 @@
 import React from 'react'
 import { event as uaEvent } from 'react-ga'
-import { useSelector } from 'react-redux'
 import { useTranslation } from 'react-i18next'
 import Spinner from '@globalfishingwatch/ui-components/dist/spinner'
 import { DatasetTypes } from '@globalfishingwatch/api-types'
 import { getVesselLabel } from 'utils/info'
 import { useDataviewInstancesConnect } from 'features/workspace/workspace.hook'
 import { getVesselDataviewInstance } from 'features/dataviews/dataviews.utils'
-import {
-  getRelatedDatasetByType,
-  getRelatedDatasetsByType,
-} from 'features/datasets/datasets.selectors'
+import { getRelatedDatasetsByType } from 'features/datasets/datasets.selectors'
 import I18nNumber from 'features/i18n/i18nNumber'
 import {
   SUBLAYER_INTERACTION_TYPES_WITH_VESSEL_INTERACTION,
@@ -20,7 +16,6 @@ import {
 import { PRESENCE_POC_INTERACTION } from 'features/datasets/datasets.slice'
 import { formatI18nDate } from 'features/i18n/i18nDate'
 import { ExtendedFeatureVessel } from 'features/map/map.slice'
-import { isUserLogged } from 'features/user/user.selectors'
 import { getEventLabel } from 'utils/analytics'
 import { AsyncReducerStatus } from 'utils/async-slice'
 import styles from './Popup.module.css'
@@ -33,42 +28,22 @@ function FishingTooltipRow({ feature, showFeaturesDetails }: FishingTooltipRowPr
   const { t } = useTranslation()
   const { upsertDataviewInstance } = useDataviewInstancesConnect()
   const { fishingInteractionStatus } = useClickedEventConnect()
-  const userLogged = useSelector(isUserLogged)
 
   const onVesselClick = (vessel: ExtendedFeatureVessel) => {
-    const vesselRelatedDataset = getRelatedDatasetByType(
-      vessel.dataset,
-      DatasetTypes.Vessels,
-      userLogged
-    )
-
-    if (!vesselRelatedDataset) {
-      console.warn('Missing info related dataset for', vessel)
-    }
-    const trackRelatedDataset = getRelatedDatasetByType(
-      vessel.dataset,
-      DatasetTypes.Tracks,
-      userLogged
-    )
-    if (!trackRelatedDataset) {
-      console.warn('Missing track related dataset for', vessel)
-    }
-
-    const eventsRelatedDatasets = getRelatedDatasetsByType(vessel.dataset, DatasetTypes.Events)
-
+    const vesselEventsDatasets = getRelatedDatasetsByType(vessel.dataset, DatasetTypes.Events)
     const eventsDatasetsId =
-      eventsRelatedDatasets && eventsRelatedDatasets?.length
-        ? eventsRelatedDatasets.map((d) => d.id)
+      vesselEventsDatasets && vesselEventsDatasets?.length
+        ? vesselEventsDatasets.map((d) => d.id)
         : []
 
-    if (vesselRelatedDataset || trackRelatedDataset) {
-      const vesselDataviewInstance = getVesselDataviewInstance(vessel, {
-        trackDatasetId: trackRelatedDataset?.id,
-        infoDatasetId: vesselRelatedDataset?.id,
-        ...(eventsDatasetsId.length > 0 && { eventsDatasetsId }),
-      })
-      upsertDataviewInstance(vesselDataviewInstance)
-    }
+    const vesselDataviewInstance = getVesselDataviewInstance(vessel, {
+      trackDatasetId: vessel.trackDataset?.id,
+      infoDatasetId: vessel.infoDataset?.id,
+      ...(eventsDatasetsId.length > 0 && { eventsDatasetsId }),
+    })
+
+    upsertDataviewInstance(vesselDataviewInstance)
+
     uaEvent({
       category: 'Tracks',
       action: 'Click in vessel from grid cell panel',

--- a/applications/fishing-map/src/features/search/search.slice.ts
+++ b/applications/fishing-map/src/features/search/search.slice.ts
@@ -18,7 +18,10 @@ import { getRelatedDatasetByType } from 'features/datasets/datasets.selectors'
 
 export const RESULTS_PER_PAGE = 20
 
-export type VesselWithDatasets = Vessel & { dataset: Dataset; trackDatasetId?: string }
+export type VesselWithDatasets = Omit<Vessel, 'dataset'> & {
+  dataset: Dataset
+  trackDatasetId?: string
+}
 export type SearchType = 'basic' | 'advanced'
 export type SearchFilterKey = 'flags' | 'gearType' | 'startDate' | 'endDate'
 export type SearchFilter = {

--- a/packages/api-types/src/vessel.ts
+++ b/packages/api-types/src/vessel.ts
@@ -10,6 +10,7 @@ export interface Vessel {
   shipname: string
   firstTransmissionDate: string
   lastTransmissionDate: string
+  dataset?: string
   imo?: string
   mmsi?: string
   callsign?: string


### PR DESCRIPTION
New Panama presence dataset contains vessels from two different datasets as this configuration reflects:
```json
"relatedDatasets": [
    {
      "id": "public-panama-non-fishing-tracks:v20200331",
      "type": "carriers-tracks:v1"
    },
    {
      "id": "public-panama-non-fishing-vessels:v20200331",
      "type": "carriers-vessels:v1"
    },
    {
      "id": "public-panama-fishing-tracks:v20200331",
      "type": "carriers-tracks:v1"
    },
    {
      "id": "public-panama-fishing-vessels:v20200331",
      "type": "carriers-vessels:v1"
    }
  ]
```

This PR supports searching in all of them instead of the first one as it used to work and move some component logic to the thunk to simplify the component.