### PR TITLE
Fishing map/time compare UI fixes

### DIFF
--- a/applications/fishing-map/src/features/analysis/analysis.hooks.ts
+++ b/applications/fishing-map/src/features/analysis/analysis.hooks.ts
@@ -451,6 +451,7 @@ export const useAnalysisTimeCompareConnect = (analysisType: WorkspaceAnalysisTyp
   const duration = timeComparison?.duration
 
   useEffect(() => {
+    if (timeComparison) return
     const baseStart = timebarStart || DEFAULT_WORKSPACE.availableEnd
     const baseEnd = timebarEnd || DEFAULT_WORKSPACE.availableEnd
     const duration = DateTime.fromISO(baseEnd).diff(DateTime.fromISO(baseStart), ['days', 'months'])

--- a/applications/fishing-map/src/features/analysis/analysis.hooks.ts
+++ b/applications/fishing-map/src/features/analysis/analysis.hooks.ts
@@ -477,16 +477,26 @@ export const useAnalysisTimeCompareConnect = (analysisType: WorkspaceAnalysisTyp
       const duration = newDuration || timeComparison.duration
       const durationType = newDurationType || timeComparison.durationType
 
+      const startFromCompareStart = parseYYYYMMDDDate(compareStart).minus({
+        [durationType]: duration,
+      })
+
       let start: string
       if (analysisType === 'beforeAfter') {
         // In before/after mode, start of 1st period is calculated automatically depending on start of 2nd period (compareStart)
-        start = parseYYYYMMDDDate(compareStart)
-          .minus({ [durationType]: duration })
-          .toISO()
+        start = startFromCompareStart.toISO()
       } else {
         start = newStart
           ? parseYYYYMMDDDate(newStart).toISO()
           : parseFullISODate(timeComparison.start).toISO()
+
+        // If new duration is set, make sure there delta from start to compareStart is >= of new duration
+        if (
+          newDuration &&
+          startFromCompareStart.toMillis() - parseFullISODate(timeComparison.start).toMillis() <= 0
+        ) {
+          start = startFromCompareStart.toISO()
+        }
       }
 
       dispatchQueryParams({

--- a/packages/layer-composer/src/generators/heatmap/util/get-legends.ts
+++ b/packages/layer-composer/src/generators/heatmap/util/get-legends.ts
@@ -60,8 +60,11 @@ export const getSublayersBreaks = (
   const end = toDT(config.end)
   // uses 'years' as breaks request a year with temporal-aggregation true
   const deltaInterval = end.diff(start, 'days').days / 10
+  const baseMultiplier = config.mode === HeatmapAnimatedMode.TimeCompare ? 1 / 8 : 1 / 4
   const sublayersBreaks = breaks?.map((bre) => {
-    return getCleanBreaks(bre.map((b) => deltaInterval * b * Math.pow(1 / 4, config.zoomLoadLevel)))
+    return getCleanBreaks(
+      bre.map((b) => deltaInterval * b * Math.pow(baseMultiplier, config.zoomLoadLevel))
+    )
   })
 
   if (config.mode === HeatmapAnimatedMode.TimeCompare && sublayersBreaks) {


### PR DESCRIPTION
- keep time compare params when switching analysis mode
- automatically set base compare time when changing duration to avoid overlap in comparison periods
- change zoom-based factor to better adapt color scale to time compare mode
Before
![Screenshot 2021-11-09 at 10 27 26](https://user-images.githubusercontent.com/1583415/140898270-a169e950-46ef-4977-9d3b-ea50d9225132.png)
After
![Screenshot 2021-11-09 at 10 26 42](https://user-images.githubusercontent.com/1583415/140898256-05dbdbad-8c4a-4a34-be79-76acd9fba9d0.png)


 