### PR TITLE
Workaround for kaniko v1.7.0 issue https://github.com/GoogleContainer…

### DIFF
--- a/applications/fishing-map/cloudbuild.yaml
+++ b/applications/fishing-map/cloudbuild.yaml
@@ -1,6 +1,6 @@
 steps:
   # Push production image to GCR
-  - name: 'gcr.io/kaniko-project/executor:latest'
+  - name: 'gcr.io/kaniko-project/executor:v1.6.0'
     id: 'Build production image'
     args:
       [
@@ -48,7 +48,7 @@ steps:
         'test',
       ]
 
-  - name: 'gcr.io/kaniko-project/executor:latest'
+  - name: 'gcr.io/kaniko-project/executor:v1.6.0'
     id: 'Build nginx server image'
     args:
       [

--- a/applications/fishing-map/cloudbuild_autodeploy_PR.yaml
+++ b/applications/fishing-map/cloudbuild_autodeploy_PR.yaml
@@ -1,6 +1,6 @@
 steps:
   # Push production image to GCR
-  - name: 'gcr.io/kaniko-project/executor:latest'
+  - name: 'gcr.io/kaniko-project/executor:v1.6.0'
     id: 'Build production image'
     args:
       [
@@ -52,7 +52,7 @@ steps:
         'test',
       ]
 
-  - name: 'gcr.io/kaniko-project/executor:latest'
+  - name: 'gcr.io/kaniko-project/executor:v1.6.0'
     id: 'Build nginx server image'
     args:
       [

--- a/applications/vessel-history/cloudbuild.yaml
+++ b/applications/vessel-history/cloudbuild.yaml
@@ -4,7 +4,7 @@ steps:
     args: ['ash', '-c', 'mkdir -p ./applications/vessel-history/node_modules/@globalfishingwatch']
 
   # Push production image to GCR
-  - name: 'gcr.io/kaniko-project/executor:latest'
+  - name: 'gcr.io/kaniko-project/executor:v1.6.0'
     id: 'Build production image'
     args:
       [
@@ -42,7 +42,7 @@ steps:
         'test',
       ]
 
-  - name: 'gcr.io/kaniko-project/executor:latest'
+  - name: 'gcr.io/kaniko-project/executor:v1.6.0'
     id: 'Build nginx server image'
     args:
       [

--- a/applications/vessel-history/cloudbuild_PR_tests.yaml
+++ b/applications/vessel-history/cloudbuild_PR_tests.yaml
@@ -1,6 +1,6 @@
 steps:
   # Push build image to GCR
-  - name: 'gcr.io/kaniko-project/executor:latest'
+  - name: 'gcr.io/kaniko-project/executor:v1.6.0'
     id: 'build base image & push to GCR'
     args:
       [

--- a/applications/vessel-history/cloudbuild_autodeploy_PR.yaml
+++ b/applications/vessel-history/cloudbuild_autodeploy_PR.yaml
@@ -18,7 +18,7 @@ steps:
         cp -r --remove-destination --parents -L ./node_modules/@globalfishingwatch ./applications/vessel-history
 
   # Build and Push production image to GCR
-  - name: 'gcr.io/kaniko-project/executor:latest'
+  - name: 'gcr.io/kaniko-project/executor:v1.6.0'
     id: 'Build and Push production image to GCR'
     args:
       [


### PR DESCRIPTION
- Workaround to fix kaniko issue pushing images to GCR (https://github.com/GoogleContainerTools/kaniko/issues/1791)

```Step #1 - "Build production image": error checking push permissions -- make sure you entered the correct tag name, and that you are authenticated correctly, and try again: checking push permission for "gcr.io/_some-repository_": creating push check transport for gcr.io failed: GET https://gcr.io/v2/token?scope=repository%_3Asome-repository%_3Apush%2Cpull&service=gcr.io: UNAUTHORIZED: Not Authorized.```