### PR TITLE
Basic zoom-dependant track thinning params

### DIFF
--- a/apps/fishing-map/data/config.ts
+++ b/apps/fishing-map/data/config.ts
@@ -1,6 +1,6 @@
 import ReactGA from 'react-ga'
 import { DateObject, DateTime } from 'luxon'
-import { DataviewCategory } from '@globalfishingwatch/api-types'
+import { DataviewCategory, ThinningConfig } from '@globalfishingwatch/api-types'
 import { TimebarGraphs, TimebarVisualisations } from 'types'
 
 export const ROOT_DOM_ELEMENT = '__next'
@@ -82,11 +82,34 @@ export const EVENTS_COLORS: Record<string, string> = {
 }
 
 export enum ThinningLevels {
+  Insane = 'Insane',
+  VeryAggressive = 'VeryAggressive',
   Aggressive = 'aggressive',
   Default = 'default',
 }
 
-export const THINNING_LEVELS = {
+
+export const THINNING_LEVELS: Record<ThinningLevels, ThinningConfig> = {
+  [ThinningLevels.Insane]: {
+    distanceFishing: 10000,
+    bearingValFishing: 20,
+    changeSpeedFishing: 1000,
+    minAccuracyFishing: 400,
+    distanceTransit: 20000,
+    bearingValTransit: 20,
+    changeSpeedTransit: 1000,
+    minAccuracyTransit: 800,
+  },
+  [ThinningLevels.VeryAggressive]: {
+    distanceFishing: 10000,
+    bearingValFishing: 10,
+    changeSpeedFishing: 500,
+    minAccuracyFishing: 100,
+    distanceTransit: 20000,
+    bearingValTransit: 10,
+    changeSpeedTransit: 500,
+    minAccuracyTransit: 200,
+  },
   [ThinningLevels.Aggressive]: {
     distanceFishing: 1000,
     bearingValFishing: 5,
@@ -108,6 +131,27 @@ export const THINNING_LEVELS = {
     minAccuracyTransit: 30,
   },
 }
+
+export const THINNING_LEVEL_BY_ZOOM: Record<number, { user: ThinningConfig, guest: ThinningConfig }> = {
+  0: {
+    user: THINNING_LEVELS[ThinningLevels.Insane],
+    guest: THINNING_LEVELS[ThinningLevels.Insane],
+  },
+  2: {
+    user: THINNING_LEVELS[ThinningLevels.VeryAggressive],
+    guest: THINNING_LEVELS[ThinningLevels.VeryAggressive],
+  },
+  4: {
+    user: THINNING_LEVELS[ThinningLevels.Aggressive],
+    guest: THINNING_LEVELS[ThinningLevels.Aggressive],
+  },
+  6: {
+    user: THINNING_LEVELS[ThinningLevels.Default],
+    guest: THINNING_LEVELS[ThinningLevels.Aggressive],
+  },
+}
+
+export const THINNING_LEVEL_ZOOMS = Object.keys(THINNING_LEVEL_BY_ZOOM) as unknown as number[]
 
 // Params to use replace instead of push for router history to make navigation easier
 export const REPLACE_URL_PARAMS = ['latitude', 'longitude', 'zoom']

--- a/apps/fishing-map/features/resources/resources.slice.ts
+++ b/apps/fishing-map/features/resources/resources.slice.ts
@@ -3,9 +3,10 @@ import {
   ResourcesState as CommonResourcesState,
   resourcesSlice,
 } from '@globalfishingwatch/dataviews-client'
-import { ThinningLevels, THINNING_LEVELS } from 'data/config'
+import { THINNING_LEVEL_BY_ZOOM, THINNING_LEVEL_ZOOMS } from 'data/config'
 import { selectDebugOptions } from 'features/debug/debug.slice'
 import { isGuestUser } from 'features/user/user.slice'
+import { selectUrlMapZoomQuery } from 'routes/routes.selectors'
 
 export {
   fetchResourceThunk,
@@ -14,12 +15,19 @@ export {
 } from '@globalfishingwatch/dataviews-client'
 
 export const selectThinningConfig = createSelector(
-  [(state) => isGuestUser(state), selectDebugOptions],
-  (guestUser, { thinning }) => {
+  [(state) => isGuestUser(state), selectDebugOptions, selectUrlMapZoomQuery],
+  (guestUser, { thinning }, currentZoom) => {
     if (!thinning) return null
-    const thinningConfig = guestUser
-      ? THINNING_LEVELS[ThinningLevels.Aggressive]
-      : THINNING_LEVELS[ThinningLevels.Default]
+
+    let thinningConfig
+    for (let i = 0; i < THINNING_LEVEL_ZOOMS.length; i++) {
+      const zoom = THINNING_LEVEL_ZOOMS[i]
+      if (currentZoom < zoom) break
+      thinningConfig = THINNING_LEVEL_BY_ZOOM[zoom][guestUser ? 'guest' : 'user']
+      
+    }
+    // console.log(currentZoom, thinningConfig)
+
     return thinningConfig
   }
 )

--- a/libs/api-types/src/datasets.ts
+++ b/libs/api-types/src/datasets.ts
@@ -131,3 +131,14 @@ export interface Dataset {
   relatedDatasets: RelatedDataset[] | null
   fieldsAllowed: string[]
 }
+
+export interface ThinningConfig {
+  distanceFishing?: number,
+  bearingValFishing?: number,
+  changeSpeedFishing?: number,
+  minAccuracyFishing?: number,
+  distanceTransit?: number,
+  bearingValTransit?: number,
+  changeSpeedTransit?: number,
+  minAccuracyTransit?: number,
+}


### PR DESCRIPTION
Loads track at 3 different thinning levels depending on zoom level. Last level thinning params depend on if user is logged in or not.
A test workspace with 5 tracks will load as following:
- 300k up to zoom 3
- 700k up to zoom 6
- 1.1mb not logged in, 1.5mb logged in from zoom 6 (previously this was the payload size for all z levels)

https://user-images.githubusercontent.com/1583415/158143868-cd52d3ed-dbca-46d9-a0d9-c9ebe9227f7e.mov

We should consider the following improvements (follow up PRs):
- [ ] **Only display track at next thinning params once entirely loaded to avoid blank map while loading**
   - memorize zoom level dependant configs once "visited" and return an array of all available tracks in [resources.selectors](https://github.com/GlobalFishingWatch/frontend/blob/develop/apps/fishing-map/features/resources/resources.slice.ts#L16)
   - generate a dataset config for each possible track config in [selectDataviewsForResourceQuerying](https://github.com/GlobalFishingWatch/frontend/blob/develop/apps/fishing-map/features/dataviews/dataviews.slice.ts#L181)
   - for [timebar](https://github.com/GlobalFishingWatch/frontend/blob/develop/apps/fishing-map/features/timebar/timebar.selectors.ts#L44) and [map](https://github.com/GlobalFishingWatch/frontend/blob/develop/apps/fishing-map/features/map/map.selectors.ts#L89) inject current zoom, decide which track to pick from resources depending on this and loading status using [resolveDataviewDatasetResources](https://github.com/GlobalFishingWatch/frontend/blob/develop/libs/dataviews-client/src/resolve-dataviews.ts#L175) 

- [ ] **Load tracks by chunks when zoomed in in time** (ie 1 year chunk if time viewed < 6 months). This would be very useful as thinning params have impact on payload, but none on server response time (TTFB is the same)
  - use dateStart/dateEnd to generate one more dataset config depending on time viewed in  [selectDataviewsForResourceQuerying](https://github.com/GlobalFishingWatch/frontend/blob/develop/apps/fishing-map/features/dataviews/dataviews.slice.ts#L181)
     - for [timebar](https://github.com/GlobalFishingWatch/frontend/blob/develop/apps/fishing-map/features/timebar/timebar.selectors.ts#L44) and [map](https://github.com/GlobalFishingWatch/frontend/blob/develop/apps/fishing-map/features/map/map.selectors.ts#L89) inject current timebar start/end, decide which track to pick from resources depending on this and loading status using [resolveDataviewDatasetResources](https://github.com/GlobalFishingWatch/frontend/blob/develop/libs/dataviews-client/src/resolve-dataviews.ts#L175) 
