### PR TITLE
VV-245 Improve UX - Time related activity and map view

### DIFF
--- a/applications/vessel-history/src/features/event-filters/EventFilters.tsx
+++ b/applications/vessel-history/src/features/event-filters/EventFilters.tsx
@@ -24,19 +24,20 @@ const EventFilters: React.FC<ModalProps> = (props): React.ReactElement => {
   const isFishingEventsActive = useSelector(selectFilter('fishingEvents'))
   const isEncountersActive = useSelector(selectFilter('encounters'))
   const isLoiteringEventsActive = useSelector(selectFilter('loiteringEvents'))
-  const start = useSelector(selectStart).slice(0, 10) as string
-  const end = useSelector(selectEnd).slice(0, 10) as string
+  const start = useSelector(selectStart)?.slice(0, 10) as string
+  const end = useSelector(selectEnd)?.slice(0, 10) as string
 
   const trackAndSetFilter = useCallback(
     (tab: 'MAP' | 'ACTIVITY', filter: availableEventFilters, value: boolean) => {
       uaEvent({
         category: 'Vessel Detail ACTIVITY or MAP Tab',
         action: 'Click Filter Icon - Event type',
-        label: JSON.stringify({ [filter]: value, tab: tab })
+        label: JSON.stringify({ [filter]: value, tab: tab }),
       })
       setFilter(filter, value)
     },
-  [setFilter])
+    [setFilter]
+  )
 
   return (
     <Modal
@@ -85,7 +86,7 @@ const EventFilters: React.FC<ModalProps> = (props): React.ReactElement => {
           }
         }}
         onRemove={() => {
-          setDate('start', DEFAULT_WORKSPACE.start)
+          setDate('start', undefined)
         }}
         label={t(`filters.start` as any, 'Start')}
         max={DEFAULT_WORKSPACE.end}
@@ -99,7 +100,7 @@ const EventFilters: React.FC<ModalProps> = (props): React.ReactElement => {
           }
         }}
         onRemove={() => {
-          setDate('end', DEFAULT_WORKSPACE.end)
+          setDate('end', undefined)
         }}
         label={t(`filters.start` as any, 'End')}
         max={DEFAULT_WORKSPACE.end}

--- a/applications/vessel-history/src/features/event-filters/filters.hooks.ts
+++ b/applications/vessel-history/src/features/event-filters/filters.hooks.ts
@@ -1,18 +1,11 @@
 import { useDispatch, useSelector } from 'react-redux'
