### PR TITLE
VV-239 Refresh token automatically

### DIFF
--- a/applications/vessel-history/src/App.tsx
+++ b/applications/vessel-history/src/App.tsx
@@ -24,7 +24,7 @@ function App() {
 
   const locationType = useSelector(getLocationType)
 
-  if (loading || minLoading || !logged || !authorized) {
+  if (((loading || minLoading) && !logged) || !authorized) {
     return <Splash intro={minLoading} />
   }
   if (locationType === SETTINGS) {

--- a/applications/vessel-history/src/features/app/analytics.hooks.ts
+++ b/applications/vessel-history/src/features/app/analytics.hooks.ts
@@ -1,4 +1,4 @@
-import { useEffect } from 'react'
+import { useEffect, useState } from 'react'
 import { initialize as uaInitialize, set as uaSet, pageview, event as uaEvent } from 'react-ga'
 import {
   GOOGLE_UNIVERSAL_ANALYTICS_ID,
@@ -25,10 +25,16 @@ export const useAnalytics = () => {
       pageview(window.location.pathname + window.location.search)
     }
   }, [])
-  const { user } = useUser()
+  const { user, logged } = useUser()
+  const [trackLogin, setTrackLogin] = useState(true)
+
+  // Set to track login only when the user has logged out
+  useEffect(() => {
+    !logged && setTrackLogin(true)
+  }, [logged])
 
   useEffect(() => {
-    if (user && GOOGLE_UNIVERSAL_ANALYTICS_ID) {
+    if (user && GOOGLE_UNIVERSAL_ANALYTICS_ID && trackLogin) {
       uaSet({
         dimension1: `${user.id}`,
         dimension3: `${JSON.stringify(user.groups)}` ?? '',
@@ -47,12 +53,11 @@ export const useAnalytics = () => {
           userLanguage: user.language,
         },
       })
-      // TODO Ensure this is not tracked when refreshing the token
-      // before searching
       uaEvent({
         category: 'User',
         action: 'Login',
       })
+      setTrackLogin(false)
     }
-  }, [user])
+  }, [user, trackLogin])
 }

--- a/applications/vessel-history/src/features/app/analytics.hooks.ts
+++ b/applications/vessel-history/src/features/app/analytics.hooks.ts
@@ -1,6 +1,10 @@
 import { useEffect } from 'react'
 import { initialize as uaInitialize, set as uaSet, pageview, event as uaEvent } from 'react-ga'
-import { GOOGLE_UNIVERSAL_ANALYTICS_ID, GOOGLE_UNIVERSAL_ANALYTICS_INIT_OPTIONS, IS_PRODUCTION } from 'data/config'
+import {
+  GOOGLE_UNIVERSAL_ANALYTICS_ID,
+  GOOGLE_UNIVERSAL_ANALYTICS_INIT_OPTIONS,
+  IS_PRODUCTION,
+} from 'data/config'
 import { useUser } from 'features/user/user.hooks'
 
 export const useAnalytics = () => {
@@ -43,6 +47,8 @@ export const useAnalytics = () => {
           userLanguage: user.language,
         },
       })
