### PR TITLE
Fishing map/activity layer stats rtk query

### DIFF
--- a/apps/fishing-map/features/workspace/activity/ActivityLayerPanel.tsx
+++ b/apps/fishing-map/features/workspace/activity/ActivityLayerPanel.tsx
@@ -52,7 +52,7 @@ function ActivityLayerPanel({
   const bivariateDataviews = useSelector(selectBivariateDataviews)
   const guestUser = useSelector(isGuestUser)
   const readOnly = useSelector(selectReadOnly)
-  const { data: stats, isLoading } = useGetStatsByDataviewQuery(
+  const { data: stats, isFetching } = useGetStatsByDataviewQuery(
     {
       dataview,
       timerange,
@@ -192,7 +192,7 @@ function ActivityLayerPanel({
           {stats && (
             <div
               className={cx(activityStyles.stats, {
-                [activityStyles.statsLoading]: isLoading,
+                [activityStyles.statsLoading]: isFetching,
               })}
             >
               {showStats ? (

--- a/apps/fishing-map/features/workspace/activity/ActivityLayerPanel.tsx
+++ b/apps/fishing-map/features/workspace/activity/ActivityLayerPanel.tsx
@@ -3,6 +3,7 @@ import cx from 'classnames'
 import { useTranslation } from 'react-i18next'
 import { useDispatch, useSelector } from 'react-redux'
 import { event as uaEvent } from 'react-ga'
+import { useGetStatsByDataviewQuery } from 'queries/stats-api'
 import { IconButton, Tooltip } from '@globalfishingwatch/ui-components'
 import { UrlDataviewInstance } from '@globalfishingwatch/dataviews-client'
 import styles from 'features/workspace/shared/LayerPanel.module.css'
@@ -14,12 +15,8 @@ import { getActivityFilters, getActivitySources, getEventLabel } from 'utils/ana
 import { getDatasetTitleByDataview, SupportedDatasetSchema } from 'features/datasets/datasets.utils'
 import Hint from 'features/help/hints/Hint'
 import { setHintDismissed } from 'features/help/hints/hints.slice'
-import {
-  selectDataviewStatsById,
-  selectDataviewStatsStatus,
-} from 'features/dataview-stats/dataview-stats.slice'
+import { useTimerangeConnect } from 'features/timebar/timebar.hooks'
 import I18nNumber from 'features/i18n/i18nNumber'
-import { AsyncReducerStatus } from 'utils/async-slice'
 import DatasetFilterSource from '../shared/DatasetSourceField'
 import DatasetFlagField from '../shared/DatasetFlagsField'
 import DatasetSchemaField from '../shared/DatasetSchemaField'
@@ -50,10 +47,14 @@ function ActivityLayerPanel({
 
   const { deleteDataviewInstance } = useDataviewInstancesConnect()
   const { dispatchQueryParams } = useLocationConnect()
+  const { timerange } = useTimerangeConnect()
   const bivariateDataviews = useSelector(selectBivariateDataviews)
   const readOnly = useSelector(selectReadOnly)
-  const dataviewStatsStatus = useSelector(selectDataviewStatsStatus)
-  const stats = useSelector(selectDataviewStatsById(dataview.id))
+  // TODO fetch only for logged users
+  const { data: stats, isLoading } = useGetStatsByDataviewQuery({
+    dataview,
+    timerange,
+  })
 
   const layerActive = dataview?.config?.visible ?? true
 
@@ -185,7 +186,7 @@ function ActivityLayerPanel({
           {stats && (
             <div
               className={cx(activityStyles.stats, {
-                [activityStyles.statsLoading]: dataviewStatsStatus === AsyncReducerStatus.Loading,
+                [activityStyles.statsLoading]: isLoading,
               })}
             >
               {showStats ? (

--- a/apps/fishing-map/features/workspace/activity/ActivityLayerPanel.tsx
+++ b/apps/fishing-map/features/workspace/activity/ActivityLayerPanel.tsx
@@ -17,6 +17,7 @@ import Hint from 'features/help/hints/Hint'
 import { setHintDismissed } from 'features/help/hints/hints.slice'
 import { useTimerangeConnect } from 'features/timebar/timebar.hooks'
 import I18nNumber from 'features/i18n/i18nNumber'
+import { isGuestUser } from 'features/user/user.slice'
 import DatasetFilterSource from '../shared/DatasetSourceField'
 import DatasetFlagField from '../shared/DatasetFlagsField'
 import DatasetSchemaField from '../shared/DatasetSchemaField'
@@ -49,12 +50,17 @@ function ActivityLayerPanel({
   const { dispatchQueryParams } = useLocationConnect()
   const { timerange } = useTimerangeConnect()
   const bivariateDataviews = useSelector(selectBivariateDataviews)
+  const guestUser = useSelector(isGuestUser)
   const readOnly = useSelector(selectReadOnly)
-  // TODO fetch only for logged users
-  const { data: stats, isLoading } = useGetStatsByDataviewQuery({
-    dataview,
-    timerange,
-  })
+  const { data: stats, isLoading } = useGetStatsByDataviewQuery(
+    {
+      dataview,
+      timerange,
+    },
+    {
+      skip: guestUser,
+    }
+  )
 
   const layerActive = dataview?.config?.visible ?? true
 

--- a/apps/fishing-map/features/workspace/activity/ActivitySection.tsx
+++ b/apps/fishing-map/features/workspace/activity/ActivitySection.tsx
@@ -7,7 +7,6 @@ import { event as uaEvent } from 'react-ga'
 import { IconButton, Choice, ChoiceOption } from '@globalfishingwatch/ui-components'
 import { GeneratorType } from '@globalfishingwatch/layer-composer'
 import { UrlDataviewInstance } from '@globalfishingwatch/dataviews-client'
-import { useMemoCompare } from '@globalfishingwatch/react-hooks'
 import {
   selectActivityDataviews,
   selectAvailableFishingDataviews,
@@ -15,7 +14,6 @@ import {
 } from 'features/dataviews/dataviews.selectors'
 import styles from 'features/workspace/shared/Sections.module.css'
 import { useDataviewInstancesConnect } from 'features/workspace/workspace.hook'
-import { fetchDataviewStats } from 'features/dataview-stats/dataview-stats.slice'
 import { useLocationConnect } from 'routes/routes.hook'
 import {
   getFishingDataviewInstance,
@@ -30,7 +28,6 @@ import {
 import { useTimerangeConnect } from 'features/timebar/timebar.hooks'
 import { getActivityFilters, getActivitySources, getEventLabel } from 'utils/analytics'
 import { getDatasetTitleByDataview } from 'features/datasets/datasets.utils'
-import { isGuestUser } from 'features/user/user.slice'
 import TooltipContainer, { TooltipListContainer } from '../shared/TooltipContainer'
 import LayerPanelContainer from '../shared/LayerPanelContainer'
 import LayerPanel from './ActivityLayerPanel'
@@ -38,11 +35,8 @@ import activityStyles from './ActivitySection.module.css'
 
 function ActivitySection(): React.ReactElement {
   const { t } = useTranslation()
-  const dispatch = useDispatch()
-  const statsPromiseRef = useRef<any>()
   const [addedDataviewId, setAddedDataviewId] = useState<string | undefined>()
   const [newLayerOpen, setNewLayerOpen] = useState<boolean>(false)
-  const guestuser = useSelector(isGuestUser)
   const readOnly = useSelector(selectReadOnly)
   const dataviews = useSelector(selectActivityDataviews)
   const activityCategory = useSelector(selectActivityCategory)
@@ -51,7 +45,7 @@ function ActivitySection(): React.ReactElement {
   const { upsertDataviewInstance } = useDataviewInstancesConnect()
   const { dispatchQueryParams } = useLocationConnect()
   const bivariateDataviews = useSelector(selectBivariateDataviews)
-  const { timerange, start, end } = useTimerangeConnect()
+  const { start, end } = useTimerangeConnect()
 
   const ACTIVITY_OPTIONS: ChoiceOption[] = useMemo(
     () => [
@@ -70,19 +64,6 @@ function ActivitySection(): React.ReactElement {
   useEffect(() => {
     setAddedDataviewId(undefined)
   }, [activityCategory])
-
-  const memoDataviews = useMemoCompare(dataviews)
-  useEffect(() => {
-    if (!guestuser && memoDataviews && memoDataviews.length > 0) {
-      if (statsPromiseRef.current) {
-        statsPromiseRef.current.abort()
-      }
-      // TODO do this only on dataview creation or dataview filters change
-      statsPromiseRef.current = dispatch(
-        fetchDataviewStats({ dataviews: memoDataviews, timerange })
-      )
-    }
-  }, [guestuser, memoDataviews, timerange, dispatch])
 
   const onActivityOptionClick = useCallback(
     (activityOption: ChoiceOption) => {

--- a/apps/fishing-map/queries/base.ts
+++ b/apps/fishing-map/queries/base.ts
@@ -1,0 +1,25 @@
+import { BaseQueryFn } from '@reduxjs/toolkit/query/react'
+import { GFWAPI, ResponseError } from '@globalfishingwatch/api-client'
+
+export const gfwBaseQuery =
+  (
+    { baseUrl }: { baseUrl: string } = { baseUrl: '' }
+  ): BaseQueryFn<
+    {
+      url: string
+      signal?: AbortSignal
+    },
+    unknown,
+    unknown
+  > =>
+  async ({ url, signal }) => {
+    try {
+      const data = await GFWAPI.fetch(baseUrl + url, { signal })
+      return { data }
+    } catch (gfwApiError) {
+      const err = gfwApiError as ResponseError
+      return {
+        error: { status: err?.status, data: err?.message },
+      }
+    }
+  }

--- a/apps/fishing-map/queries/stats-api.ts
+++ b/apps/fishing-map/queries/stats-api.ts
@@ -20,15 +20,20 @@ export type FetchDataviewStatsParams = {
 interface CustomBaseQueryArg extends BaseQueryArg<BaseQueryFn> {
   url: string
   dataview: UrlDataviewInstance
+  timerange: Range
 }
-const serializeQueryArgs: SerializeQueryArgs<CustomBaseQueryArg> = ({ queryArgs }) => {
-  return queryArgs.dataview.id
+const serializeStatsDataviewKey: SerializeQueryArgs<CustomBaseQueryArg> = ({ queryArgs }) => {
+  return [
+    queryArgs.dataview.id,
+    JSON.stringify(queryArgs.dataview.config),
+    JSON.stringify(queryArgs.timerange),
+  ].join('-')
 }
 
 // Define a service using a base URL and expected endpoints
 export const dataviewStatsApi = createApi({
   reducerPath: 'dataviewStatsApi',
-  serializeQueryArgs,
+  serializeQueryArgs: serializeStatsDataviewKey,
   baseQuery: gfwBaseQuery({
     baseUrl: '/proto/4wings/stats',
   }),

--- a/apps/fishing-map/queries/stats-api.ts
+++ b/apps/fishing-map/queries/stats-api.ts
@@ -1,0 +1,50 @@
+import { createApi } from '@reduxjs/toolkit/query/react'
+import { stringify } from 'qs'
+import { gfwBaseQuery } from 'queries/base'
+import { UrlDataviewInstance } from '@globalfishingwatch/dataviews-client'
+import { Range } from 'features/timebar/timebar.slice'
+
+export type StatField = 'flag' | 'vessel_id' | 'geartype'
+export type StatFields = {
+  [key in StatField]: number
+}
+export type DataviewStats = {
+  [key: string]: StatFields
+}
+
+export type FetchDataviewStatsParams = {
+  timerange: Range
+  dataview: UrlDataviewInstance
+  fields?: StatField[]
+}
+
+// Define a service using a base URL and expected endpoints
+export const dataviewStatsApi = createApi({
+  reducerPath: 'dataviewStatsApi',
+  baseQuery: gfwBaseQuery({
+    baseUrl: '/proto/4wings/stats',
+  }),
+  endpoints: (builder) => ({
+    getStatsByDataview: builder.query<DataviewStats, FetchDataviewStatsParams>({
+      query: ({ dataview, timerange, fields = ['vessel_id', 'flag'] }) => {
+        const statsParams = {
+          datasets: [dataview.config?.datasets?.join(',') || []],
+          filters: dataview.config?.filter || [],
+          'date-range': [timerange.start, timerange.end].join(','),
+        }
+        return {
+          url: `?fields=${fields.join(',')}&${stringify(statsParams, {
+            arrayFormat: 'indices',
+          })}`,
+        }
+      },
+      transformResponse: (response: DataviewStats[], meta, arg) => {
+        return response?.[0]
+      },
+    }),
+  }),
+})
+
+// Export hooks for usage in functional components, which are
+// auto-generated based on the defined endpoints
+export const { useGetStatsByDataviewQuery } = dataviewStatsApi

--- a/apps/fishing-map/queries/stats-api.ts
+++ b/apps/fishing-map/queries/stats-api.ts
@@ -1,6 +1,8 @@
 import { createApi } from '@reduxjs/toolkit/query/react'
 import { stringify } from 'qs'
 import { gfwBaseQuery } from 'queries/base'
+import { BaseQueryArg, BaseQueryFn } from '@reduxjs/toolkit/dist/query/baseQueryTypes'
+import { SerializeQueryArgs } from '@reduxjs/toolkit/dist/query/defaultSerializeQueryArgs'
 import { UrlDataviewInstance } from '@globalfishingwatch/dataviews-client'
 import { Range } from 'features/timebar/timebar.slice'
 
@@ -18,9 +20,18 @@ export type FetchDataviewStatsParams = {
   fields?: StatField[]
 }
 
+interface CustomBaseQueryArg extends BaseQueryArg<BaseQueryFn> {
+  url: string
+  dataview: UrlDataviewInstance
+}
+const serializeQueryArgs: SerializeQueryArgs<CustomBaseQueryArg> = ({ queryArgs }) => {
+  return queryArgs.dataview.id
+}
+
 // Define a service using a base URL and expected endpoints
 export const dataviewStatsApi = createApi({
   reducerPath: 'dataviewStatsApi',
+  serializeQueryArgs,
   baseQuery: gfwBaseQuery({
     baseUrl: '/proto/4wings/stats',
   }),

--- a/apps/fishing-map/queries/stats-api.ts
+++ b/apps/fishing-map/queries/stats-api.ts
@@ -10,9 +10,6 @@ export type StatField = 'flag' | 'vessel_id' | 'geartype'
 export type StatFields = {
   [key in StatField]: number
 }
-export type DataviewStats = {
-  [key: string]: StatFields
-}
 
 export type FetchDataviewStatsParams = {
   timerange: Range
@@ -36,7 +33,7 @@ export const dataviewStatsApi = createApi({
     baseUrl: '/proto/4wings/stats',
   }),
   endpoints: (builder) => ({
-    getStatsByDataview: builder.query<DataviewStats, FetchDataviewStatsParams>({
+    getStatsByDataview: builder.query<StatFields, FetchDataviewStatsParams>({
       query: ({ dataview, timerange, fields = ['vessel_id', 'flag'] }) => {
         const statsParams = {
           datasets: [dataview.config?.datasets?.join(',') || []],
@@ -49,7 +46,7 @@ export const dataviewStatsApi = createApi({
           })}`,
         }
       },
-      transformResponse: (response: DataviewStats[], meta, arg) => {
+      transformResponse: (response: StatFields[]) => {
         return response?.[0]
       },
     }),

--- a/apps/fishing-map/store.ts
+++ b/apps/fishing-map/store.ts
@@ -1,4 +1,5 @@
 import { configureStore, ThunkAction, Action, combineReducers } from '@reduxjs/toolkit'
+import { dataviewStatsApi } from 'queries/stats-api'
 import { routerQueryMiddleware, routerWorkspaceMiddleware } from './routes/routes.middlewares'
 import areasReducer from './features/areas/areas.slice'
 import bigQueryReducer from './features/bigquery/bigquery.slice'
@@ -49,6 +50,7 @@ const rootReducer = combineReducers({
   user: userReducer,
   workspace: workspaceReducer,
   workspaces: workspacesReducer,
+  [dataviewStatsApi.reducerPath]: dataviewStatsApi.reducer,
 })
 
 // Can't type because GetDefaultMiddlewareOptions type is not exposed by RTK
@@ -85,7 +87,8 @@ const store = configureStore({
     getDefaultMiddleware(defaultMiddlewareOptions)
       .concat(routerQueryMiddleware)
       .concat(routerWorkspaceMiddleware)
-      .concat(routerMiddleware),
+      .concat(routerMiddleware)
+      .concat(dataviewStatsApi.middleware),
   enhancers: (defaultEnhancers) => [routerEnhancer, ...defaultEnhancers],
 })
 


### PR DESCRIPTION
Compare traditional redux-toolkit slice approach against [react-toolkit-query](https://redux-toolkit.js.org/rtk-query/overview) method to fetch layer stats. 
It needs a custom [baseQuery](https://redux-toolkit.js.org/rtk-query/usage/customizing-queries#customizing-queries-with-basequery), see [code](https://github.com/GlobalFishingWatch/frontend/compare/fishing-map/activity-layer-stats...fishing-map/activity-layer-stats-rtk-query?expand=1#diff-aaef2cbeabe68e04bfa31d060c708e24c9e5579d76eb85114f6bc8c650413b43R4) but works nice

Apart of having less code boilerplate the main advantage vs the [previous approach](https://github.com/GlobalFishingWatch/frontend/pull/1274) is each request is done individually getting an automatic cache layer effortless and works great because this means changing a filter in one layer doesn't affect the rest.

My concerns so far:
- we'll need to be careful if we start making lot of requests in the components side and lost track
- looks like the reducer stores all the arguments sent to the hook as the query key so we need to be careful with:
![image](https://user-images.githubusercontent.com/10500650/157410888-37cdae23-fadb-4fd1-8d34-f09b1eafb835.png)
or creating a [custom cache key](https://github.com/GlobalFishingWatch/frontend/commit/3b17e74c8edc49de976e09a44ba6abca9b461255)
- keep this in mind https://redux-toolkit.js.org/rtk-query/usage/server-side-rendering#server-side-rendering-with-nextjs for the future

Would be nice to keep investigating:
- https://redux-toolkit.js.org/rtk-query/usage/pagination in vessel searchs
- https://redux-toolkit.js.org/rtk-query/usage/conditional-fetching for request depending on others, like fetching the workspace when the user request finishes