### PR TITLE
Fixed app install from browser not available using the new url globalfishingwatch.org/vessel-viewer 2

### DIFF
--- a/applications/vessel-history/public/manifest.json
+++ b/applications/vessel-history/public/manifest.json
@@ -6,8 +6,8 @@
   "lang": "en-US",
   "display": "standalone",
   "orientation": "any",
-  "start_url": "/vessel-viewer",
-  "scope": "/vessel-viewer",
+  "start_url": "vessel-viewer",
+  "scope": "/",
   "background_color": "#fff",
   "theme_color": "#163f89",
   "icons": [


### PR DESCRIPTION
fix app installation in using subdomains and paths
