### PR TITLE
Download data from a custom polygon - zip includes undefined and name is not displayed in the pop up

### DIFF
--- a/apps/fishing-map/features/download/downloadActivity.slice.ts
+++ b/apps/fishing-map/features/download/downloadActivity.slice.ts
@@ -106,7 +106,7 @@ const downloadActivitySlice = createSlice({
     },
     setDownloadActivityGeometry: (state, action: PayloadAction<TooltipEventFeature>) => {
       state.geometry = action.payload.geometry as Geometry
-      state.name = action.payload.value
+      state.name = action.payload.value || action.payload.title as string
     },
   },
   extraReducers: (builder) => {


### PR DESCRIPTION
https://globalfishingwatch.atlassian.net/browse/MAP-624

- [x] fix area name in the modal
- [x] fix zip name