### PR TITLE
Fix precommit not running on vscode git commit 

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,6 +1,4 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-export PATH="/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
-
-npx lint-staged
+yarn lint-staged


### PR DESCRIPTION
- Fixed precommit hook not working when committing from vscode (and using nvm)
```
> git -c user.useConfigOnly=true commit --quiet --allow-empty-message --file -
Executing ~/.huskyrc
.husky/pre-commit: line 6: npx: command not found
husky - pre-commit hook exited with code 127 (error)
```