### PR TITLE
Fixed app install from browser not available using the new url globalfishingwatch.org/vessel-viewer 3

### DIFF
--- a/applications/vessel-history/public/manifest.json
+++ b/applications/vessel-history/public/manifest.json
@@ -6,8 +6,8 @@
   "lang": "en-US",
   "display": "standalone",
   "orientation": "any",
-  "start_url": "vessel-viewer",
-  "scope": "/",
+  "start_url": "./",
+  "scope": ".",
   "background_color": "#fff",
   "theme_color": "#163f89",
   "icons": [

--- a/applications/vessel-history/src/data/constants.ts
+++ b/applications/vessel-history/src/data/constants.ts
@@ -10,7 +10,9 @@ export const BASE_DATASET =
 export const SHOW_VESSEL_API_SOURCE = true
 
 export const API_GATEWAY = process.env.REACT_APP_API_GATEWAY
-export const LANDMASS_OFFLINE_GEOJSON = '/data/ne_10m_admin_0_countries_gj.geojson'
+export const LANDMASS_OFFLINE_GEOJSON = `${
+  process.env.PUBLIC_URL ?? ''
+}/data/ne_10m_admin_0_countries_gj.geojson`
 
 export const ENCOUNTERS_MIN_DURATION = 2
 export const ENCOUNTERS_MAX_DURATION = 99


### PR DESCRIPTION
fix app installation in using subdomains and paths