-import {
-  selectFilters,
-  updateFilters,
-  availableEventFilters,
-} from './filters.slice'
+import { selectFilters, updateFilters, availableEventFilters } from './filters.slice'
 
 export const useApplyFiltersConnect = () => {
   const dispatch = useDispatch()
   const filters = useSelector(selectFilters)
 
-  const setFilter = (
-    filter: availableEventFilters,
-    value: boolean
-  ) => {
+  const setFilter = (filter: availableEventFilters, value: boolean) => {
     const newFilters = {
       ...filters,
       [filter]: value,
@@ -20,10 +13,7 @@ export const useApplyFiltersConnect = () => {
     dispatch(updateFilters(newFilters))
   }
 
-  const setDate = (
-    filter: 'start' | 'end',
-    value: string
-  ) => {
+  const setDate = (filter: 'start' | 'end', value?: string) => {
     const newFilters = {
       ...filters,
       [filter]: value,
@@ -38,6 +28,6 @@ export const useApplyFiltersConnect = () => {
   return {
     setFilter,
     setDate,
-    resetFilters
+    resetFilters,
   }
 }

--- a/applications/vessel-history/src/features/event-filters/filters.slice.ts
+++ b/applications/vessel-history/src/features/event-filters/filters.slice.ts
@@ -1,17 +1,20 @@
 import { createSelector, createSlice, PayloadAction } from '@reduxjs/toolkit'
-import { memoize } from 'lodash';
-import { DEFAULT_WORKSPACE } from 'data/config';
+import { memoize } from 'lodash'
 import { RootState } from 'store'
 
-export type availableEventFilters = 'portVisits' | 'fishingEvents' | 'encounters' | 'loiteringEvents'
+export type availableEventFilters =
+  | 'portVisits'
+  | 'fishingEvents'
+  | 'encounters'
+  | 'loiteringEvents'
 
 export type Filters = {
   portVisits: boolean
   fishingEvents: boolean
   encounters: boolean
   loiteringEvents: boolean
-  start: string,
-  end: string
+  start?: string
+  end?: string
 }
 
 export type FiltersSlice = {
@@ -23,8 +26,6 @@ export const initialState: FiltersSlice = {
     encounters: true,
     loiteringEvents: true,
     portVisits: true,
-    start: DEFAULT_WORKSPACE.start,
-    end: DEFAULT_WORKSPACE.end,
   },
 }
 
@@ -49,7 +50,6 @@ export const selectEnd = (state: RootState) => state.filters.filters.end
 
 export const selectFilter = memoize((field: availableEventFilters) =>
   createSelector([selectFilters], (filters: Filters) => {
-
     return filters[field] as boolean
   })
 )

--- a/applications/vessel-history/src/features/vessels/activity/vessels-activity.selectors.ts
+++ b/applications/vessel-history/src/features/vessels/activity/vessels-activity.selectors.ts
@@ -7,7 +7,7 @@ import {
   selectResources,
 } from '@globalfishingwatch/dataviews-client'
 import { DatasetTypes, EventTypes, ResourceStatus } from '@globalfishingwatch/api-types'
-import { EVENTS_COLORS } from 'data/config'
+import { DEFAULT_WORKSPACE, EVENTS_COLORS } from 'data/config'
 import { Filters, initialState, selectFilters } from 'features/event-filters/filters.slice'
 import { t } from 'features/i18n/i18n'
 import { selectActiveTrackDataviews } from 'features/dataviews/dataviews.selectors'
@@ -265,11 +265,15 @@ export const selectFilteredEvents = createSelector(
     // Need to parse the timerange start and end dates in UTC
     // to not exclude events in the boundaries of the range
     // if the user setting the filter is in a timezone with offset != 0
-    const startDate = DateTime.fromISO(filters.start, { zone: 'utc' })
+    const startDate = DateTime.fromISO(filters.start ?? DEFAULT_WORKSPACE.availableStart, {
+      zone: 'utc',
+    })
 
     // Setting the time to 23:59:59.99 so the events in that same day
     //  are also displayed
-    const endDateUTC = DateTime.fromISO(filters.end, { zone: 'utc' }).toISODate()
+    const endDateUTC = DateTime.fromISO(filters.end ?? DEFAULT_WORKSPACE.availableEnd, {
+      zone: 'utc',
+    }).toISODate()
     const endDate = DateTime.fromISO(`${endDateUTC}T23:59:59.999Z`, { zone: 'utc' })
     const interval = Interval.fromDateTimes(startDate, endDate)
 

--- a/applications/vessel-history/src/features/vessels/voyages/voyages.hook.ts
+++ b/applications/vessel-history/src/features/vessels/voyages/voyages.hook.ts
@@ -11,6 +11,7 @@ function useVoyagesConnect() {
   const [expandedVoyages, setExpandedVoyages] = useState<
     Record<number, RenderedVoyage | undefined>
   >([])
+  const [expandedByDefaultInitialized, setExpandedByDefaultInitialized] = useState(false)
 
   const toggleVoyage = useCallback(
     (voyage: RenderedVoyage) => {
@@ -52,13 +53,18 @@ function useVoyagesConnect() {
   }, [eventsList, expandedVoyages])
 
   useEffect(() => {
+    if (!expandedByDefaultInitialized || events.length === 0) return
+
     const [lastVoyage] = events.filter((event) => event.type === EventTypeVoyage.Voyage)
-    if (lastVoyage)
+    if (lastVoyage) {
       setExpandedVoyages({
         [(lastVoyage as RenderedVoyage).timestamp]: lastVoyage as RenderedVoyage,
       })
+      setExpandedByDefaultInitialized(true)
+    }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [])
+  }, [events, expandedVoyages])
+
   return { eventsLoading, events, toggleVoyage }
 }
 

--- a/applications/vessel-history/src/features/vessels/voyages/voyages.selectors.ts
+++ b/applications/vessel-history/src/features/vessels/voyages/voyages.selectors.ts
@@ -4,6 +4,7 @@ import { EventTypes } from '@globalfishingwatch/api-types'
 import { selectFilters } from 'features/event-filters/filters.slice'
 import { ActivityEvent } from 'types/activity'
 import { Voyage, EventTypeVoyage } from 'types/voyage'
+import { DEFAULT_WORKSPACE } from 'data/config'
 import { selectEventsForTracks, selectFilteredEvents } from '../activity/vessels-activity.selectors'
 
 export const selectVoyages = createSelector([selectEventsForTracks], (eventsForTrack) => {
@@ -56,11 +57,15 @@ export const selectFilteredEventsByVoyages = createSelector(
     // Need to parse the timerange start and end dates in UTC
     // to not exclude events in the boundaries of the range
     // if the user setting the filter is in a timezone with offset != 0
-    const startDate = DateTime.fromISO(filters.start, { zone: 'utc' })
+    const startDate = DateTime.fromISO(filters.start ?? DEFAULT_WORKSPACE.availableStart, {
+      zone: 'utc',
+    })
 
     // Setting the time to 23:59:59.99 so the events in that same day
     //  are also displayed
-    const endDateUTC = DateTime.fromISO(filters.end, { zone: 'utc' }).toISODate()
+    const endDateUTC = DateTime.fromISO(filters.end ?? DEFAULT_WORKSPACE.availableEnd, {
+      zone: 'utc',
+    }).toISODate()
     const endDate = DateTime.fromISO(`${endDateUTC}T23:59:59.999Z`, { zone: 'utc' })
     const interval = Interval.fromDateTimes(startDate, endDate)
 


### PR DESCRIPTION
- [x] Remove default time filter, remove 6 months default time
- [x] Activity Tab - Last voyage should be expanded by default
- [ ] Map Tab - Default state
- [ ] Activity Tab - Add Link from activity voyages to map
- [ ] Display more clearly what date filters are applied (definition to be completed)
- [ ] Display current voyage information in the MAP (TDB)
- [ ] Map - Prev/Next navigation updating current voyage
- [ ] Map - Implement new dates filters approach
- [ ] Fix Prev/Next buttons not navigating events chronologically