### PR TITLE
Fixed failing tests with old vessel source values (GFW+TMT)

### DIFF
--- a/applications/vessel-history/src/features/vessel-list-item/VesselListItem.test.tsx
+++ b/applications/vessel-history/src/features/vessel-list-item/VesselListItem.test.tsx
@@ -42,7 +42,7 @@ describe('<VesselListItem />', () => {
       </I18nextProvider>
     )
     expect(component.getAllByText('source').length).toBe(1)
-    expect(component.getAllByText('GFW+TMT').length).toBe(1)
+    expect(component.getAllByText('AIS+Other').length).toBe(1)
     expect(component.asFragment()).toMatchSnapshot()
   })
 

--- a/applications/vessel-history/src/features/vessel-list-item/__snapshots__/VesselListItem.test.tsx.snap
+++ b/applications/vessel-history/src/features/vessel-list-item/__snapshots__/VesselListItem.test.tsx.snap
@@ -75,7 +75,7 @@ exports[`<VesselListItem /> shows source API in environments others than product
         <label>
           source
         </label>
-        GFW+TMT
+        AIS+Other
       </div>
       <div>
         <label>


### PR DESCRIPTION
updated snapshots to validate vessel source with new values `AIS+Other` instead of `GFW+TMT`