### PR TITLE
Allow users to download multiple activity dataviews

### DIFF
--- a/applications/fishing-map/src/features/download/DownloadActivityModal.tsx
+++ b/applications/fishing-map/src/features/download/DownloadActivityModal.tsx
@@ -158,22 +158,24 @@ function DownloadActivityModal() {
       })
       .filter((dataview) => dataview.datasets.length > 0)
 
-    const downloadParams: DownloadActivityParams = {
-      dateRange: timerange as DateRange,
-      dataviews: downloadDataviews,
-      geometry: downloadAreaGeometry as Geometry,
-      areaName: downloadAreaName,
-      format,
-      temporalResolution,
-      spatialResolution,
-      groupBy,
-    }
+    downloadDataviews.forEach((dataview) => {
+      const downloadParams: DownloadActivityParams = {
+        dateRange: timerange as DateRange,
+        geometry: downloadAreaGeometry as Geometry,
+        areaName: downloadAreaName,
+        dataview,
+        format,
+        temporalResolution,
+        spatialResolution,
+        groupBy,
+      }
 
-    try {
-      await dispatch(downloadActivityThunk(downloadParams))
-    } catch (e: any) {
-      console.warn(e)
-    }
+      try {
+        dispatch(downloadActivityThunk(downloadParams))
+      } catch (e: any) {
+        console.warn(e)
+      }
+    })
 
     uaEvent({
       category: 'Download',

--- a/applications/fishing-map/src/features/download/downloadActivity.slice.ts
+++ b/applications/fishing-map/src/features/download/downloadActivity.slice.ts
@@ -28,10 +28,10 @@ const initialState: DownloadActivityState = {
 
 export type DownloadActivityParams = {
   dateRange: DateRange
-  dataviews: {
-    filters: Record<string, any>
+  dataview: {
     datasets: string[]
-  }[]
+    filters?: Record<string, any>
+  }
   geometry: Geometry
   areaName: string
   format: Format
@@ -50,7 +50,7 @@ export const downloadActivityThunk = createAsyncThunk<
   try {
     const {
       dateRange,
-      dataviews,
+      dataview,
       geometry,
       areaName,
       format,
@@ -62,8 +62,8 @@ export const downloadActivityThunk = createAsyncThunk<
     const toDate = DateTime.fromISO(dateRange.end).toUTC()
 
     const downloadActivityParams = {
-      datasets: dataviews.map(({ datasets }) => datasets.join(',')),
-      filters: dataviews.map(({ filters }) => transformFilters(filters)),
+      datasets: [dataview.datasets.join(',')],
+      filters: [dataview.filters && transformFilters(dataview.filters)],
       'date-range': [fromDate, toDate].join(','),
       format,
       spatialResolution,


### PR DESCRIPTION
Now we perform a request to the download API for each activity dataview users have visible. 

e.g. Two dataviews, one with AIS and one with Peru VMS produce two downloads, containing these files:
<img width="1256" alt="Screenshot 2021-10-06 at 17 51 40" src="https://user-images.githubusercontent.com/38662877/136240088-4d2906f0-480b-4c6a-b6ee-1c138f35de33.png">
