### PR TITLE
smaller time chunks

### DIFF
--- a/packages/layer-composer/src/generators/heatmap/util/time-chunks.ts
+++ b/packages/layer-composer/src/generators/heatmap/util/time-chunks.ts
@@ -45,18 +45,18 @@ const getVisibleStartFrame = (rawFrame: number) => {
 export const CONFIG_BY_INTERVAL: Record<Interval, Record<string, any>> = {
   hour: {
     isValid: (duration: Duration): boolean => {
-      return duration.as('days') < 5
+      return duration.as('days') <= 2
     },
     getFirstChunkStart: (bufferedActiveStart: number): DateTime => {
-      const TWENTY_DAYS_MS = 1000 * 60 * 60 * 24 * 20
-      const time = TWENTY_DAYS_MS * Math.floor(bufferedActiveStart / TWENTY_DAYS_MS)
+      const FIVE_DAYS_MS = 1000 * 60 * 60 * 24 * 55
+      const time = FIVE_DAYS_MS * Math.floor(bufferedActiveStart / FIVE_DAYS_MS)
       return DateTime.fromMillis(time).toUTC()
     },
     getChunkViewEnd: (chunkStart: DateTime): DateTime => {
-      return chunkStart.plus({ days: 20 })
+      return chunkStart.plus({ days: 5 })
     },
     getChunkDataEnd: (chunkViewEnd: DateTime): DateTime => {
-      return chunkViewEnd.plus({ days: 5 })
+      return chunkViewEnd.plus({ days: 2 })
     },
     // We will substract every timestamp with a quantize offset to end up with shorter arrays indexes
     getRawFrame: (start: number) => {
@@ -68,17 +68,17 @@ export const CONFIG_BY_INTERVAL: Record<Interval, Record<string, any>> = {
   },
   day: {
     isValid: (duration: Duration): boolean => {
-      return duration.as('days') < 100
+      return duration.as('days') <= 31
     },
     getFirstChunkStart: (bufferedActiveStart: number): DateTime => {
-      // tileset should start at current year
-      return DateTime.fromMillis(bufferedActiveStart).toUTC().startOf('year')
+      // tileset should start at beginning of Quarter
+      return DateTime.fromMillis(bufferedActiveStart).toUTC().startOf('quarter')
     },
     getChunkViewEnd: (chunkStart: DateTime): DateTime => {
-      return chunkStart.plus({ years: 1 })
+      return chunkStart.plus({ months: 3 })
     },
     getChunkDataEnd: (chunkViewEnd: DateTime): DateTime => {
-      return chunkViewEnd.plus({ days: 100 })
+      return chunkViewEnd.plus({ months: 1 })
     },
     getRawFrame: (start: number) => {
       return start / 1000 / 60 / 60 / 24

--- a/packages/layer-composer/src/generators/heatmap/util/time-chunks.ts
+++ b/packages/layer-composer/src/generators/heatmap/util/time-chunks.ts
@@ -48,12 +48,10 @@ export const CONFIG_BY_INTERVAL: Record<Interval, Record<string, any>> = {
       return duration.as('days') <= 2
     },
     getFirstChunkStart: (bufferedActiveStart: number): DateTime => {
-      const FIVE_DAYS_MS = 1000 * 60 * 60 * 24 * 55
-      const time = FIVE_DAYS_MS * Math.floor(bufferedActiveStart / FIVE_DAYS_MS)
-      return DateTime.fromMillis(time).toUTC()
+      return DateTime.fromMillis(bufferedActiveStart).toUTC().startOf('week')
     },
     getChunkViewEnd: (chunkStart: DateTime): DateTime => {
-      return chunkStart.plus({ days: 5 })
+      return chunkStart.plus({ days: 7 })
     },
     getChunkDataEnd: (chunkViewEnd: DateTime): DateTime => {
       return chunkViewEnd.plus({ days: 2 })

--- a/packages/layer-composer/src/generators/heatmap/util/time-chunks.ts
+++ b/packages/layer-composer/src/generators/heatmap/util/time-chunks.ts
@@ -69,11 +69,14 @@ export const CONFIG_BY_INTERVAL: Record<Interval, Record<string, any>> = {
       return duration.as('days') <= 31
     },
     getFirstChunkStart: (bufferedActiveStart: number): DateTime => {
-      // tileset should start at beginning of Quarter
-      return DateTime.fromMillis(bufferedActiveStart).toUTC().startOf('quarter')
+      const monthStart = DateTime.fromMillis(bufferedActiveStart).toUTC().startOf('month')
+      const monthStartMonth = monthStart.get('month')
+      const chunkStart = monthStart.set({ month: monthStartMonth - ((monthStartMonth - 1) % 2) })
+
+      return chunkStart
     },
     getChunkViewEnd: (chunkStart: DateTime): DateTime => {
-      return chunkStart.plus({ months: 3 })
+      return chunkStart.plus({ months: 2 })
     },
     getChunkDataEnd: (chunkViewEnd: DateTime): DateTime => {
       return chunkViewEnd.plus({ months: 1 })


### PR DESCRIPTION

Size of day tilesets: ~30% of original size 

![Screenshot 2021-11-08 at 10 22 53](https://user-images.githubusercontent.com/1583415/140716270-75d96ac0-93eb-4200-92d8-7b6f78222a79.png)
