### PR TITLE
Vessel viewer/fix events request

### DIFF
--- a/applications/vessel-history/src/features/dataviews/dataviews.selectors.ts
+++ b/applications/vessel-history/src/features/dataviews/dataviews.selectors.ts
@@ -118,7 +118,7 @@ export const selectDataviewsResourceQueries = createSelector(
 )
 
 export const selectDataviewInstancesByType = (type: Generators.Type) => {
-  return createSelector([selectDataviewInstancesResolved], (dataviews) => {
+  return createSelector([selectDataviewsForResourceQuerying], (dataviews) => {
     return dataviews?.filter((dataview) => dataview.config?.type === type)
   })
 }

--- a/applications/vessel-history/src/features/dataviews/dataviews.selectors.ts
+++ b/applications/vessel-history/src/features/dataviews/dataviews.selectors.ts
@@ -57,12 +57,42 @@ export const selectDataviewInstancesMerged = createSelector(
   }
 )
 
+export const selectDataviewInstancesResolved = createSelector(
+  [
+    selectDataviewsStatus,
+    selectAllDataviews,
+    selectDatasets,
+    selectDatasetsStatus,
+    selectDataviewInstancesMerged,
+  ],
+  (
+    dataviewsStatus,
+    dataviews,
+    datasets,
+    datasetsStatus,
+    dataviewInstances
+  ): UrlDataviewInstance[] => {
+    if (
+      dataviewsStatus !== AsyncReducerStatus.Finished ||
+      datasetsStatus !== AsyncReducerStatus.Finished
+    ) {
+      return []
+    }
+    const dataviewInstancesResolved = resolveDataviews(
+      dataviewInstances as UrlDataviewInstance[],
+      dataviews,
+      datasets
+    )
+    return dataviewInstancesResolved
+  }
+)
+
 /**
  * Calls getDataviewsForResourceQuerying to prepare track dataviews' datasetConfigs.
  * Injects app-specific logic by using getDataviewsForResourceQuerying's callback
  */
 export const selectDataviewsForResourceQuerying = createSelector(
-  [selectDataviewInstancesMerged],
+  [selectDataviewInstancesResolved],
   (dataviewInstances) => {
     const thinningConfig = THINNING_LEVELS[APP_THINNING]
     const datasetConfigsTransforms: DatasetConfigsTransforms = {
@@ -80,37 +110,8 @@ export const selectDataviewsForResourceQuerying = createSelector(
   }
 )
 
-export const selectDataviewInstancesResolved = createSelector(
-  [
-    selectDataviewsStatus,
-    selectAllDataviews,
-    selectDatasets,
-    selectDatasetsStatus,
-    selectDataviewsForResourceQuerying,
-  ],
-  (
-    dataviewsStatus,
-    dataviews,
-    datasets,
-    datasetsStatus,
-    dataviewInstances
-  ): UrlDataviewInstance[] => {
-    if (
-      dataviewsStatus !== AsyncReducerStatus.Finished ||
-      datasetsStatus !== AsyncReducerStatus.Finished
-    )
-      return []
-    const dataviewInstancesResolved = resolveDataviews(
-      dataviewInstances as UrlDataviewInstance[],
-      dataviews,
-      datasets
-    )
-    return dataviewInstancesResolved
-  }
-)
-
 export const selectDataviewsResourceQueries = createSelector(
-  [selectDataviewInstancesResolved],
+  [selectDataviewsForResourceQuerying],
   (dataviews) => {
     return resolveResourcesFromDatasetConfigs(dataviews)
   }

--- a/applications/vessel-history/src/features/dataviews/dataviews.utils.ts
+++ b/applications/vessel-history/src/features/dataviews/dataviews.utils.ts
@@ -56,6 +56,7 @@ export const getVesselDataviewInstance = (
     id: `${VESSEL_LAYER_PREFIX}${vessel.id}`,
     dataviewId: DEFAULT_VESSEL_DATAVIEW_ID,
     config: {
+      type: Generators.Type.Track,
       color: DEFAULT_TRACK_COLOR,
       pointsToSegmentsSwitchLevel: null,
       event: {

--- a/applications/vessel-history/src/features/map/Map.tsx
+++ b/applications/vessel-history/src/features/map/Map.tsx
@@ -44,8 +44,8 @@ const Map = (): ReactElement => {
     let flying = false
     let centetingMap: ReturnType<typeof setTimeout>
     mapRef?.current?.getMap().on('moveend', (e: any) => {
-      if(flying) {
-        if (centetingMap){
+      if (flying) {
+        if (centetingMap) {
           clearTimeout(centetingMap)
         }
         const currentPitch = mapRef?.current?.getMap().getPitch()
@@ -57,30 +57,32 @@ const Map = (): ReactElement => {
             zoom: mapRef.current.getMap().getZoom(),
 
             pitch: currentPitch,
-            bearing: currentBearing
+            bearing: currentBearing,
           })
           setTimeout(() => {
             mapRef?.current?.getMap().easeTo({
               center: [
                 mapRef.current?.getMap().getCenter().lng,
-                mapRef.current?.getMap().getCenter().lat
+                mapRef.current?.getMap().getCenter().lat,
               ],
               zoom: mapRef.current.getMap().getZoom() + 1,
-              duration: 2000 + (ENABLE_FLYTO === FLY_EFFECTS.fly ? currentPitch * 10 + currentBearing * 10 : -500),
+              duration:
+                2000 +
+                (ENABLE_FLYTO === FLY_EFFECTS.fly ? currentPitch * 10 + currentBearing * 10 : -500),
               pitch: 0,
               bearing: 0,
             })
           }, 50)
         }, 50)
-        mapRef?.current?.getMap().fire('flyend');
+        mapRef?.current?.getMap().fire('flyend')
       }
-    });
-    mapRef?.current?.getMap().on('flystart', function(){
+    })
+    mapRef?.current?.getMap().on('flystart', function () {
       flying = true
-    });
-    mapRef?.current?.getMap().on('flyend', function(){
+    })
+    mapRef?.current?.getMap().on('flyend', function () {
       flying = false
-    });
+    })
   }
 
   const onEventChange = useCallback(
@@ -88,36 +90,38 @@ const Map = (): ReactElement => {
       const currentZoom = mapRef.current.getMap().getZoom() - 1
       if (ENABLE_FLYTO) {
         mapRef.current.getMap().flyTo({
-          center: [
-            nextEvent.position.lon,
-            nextEvent.position.lat,
-          ],
-          pitch: (ENABLE_FLYTO === FLY_EFFECTS.fly ? pitch : 0),
-          bearing: (ENABLE_FLYTO === FLY_EFFECTS.fly ? bearing : 0),
+          center: [nextEvent.position.lon, nextEvent.position.lat],
+          pitch: ENABLE_FLYTO === FLY_EFFECTS.fly ? pitch : 0,
+          bearing: ENABLE_FLYTO === FLY_EFFECTS.fly ? bearing : 0,
           zoom: currentZoom,
           padding: {
-            bottom: padding
+            bottom: padding,
           },
           speed: currentZoom / 20, // make the flying slow
-          curve: (ENABLE_FLYTO === FLY_EFFECTS.fly ? 1.5 : 2.5), // change the speed at which it zooms out
-          essential: true // this animation is considered essential with respect to prefers-reduced-motion
+          curve: ENABLE_FLYTO === FLY_EFFECTS.fly ? 1.5 : 2.5, // change the speed at which it zooms out
+          essential: true, // this animation is considered essential with respect to prefers-reduced-motion
         })
         mapRef?.current?.getMap().fire('flystart')
-        dispatchQueryParams({'latitude': nextEvent.position.lat, 'longitude': nextEvent.position.lon})
+        dispatchQueryParams({ latitude: nextEvent.position.lat, longitude: nextEvent.position.lon })
       } else {
         //with this change we will center the event in the available map on the screen
-        const coordinates = mapRef.current.getMap().project([nextEvent.position.lon, nextEvent.position.lat]);
-        const offsetCoordinates = mapRef.current.getMap().unproject([coordinates.x, coordinates.y + (padding / 2)]);
+        const coordinates = mapRef.current
+          .getMap()
+          .project([nextEvent.position.lon, nextEvent.position.lat])
+        const offsetCoordinates = mapRef.current
+          .getMap()
+          .unproject([coordinates.x, coordinates.y + padding / 2])
         setMapCoordinates({
           latitude: offsetCoordinates.lat,
           longitude: offsetCoordinates.lng,
           zoom: currentZoom,
           pitch: 0,
-          bearing: 0
+          bearing: 0,
         })
       }
-    }, [dispatchQueryParams, setMapCoordinates])
-  
+    },
+    [dispatchQueryParams, setMapCoordinates]
+  )
 
   return (
     <div className={styles.container}>

--- a/applications/vessel-history/src/features/map/info/Info.tsx
+++ b/applications/vessel-history/src/features/map/info/Info.tsx
@@ -4,7 +4,10 @@ import cx from 'classnames'
 import formatcoords from 'formatcoords'
 import { IconButton } from '@globalfishingwatch/ui-components'
 import { ApiEvent } from '@globalfishingwatch/api-types/dist/events'
-import { RenderedEvent, selectMapEvents } from 'features/vessels/activity/vessels-activity.selectors'
+import {
+  RenderedEvent,
+  selectFilteredEvents,
+} from 'features/vessels/activity/vessels-activity.selectors'
 import ActivityModalContent from 'features/profile/components/activity/ActivityModalContent'
 import ActivityDate from 'features/profile/components/activity/ActivityDate'
 import { cheapDistance } from 'utils/vessel'
@@ -19,33 +22,40 @@ const Info: React.FC<InfoProps> = (props): React.ReactElement => {
   const dispatch = useDispatch()
   const [expanded, setExpanded] = useState(false)
   const [height, setHeight] = useState(0)
-  const events: RenderedEvent[] = useSelector(selectMapEvents)
-  const eventsMap: string[] = useMemo(() => events.map(e => e.id), [events])
+  const events: RenderedEvent[] = useSelector(selectFilteredEvents)
+  const eventsMap: string[] = useMemo(() => events.map((e) => e.id), [events])
   const highlightedEvent = useSelector(selectHighlightedEvent)
   const [selectedEvent, setSelectedEvent] = useState<RenderedEvent | undefined>(undefined)
 
-  const changeVesselEvent = useCallback((actualEventId, direction) => {
+  const changeVesselEvent = useCallback(
+    (actualEventId, direction) => {
       const actualEventIndex = eventsMap.indexOf(actualEventId.id)
-      const nextPosition = direction === 'prev' ? actualEventIndex + 1 : actualEventIndex - 1;
+      const nextPosition = direction === 'prev' ? actualEventIndex + 1 : actualEventIndex - 1
       if (nextPosition >= 0 && nextPosition < eventsMap.length) {
         const nextEvent = events[nextPosition]
-        dispatch(setHighlightedEvent({id: eventsMap[nextPosition] } as ApiEvent))
-        const distance = Math.floor(cheapDistance(nextEvent.position, events[actualEventIndex].position) * 10)
+        dispatch(setHighlightedEvent({ id: eventsMap[nextPosition] } as ApiEvent))
+        const distance = Math.floor(
+          cheapDistance(nextEvent.position, events[actualEventIndex].position) * 10
+        )
         const pitch = Math.min(distance * 4, 60)
-        const bearing = Math.atan2(
-          nextEvent.position.lon - events[actualEventIndex].position.lon, 
-          nextEvent.position.lat - events[actualEventIndex].position.lat
-        ) * pitch * -1;
+        const bearing =
+          Math.atan2(
+            nextEvent.position.lon - events[actualEventIndex].position.lon,
+            nextEvent.position.lat - events[actualEventIndex].position.lat
+          ) *
+          pitch *
+          -1
         props.onEventChange(nextEvent, pitch, bearing, height)
       }
-    }, [dispatch, events, eventsMap, height, props]
+    },
+    [dispatch, events, eventsMap, height, props]
   )
 
   useEffect(() => {
-    const event = events.find(e => e.id === highlightedEvent?.id)
-    if (event){
+    const event = events.find((e) => e.id === highlightedEvent?.id)
+    if (event) {
       setSelectedEvent(event)
-    }else{
+    } else {
       setSelectedEvent(undefined)
     }
   }, [highlightedEvent, dispatch, events, selectedEvent])
@@ -53,23 +63,44 @@ const Info: React.FC<InfoProps> = (props): React.ReactElement => {
   return (
     <Fragment>
       {selectedEvent && (
-        <div className={cx(styles.infoContainer, expanded ? styles.expanded : '')} ref={el => {
-          if (!el) return;
-          setHeight(el.clientHeight) 
-        }}>
+        <div
+          className={cx(styles.infoContainer, expanded ? styles.expanded : '')}
+          ref={(el) => {
+            if (!el) return
+            setHeight(el.clientHeight)
+          }}
+        >
           <div className={cx(styles.footer, styles.panel)}>
             <div className={styles.switcher}>
-              <IconButton size="tiny" icon={expanded ? 'compare' : 'split'} type="border" onClick={() => setExpanded(!expanded)}></IconButton>
+              <IconButton
+                size="tiny"
+                icon={expanded ? 'compare' : 'split'}
+                type="border"
+                onClick={() => setExpanded(!expanded)}
+              ></IconButton>
             </div>
-            <div className={styles.eventSelector}> 
-              <IconButton icon="arrow-left" type="map-tool" size="small" onClick={() => changeVesselEvent(highlightedEvent, 'prev')}></IconButton>
+            <div className={styles.eventSelector}>
+              <IconButton
+                icon="arrow-left"
+                type="map-tool"
+                size="small"
+                onClick={() => changeVesselEvent(highlightedEvent, 'prev')}
+              ></IconButton>
               <span className={styles.coords}>
-                {formatcoords(selectedEvent.position.lat, selectedEvent.position.lon).format('DDMMssX', {
-                  latLonSeparator: ' ',
-                  decimalPlaces: 2,
-                })}
-              </span> 
-              <IconButton icon="arrow-right" type="map-tool" size="small" onClick={() => changeVesselEvent(highlightedEvent, 'next')}></IconButton>
+                {formatcoords(selectedEvent.position.lat, selectedEvent.position.lon).format(
+                  'DDMMssX',
+                  {
+                    latLonSeparator: ' ',
+                    decimalPlaces: 2,
+                  }
+                )}
+              </span>
+              <IconButton
+                icon="arrow-right"
+                type="map-tool"
+                size="small"
+                onClick={() => changeVesselEvent(highlightedEvent, 'next')}
+              ></IconButton>
             </div>
             <div className={cx(styles.footerArea)}>
               <div className={cx(styles.footerAreaContent)}>

--- a/applications/vessel-history/src/features/map/map.selectors.ts
+++ b/applications/vessel-history/src/features/map/map.selectors.ts
@@ -6,7 +6,7 @@ import {
   UrlDataviewInstance,
 } from '@globalfishingwatch/dataviews-client'
 import {
-  selectDataviewInstancesResolved,
+  selectDataviewsForResourceQuerying,
   selectDefaultBasemapGenerator,
   selectDefaultOfflineDataviewsGenerators,
 } from 'features/dataviews/dataviews.selectors'
@@ -56,7 +56,12 @@ const getGeneratorsConfig = ({
 }
 
 const selectMapGeneratorsConfig = createSelector(
-  [selectDataviewInstancesResolved, selectResources, selectHighlightedTime, selectHighlightedEvent],
+  [
+    selectDataviewsForResourceQuerying,
+    selectResources,
+    selectHighlightedTime,
+    selectHighlightedEvent,
+  ],
   (dataviews = [], resources, highlightedTime, highlightedEvent) => {
     return getGeneratorsConfig({
       dataviews,

--- a/applications/vessel-history/src/features/map/map.slice.ts
+++ b/applications/vessel-history/src/features/map/map.slice.ts
@@ -10,6 +10,7 @@ import {
 import { RootState } from 'store'
 import { selectUrlMapZoomQuery, getDateRange } from 'routes/routes.selectors'
 import { Range } from 'types'
+import { selectFilters } from 'features/profile/filters/filters.slice'
 
 export interface MapState {
   generatorsConfig: AnyGeneratorConfig[]
@@ -72,7 +73,8 @@ export const selectHighlightedTime = (state: RootState) => state.map.highlighted
 export const selectHighlightedEvent = (state: RootState) => state.map.highlightedEvent
 
 export const selectGlobalGeneratorsConfig = createSelector(
-  [selectUrlMapZoomQuery, getDateRange],
+  // TODO sync filters and url for dates
+  [selectUrlMapZoomQuery, selectFilters],
   (zoom, { start, end }) => ({
     zoom,
     start,

--- a/applications/vessel-history/src/features/profile/components/activity/Activity.tsx
+++ b/applications/vessel-history/src/features/profile/components/activity/Activity.tsx
@@ -50,7 +50,7 @@ const Activity: React.FC<ActivityProps> = (props): React.ReactElement => {
             {selectedEvent && <ActivityModalContent event={selectedEvent}></ActivityModalContent>}
           </Modal>
           <div className={styles.activityContainer}>
-            {events && events.length > 0 && (
+            {events && events.length > 0 ? (
               <AutoSizer disableWidth={true}>
                 {({ width, height }) => (
                   <List
@@ -75,6 +75,8 @@ const Activity: React.FC<ActivityProps> = (props): React.ReactElement => {
                   </List>
                 )}
               </AutoSizer>
+            ) : (
+              <p>No events results, try change the filters</p>
             )}
           </div>
         </Fragment>

--- a/applications/vessel-history/src/features/vessels/activity/vessels-activity.selectors.ts
+++ b/applications/vessel-history/src/features/vessels/activity/vessels-activity.selectors.ts
@@ -137,8 +137,8 @@ export const selectEventsWithRenderingInfo = createSelector(
             : '',
           duration.minutes && duration.minutes > 0
             ? t('event.minuteAbbreviated', '{{count}}m', {
-              count: Math.round(duration.minutes as number),
-            })
+                count: Math.round(duration.minutes as number),
+              })
             : '',
         ].join(' ')
 
@@ -206,21 +206,12 @@ const getEventRegionDescription = (event: ActivityEvent, eezs: Region[], rfmos: 
   return regionsDescription ?? ''
 }
 
-export const selectEvents = createSelector(
-  [selectEventsWithRenderingInfo],
-  (events) => events.flat().sort((a, b) => (a.start > b.start ? -1 : 1))
-)
-
-export const selectMapEvents = createSelector(
-  [selectEvents, selectFilters],
-  (events, filters) => {
-    const startDate = DateTime.fromISO(filters.start, { zone: 'utc' })
-    return events.filter(event => event.start >= startDate.toMillis())
-  }
+export const selectEvents = createSelector([selectEventsWithRenderingInfo], (events) =>
+  events.flat().sort((a, b) => (a.start > b.start ? -1 : 1))
 )
 
 export const selectFilteredEvents = createSelector(
-  [selectMapEvents, selectFilters],
+  [selectEvents, selectFilters],
   (events, filters) => {
     // Need to parse the timerange start and end dates in UTC
     // to not exclude events in the boundaries of the range
@@ -233,30 +224,28 @@ export const selectFilteredEvents = createSelector(
     const endDate = DateTime.fromISO(`${endDateUTC}T23:59:59.999Z`, { zone: 'utc' })
     const interval = Interval.fromDateTimes(startDate, endDate)
 
-    return events
-      .filter((event: RenderedEvent) => {
-        if (
-          !interval.contains(DateTime.fromMillis(event.start as number)) &&
-          !interval.contains(DateTime.fromMillis(event.end as number))
-        ) {
-          return false
-        }
-        if (event.type === 'fishing') {
-          return filters.fishingEvents
-        }
-        if (event.type === 'loitering') {
-          return filters.loiteringEvents
-        }
-        if (event.type === 'encounter') {
-          return filters.encounters
-        }
-        if (event.type === 'port_visit') {
-          return filters.portVisits
-        }
+    return events.filter((event: RenderedEvent) => {
+      if (
+        !interval.contains(DateTime.fromMillis(event.start as number)) &&
+        !interval.contains(DateTime.fromMillis(event.end as number))
+      ) {
+        return false
+      }
+      if (event.type === 'fishing') {
+        return filters.fishingEvents
+      }
+      if (event.type === 'loitering') {
+        return filters.loiteringEvents
+      }
+      if (event.type === 'encounter') {
+        return filters.encounters
+      }
+      if (event.type === 'port_visit') {
+        return filters.portVisits
+      }
 
-        return true
-      })
-
+      return true
+    })
   }
 )
 


### PR DESCRIPTION
Fixed missing params in events request to get:
![image](https://user-images.githubusercontent.com/10500650/131495047-df8f925f-1af2-40eb-be4a-c17a1f4a4797.png)


Added placeholder when no events results in the current filter selection
![image](https://user-images.githubusercontent.com/10500650/131501965-64d9fac9-98d8-4485-9258-d5c4381fd015.png)

TODO:
- [ ] Sync filters with url to use in the [globalGeneratorsConfig](https://github.com/GlobalFishingWatch/frontend/pull/863/files#diff-b3447a53692159ccb266e4830b90d75daa60daf1422ad2d60075681648aa08baR77)
- [ ] Style placeholder when no events