### PR TITLE
Vessel viewer/show events out of voyages

### DIFF
--- a/applications/vessel-history/src/features/vessels/voyages/voyages.hook.ts
+++ b/applications/vessel-history/src/features/vessels/voyages/voyages.hook.ts
@@ -23,29 +23,32 @@ function useVoyagesConnect() {
   )
 
   const events: (RenderedEvent | RenderedVoyage)[] = useMemo(() => {
-    return eventsList
-      .map((event, index, allEvents) => {
-        if (event.type === EventTypeVoyage.Voyage) {
-          return {
-            ...event,
-            status: expandedVoyages[event.timestamp] ? 'expanded' : 'collapsed',
-          } as RenderedVoyage
-        } else {
-          return event as RenderedEvent
-        }
-      })
-      .filter((event) => {
-        return (
-          event.type === EventTypeVoyage.Voyage ||
-          Object.values(expandedVoyages).find(
-            (voyage) =>
-              voyage !== undefined &&
-              // event timestamp or start is inside the voyage
-              voyage.start <= (event.timestamp ?? event.start) &&
-              voyage.end >= (event.timestamp ?? event.start)
+    const hasVoyages =
+      eventsList.filter((event) => event.type === EventTypeVoyage.Voyage).length > 0
+    const eventsListParsed = eventsList.map((event) => {
+      if (event.type === EventTypeVoyage.Voyage) {
+        return {
+          ...event,
+          status: expandedVoyages[event.timestamp] ? 'expanded' : 'collapsed',
+        } as RenderedVoyage
+      } else {
+        return event as RenderedEvent
+      }
+    })
+    return hasVoyages
+      ? eventsListParsed.filter((event) => {
+          return (
+            event.type === EventTypeVoyage.Voyage ||
+            Object.values(expandedVoyages).find(
+              (voyage) =>
+                voyage !== undefined &&
+                // event timestamp or start is inside the voyage
+                voyage.start <= (event.timestamp ?? event.start) &&
+                voyage.end >= (event.timestamp ?? event.start)
+            )
           )
-        )
-      })
+        })
+      : eventsListParsed
   }, [eventsList, expandedVoyages])
 
   useEffect(() => {


### PR DESCRIPTION
Fixes [VV-201](https://globalfishingwatch.atlassian.net/browse/VV-201) rendering the events which are out of the voyage

<img width="1436" alt="image" src="https://user-images.githubusercontent.com/10500650/133804802-86b4f2d2-0302-4b3c-b77c-d2d60e869ec6.png">
