### PR TITLE
Fishing map/port events

### DIFF
--- a/.changeset/wild-hornets-itch.md
+++ b/.changeset/wild-hornets-itch.md
@@ -1,0 +1,5 @@
+---
+'@globalfishingwatch/api-types': patch
+---
+
+add dataview info config types

--- a/applications/fishing-map/public/locales/en/translations.json
+++ b/applications/fishing-map/public/locales/en/translations.json
@@ -152,6 +152,7 @@
     "notInCVP": "Event not available.",
     "port": "Port",
     "portAction": "Docked for",
+    "port_visit": "Port visit",
     "portAt": "Docked at {{port}} for",
     "seeInCVP": "See in carrier vessel portal",
     "unknown": "Unknown event"

--- a/applications/fishing-map/public/locales/source/translations.json
+++ b/applications/fishing-map/public/locales/source/translations.json
@@ -152,6 +152,7 @@
     "notInCVP": "This event happened outside the timerange of the Carrier Vessel Portal data",
     "port": "Port",
     "portAction": "Docked for",
+    "port_visit": "Port visit",
     "portAt": "Docked at {{port}} for",
     "seeInCVP": "See in Carrier Vessel Portal",
     "unknown": "Unknown event"

--- a/applications/fishing-map/src/data/config.ts
+++ b/applications/fishing-map/src/data/config.ts
@@ -76,7 +76,7 @@ export const EVENTS_COLORS: Record<string, string> = {
   encounterunmatched: '#CE2C54',
   encounter: '#FAE9A0',
   loitering: '#cfa9f9',
-  port: '#99EEFF',
+  port_visit: '#99EEFF',
   fishing: '#fff',
   fishingLabels: '#163f89',
 }

--- a/applications/fishing-map/src/features/dataviews/dataviews.mock.ts
+++ b/applications/fishing-map/src/features/dataviews/dataviews.mock.ts
@@ -1,4 +1,4 @@
-import { Dataview } from '@globalfishingwatch/api-types/dist'
+import type { Dataview } from '@globalfishingwatch/api-types/dist'
 
 export const dataviews: Dataview[] = []
 

--- a/applications/fishing-map/src/features/workspace/vessels/VesselEventsLegend.tsx
+++ b/applications/fishing-map/src/features/workspace/vessels/VesselEventsLegend.tsx
@@ -9,6 +9,7 @@ import { selectVisibleEvents } from 'features/app/app.selectors'
 import styles from 'features/workspace/shared/Sections.module.css'
 import { getEventsDatasetsInDataview } from 'features/datasets/datasets.utils'
 import { useLocationConnect } from 'routes/routes.hook'
+import { upperFirst } from 'utils/info'
 import layerStyles from './VesselSection.module.css'
 
 type VesselEventsLegendProps = {
@@ -83,7 +84,7 @@ function VesselEventsLegend({ dataviews }: VesselEventsLegendProps): React.React
                 }
               />
               <label className={layerStyles.eventLegendLabel} htmlFor={eventType}>
-                {t(`event.${eventType}` as any, eventType)}
+                {upperFirst(t(`event.${eventType}` as any, eventType))}
               </label>
             </li>
           )

--- a/applications/fishing-map/src/features/workspace/vessels/VesselSection.module.css
+++ b/applications/fishing-map/src/features/workspace/vessels/VesselSection.module.css
@@ -44,7 +44,7 @@
   position: relative;
   padding-left: 0.5rem;
   font: var(--font-S);
-  text-transform: capitalize;
+  text-transform: none;
 }
 
 .eventLegendCheckbox:not(:checked) + .eventLegendLabel {

--- a/packages/api-types/src/dataviews.ts
+++ b/packages/api-types/src/dataviews.ts
@@ -34,7 +34,7 @@ export interface DataviewCreation<T = any> {
 
 export interface DataviewInfoConfigField {
   id: string
-  type: 'flag' | 'number' | 'date'
+  type: 'flag' | 'number' | 'date' | 'fleet' | 'string'
   mandatory?: boolean
   guest?: boolean
 }


### PR DESCRIPTION
Include port events with confidence 4

![image](https://user-images.githubusercontent.com/10500650/133449942-1993196a-4570-4c8f-9066-3073500963b5.png)

![image](https://user-images.githubusercontent.com/10500650/133449738-84636b15-4548-46c8-bea7-9d85e6e8ca54.png)

Configuration required:
- Updated `public-global-fishing-effort:v20201001` dataset to include `public-global-port-visits-c2-events:v20201001` as realtedDataset
- Updated vesselDataview datasetsConfig with:
```json
{
      "query": [
        {
          "id": "vessels",
          "value": ""
        },
        {
          "id": "summary",
          "value": true
        },
        {
          "id": "confidences",
          "value": 4
        }
      ],
      "params": [],
      "endpoint": "carriers-events",
      "datasetId": "public-global-port-visits-c2-events:v20201001"
    }
```