+      // TODO Ensure this is not tracked when refreshing the token
+      // before searching
       uaEvent({
         category: 'User',
         action: 'Login',

--- a/applications/vessel-history/src/features/home/Home.tsx
+++ b/applications/vessel-history/src/features/home/Home.tsx
@@ -5,7 +5,6 @@ import { event as uaEvent } from 'react-ga'
 import Link from 'redux-first-router-link'
 import { redirect } from 'redux-first-router'
 import { DateTime, Interval } from 'luxon'
-import GFWAPI from '@globalfishingwatch/api-client'
 import { VesselSearch } from '@globalfishingwatch/api-types'
 import Logo from '@globalfishingwatch/ui-components/dist/logo'
 import { Spinner, IconButton, Button } from '@globalfishingwatch/ui-components'
@@ -50,8 +49,6 @@ const Home: React.FC<LoaderProps> = (): React.ReactElement => {
   const totalResults = useSelector(selectSearchTotalResults)
   const offlineVessels = useSelector(selectAllOfflineVessels)
   const { dispatchFetchOfflineVessels, dispatchDeleteOfflineVessel } = useOfflineVesselsAPI()
-
-  // useEffect(() => GFWAPI.setConfig({ ...GFWAPI.getConfig(), debug: true }))
 
   useEffect(() => {
     dispatchFetchOfflineVessels()
@@ -135,7 +132,6 @@ const Home: React.FC<LoaderProps> = (): React.ReactElement => {
           <IconButton type="default" size="default" icon="settings"></IconButton>
         </Link>
         <LanguageToggle />
-        <button onClick={() => GFWAPI.setToken('97yfghuwe')}>invalidate token</button>
       </header>
       <div className={styles.search}>
         <AdvancedSearch />

--- a/applications/vessel-history/src/features/search/AdvancedSearch.tsx
+++ b/applications/vessel-history/src/features/search/AdvancedSearch.tsx
@@ -74,7 +74,7 @@ const AdvancedSearch: React.FC = () => {
         <InputText
           inputSize="small"
           onChange={onMainQueryChange}
-          value={query}
+          value={query ?? ''}
           label={t('search.shipname', 'Name')}
           autoFocus
           className={styles.full}
@@ -84,7 +84,7 @@ const AdvancedSearch: React.FC = () => {
           onChange={setQueryParam}
           id="MMSI"
           className={styles.width8ch}
-          value={MMSI}
+          value={MMSI ?? ''}
           label={t('search.MMSI', 'MMSI')}
         />
         <InputText
@@ -92,7 +92,7 @@ const AdvancedSearch: React.FC = () => {
           onChange={setQueryParam}
           id="IMO"
           className={styles.width7ch}
-          value={IMO}
+          value={IMO ?? ''}
           label={t('search.IMO', 'IMO')}
         />
         <InputText
@@ -100,7 +100,7 @@ const AdvancedSearch: React.FC = () => {
           onChange={setQueryParam}
           id="callsign"
           className={styles.width6ch}
-          value={callsign}
+          value={callsign ?? ''}
           label={t('search.callsign', 'Callsign')}
         />
       </div>
@@ -123,7 +123,7 @@ const AdvancedSearch: React.FC = () => {
       </div>
       <div className={styles.row}>
         <InputDate
-          value={lastTransmissionDate}
+          value={lastTransmissionDate ?? ''}
           className={styles.full}
           max={DEFAULT_WORKSPACE.availableEnd.slice(0, 10) as string}
           min={DEFAULT_WORKSPACE.availableStart.slice(0, 10) as string}
@@ -140,7 +140,7 @@ const AdvancedSearch: React.FC = () => {
           }}
         />
         <InputDate
-          value={firstTransmissionDate}
+          value={firstTransmissionDate ?? ''}
           className={styles.full}
           max={DEFAULT_WORKSPACE.availableEnd.slice(0, 10) as string}
           min={DEFAULT_WORKSPACE.availableStart.slice(0, 10) as string}

--- a/applications/vessel-history/src/features/search/AdvancedSearch.tsx
+++ b/applications/vessel-history/src/features/search/AdvancedSearch.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useMemo } from 'react'
 import cx from 'classnames'
-import { useDispatch, useSelector } from 'react-redux'
+import { useSelector } from 'react-redux'
 import { useTranslation } from 'react-i18next'
 import InputText from '@globalfishingwatch/ui-components/dist/input-text'
 import InputDate from '@globalfishingwatch/ui-components/dist/input-date'
@@ -9,23 +9,21 @@ import { Button } from '@globalfishingwatch/ui-components'
 import { useLocationConnect } from 'routes/routes.hook'
 import {
   selectAdvancedSearchCallsign,
-  selectAdvancedSearchFields,
   selectAdvancedSearchFlags,
   selectAdvancedSearchIMO,
   selectAdvancedSearchMMSI,
   selectFirstTransmissionDate,
   selectLastTransmissionDate,
-  selectUrlQuery,
 } from 'routes/routes.selectors'
 import { getFlags } from 'utils/flags'
 import { DEFAULT_WORKSPACE } from 'data/config'
-import { fetchVesselSearchThunk } from './search.thunk'
+import { useSearchConnect } from './search.hooks'
 import styles from './AdvancedSearch.module.css'
 
 const AdvancedSearch: React.FC = () => {
   const { t } = useTranslation()
-  const dispatch = useDispatch()
-  const query = useSelector(selectUrlQuery)
+
+  const { query, fetchResults } = useSearchConnect()
   const MMSI = useSelector(selectAdvancedSearchMMSI)
   const IMO = useSelector(selectAdvancedSearchIMO)
   const callsign = useSelector(selectAdvancedSearchCallsign)
@@ -38,17 +36,6 @@ const AdvancedSearch: React.FC = () => {
     return flags.map((id) => ({ id, label: allFlagOptions.find((f) => f.id === id)?.label || '' }))
   }, [flags, allFlagOptions])
 
-  const advancedSearch = useSelector(selectAdvancedSearchFields)
-  const fetchResults = useCallback(() => {
-    dispatch(
-      fetchVesselSearchThunk({
-        query,
-        offset: 0,
-        advancedSearch,
-      })
-    )
-  }, [dispatch, query, advancedSearch])
-
   const { dispatchQueryParams } = useLocationConnect()
 
   const setQueryParam = useCallback(
@@ -58,6 +45,13 @@ const AdvancedSearch: React.FC = () => {
       })
     },
     [dispatchQueryParams]
+  )
+
+  const onSearchClick = useCallback(
+    (e) => {
+      fetchResults()
+    },
+    [fetchResults]
   )
 
   const onMainQueryChange = useCallback(
@@ -164,7 +158,7 @@ const AdvancedSearch: React.FC = () => {
         />
       </div>
       <div className={cx(styles.row, styles.flexEnd)}>
-        <Button className={styles.cta} onClick={fetchResults}>
+        <Button className={styles.cta} onClick={onSearchClick}>
           {t('search.title', 'Search')}
         </Button>
       </div>

--- a/applications/vessel-history/src/features/search/search.thunk.ts
+++ b/applications/vessel-history/src/features/search/search.thunk.ts
@@ -111,40 +111,35 @@ export type VesselSearchThunk = {
   advancedSearch?: Record<string, any>
 }
 
-const trackData = (
-  query: any,
-  results: SearchResults | null,
-  actualResults: number
-) => {
+const trackData = (query: any, results: SearchResults | null, actualResults: number) => {
   if (!query.offset || query.offset === 0) {
-    const vessels = results?.vessels.slice(0, 5).map(vessel => {
+    const vessels = results?.vessels.slice(0, 5).map((vessel) => {
       return {
         gfw: vessel.id,
-        tmt: vessel.vesselMatchId
+        tmt: vessel.vesselMatchId,
       }
     })
     uaEvent({
       category: 'Search Vessel VV',
       action: 'Click Search',
       label: JSON.stringify({ ...query, vessels }),
-      value: results?.total
+      value: results?.total,
     })
   } else {
     uaEvent({
       category: 'Search Vessel VV',
       action: 'Click Load More',
       label: actualResults.toString(),
-      value: results?.total
+      value: results?.total,
     })
   }
-
 }
 
 export const fetchVesselSearchThunk = createAsyncThunk(
   'search/vessels',
   async (
     { query, offset, advancedSearch }: VesselSearchThunk,
-    { rejectWithValue, getState, signal }
+    { rejectWithValue, getState, signal, dispatch }
   ) => {
     const searchData = await fetchData(query, offset, signal, advancedSearch)
     trackData({ query: query, ...advancedSearch }, searchData, 5)

--- a/applications/vessel-history/src/features/user/user.hooks.ts
+++ b/applications/vessel-history/src/features/user/user.hooks.ts
@@ -1,16 +1,30 @@
-import { useCallback, useMemo } from 'react'
+import { useCallback, useEffect, useMemo } from 'react'
 import { intersection } from 'lodash'
 import { event as uaEvent } from 'react-ga'
-import { useDispatch } from 'react-redux'
-import useGFWLogin from '@globalfishingwatch/react-hooks/dist/use-login'
-import GFWAPI from '@globalfishingwatch/api-client'
+import { useSelector, useDispatch } from 'react-redux'
+import GFWAPI, { getAccessTokenFromUrl } from '@globalfishingwatch/api-client'
 import { AUTHORIZED_USER_GROUPS } from 'data/config'
 import { BASE_URL } from 'data/constants'
-import { logoutUserThunk } from './user.slice'
+import { AsyncReducerStatus } from 'utils/async-slice'
+import {
+  fetchUserThunk,
+  logoutUserThunk,
+  selectUserData,
+  selectUserLogged,
+  selectUserStatus,
+} from './user.slice'
 
 export const useUser = () => {
   const dispatch = useDispatch()
-  const { loading, logged, user } = useGFWLogin(GFWAPI)
+
+  const logged = useSelector(selectUserLogged)
+  const user = useSelector(selectUserData)
+  const status = useSelector(selectUserStatus)
+
+  const accessToken = getAccessTokenFromUrl()
+  const token = GFWAPI.getToken()
+  const refreshToken = GFWAPI.getRefreshToken()
+
   const authorized = useMemo(() => {
     return user && intersection(user.groups, AUTHORIZED_USER_GROUPS).length > 0
   }, [user])
@@ -28,5 +42,16 @@ export const useUser = () => {
     dispatch(logoutUserThunk({ redirectTo: 'home' }))
   }, [dispatch])
 
-  return { loading, logged, user, authorized, login, logout }
+  useEffect(() => {
+    if (!logged && (token || refreshToken || accessToken)) dispatch(fetchUserThunk())
+  }, [accessToken, dispatch, logged, refreshToken, token])
+
+  return {
+    loading: status !== AsyncReducerStatus.Finished,
+    logged,
+    user,
+    authorized,
+    login,
+    logout,
+  }
 }

--- a/applications/vessel-history/src/features/user/user.slice.ts
+++ b/applications/vessel-history/src/features/user/user.slice.ts
@@ -1,5 +1,48 @@
-import { createAsyncThunk } from '@reduxjs/toolkit'
-import GFWAPI from '@globalfishingwatch/api-client'
+import { createAsyncThunk, createSlice } from '@reduxjs/toolkit'
+import { UserData } from '@globalfishingwatch/api-types'
+import GFWAPI, {
+  getAccessTokenFromUrl,
+  removeAccessTokenFromUrl,
+} from '@globalfishingwatch/api-client'
+import { AsyncReducerStatus } from 'utils/async-slice'
+import { RootState } from 'store'
+
+interface UserState {
+  logged: boolean
+  status: AsyncReducerStatus
+  data: UserData | null
+}
+
+const initialState: UserState = {
+  logged: false,
+  status: AsyncReducerStatus.Idle,
+  data: null,
+}
+
+export const GFW_GROUP_ID = 'GFW'
+
+export const fetchUserThunk = createAsyncThunk(
+  'user/fetch',
+  async () => {
+    const accessToken = getAccessTokenFromUrl()
+    if (accessToken) {
+      removeAccessTokenFromUrl()
+    }
+
+    try {
+      return await GFWAPI.login({ accessToken })
+    } catch (e: any) {
+      await logoutUserThunk({ redirectTo: 'gfw-login' })
+      return undefined
+    }
+  },
+  {
+    condition: (_, { getState, extra }) => {
+      const status = selectUserStatus(getState() as RootState)
+      return status !== AsyncReducerStatus.Loading
+    },
+  }
+)
 
 export const logoutUserThunk = createAsyncThunk(
   'user/logout',
@@ -17,3 +60,33 @@ export const logoutUserThunk = createAsyncThunk(
     }
   }
 )
+
+const userSlice = createSlice({
+  name: 'user',
+  initialState,
+  reducers: {},
+  extraReducers: (builder) => {
+    builder.addCase(fetchUserThunk.pending, (state) => {
+      state.status = AsyncReducerStatus.Loading
+    })
+    builder.addCase(fetchUserThunk.fulfilled, (state, action) => {
+      state.status = AsyncReducerStatus.Finished
+      state.logged = true
+      state.data = action.payload ?? null
+    })
+    builder.addCase(fetchUserThunk.rejected, (state) => {
+      state.status = AsyncReducerStatus.Error
+    })
+    builder.addCase(logoutUserThunk.fulfilled, (state) => {
+      state.logged = false
+      state.data = null
+    })
+  },
+})
+
+export const selectUserData = (state: RootState) => state.user.data
+export const selectUserStatus = (state: RootState) => state.user.status
+export const selectUserLogged = (state: RootState) => state.user.logged
+export const isGFWUser = (state: RootState) => state.user.data?.groups.includes(GFW_GROUP_ID)
+
+export default userSlice.reducer

--- a/applications/vessel-history/src/store.ts
+++ b/applications/vessel-history/src/store.ts
@@ -12,6 +12,7 @@ import datasetsReducer from './features/datasets/datasets.slice'
 import psmaReducer from './features/psma/psma.slice'
 import regionsReducer from './features/regions/regions.slice'
 import resourcesReducer from './features/resources/resources.slice'
+import userReducer from './features/user/user.slice'
 import workspaceReducer from './features/workspace/workspace.slice'
 
 const {
@@ -33,6 +34,7 @@ const rootReducer = combineReducers({
   psma: psmaReducer,
   regions: regionsReducer,
   resources: resourcesReducer,
+  user: userReducer,
   workspace: workspaceReducer,
 })
 


### PR DESCRIPTION
https://globalfishingwatch.atlassian.net/browse/VV-239
- [x] Ensure the user has a valid token before performing the vessel search
- [x] Stop using useGFWLogin in multiple components to reduce the number of successive unnecessary calls to `/auth/me`
- [x] Enhanced user hook to share its state thru redux centralizing user data and actions
- [x] Refactored advanced search logic into a hook
- [x] Fixed warning in AdvancedSearch `A component is changing an uncontrolled input to be controlled.` 
- [x] Fixed analytics to not track user refresh data & token as login event