### PR TITLE
Fishing map/activity filters

### DIFF
--- a/apps/fishing-map/features/datasets/datasets.utils.ts
+++ b/apps/fishing-map/features/datasets/datasets.utils.ts
@@ -40,13 +40,13 @@ export type SupportedDatasetSchema =
   | 'target_species' // between camelCase or snake_case
   | 'license_category'
 
-type IncomptibleFilter = {
+type IncompatibleFilter = {
   id: SupportedDatasetSchema
   value: any
   disabled: SupportedDatasetSchema[]
 }
-type IncomptibleFiltersDict = Record<string, IncomptibleFilter[]>
-const INCOMPATIBLE_FILTERS_DICT: IncomptibleFiltersDict = {
+type IncompatibleFiltersDict = Record<string, IncompatibleFilter[]>
+const INCOMPATIBLE_FILTERS_DICT: IncompatibleFiltersDict = {
   'public-presence-viirs-match-prototype:v20220112': [
     { id: 'matched', value: false, disabled: ['source', 'flag', 'shiptype', 'geartype'] },
   ],

--- a/apps/fishing-map/features/datasets/datasets.utils.ts
+++ b/apps/fishing-map/features/datasets/datasets.utils.ts
@@ -23,6 +23,7 @@ import {
   VIIRS_DATAVIEW_ID,
   VIIRS_MATCH_DATAVIEW_ID,
 } from 'data/workspaces'
+import { getFlags, getFlagsByIds } from 'utils/flags'
 
 export type SupportedDatasetSchema =
   | 'flag'
@@ -216,6 +217,10 @@ export const hasDatasetConfigVesselData = (datasetConfig: DataviewDatasetConfig)
 }
 
 export const datasetHasSchemaFields = (dataset: Dataset, schema: SupportedDatasetSchema) => {
+  if (schema === 'flag') {
+    // returning true as the schema fields enum comes from the static list in getFlags()
+    return true
+  }
   return dataset.schema?.[schema]?.enum !== undefined && dataset.schema?.[schema].enum.length > 0
 }
 
@@ -265,6 +270,9 @@ export const getCommonSchemaFieldsInDataview = (
   dataview: SchemaFieldDataview,
   schema: SupportedDatasetSchema
 ): SchemaFieldSelection[] => {
+  if (schema === 'flag') {
+    return getFlags()
+  }
   const activeDatasets = dataview?.datasets?.filter((dataset) =>
     dataview.config?.datasets?.includes(dataset.id)
   )
@@ -295,6 +303,9 @@ export const getSchemaOptionsSelectedInDataview = (
   schema: SupportedDatasetSchema,
   options: ReturnType<typeof getCommonSchemaFieldsInDataview>
 ) => {
+  if (schema === 'flag') {
+    return getFlagsByIds(dataview.config?.filters?.flag || [])
+  }
   return options?.filter((option) =>
     dataview.config?.filters?.[schema]?.map((o) => o.toString())?.includes(option.id)
   )

--- a/apps/fishing-map/features/search/SearchFilters.tsx
+++ b/apps/fishing-map/features/search/SearchFilters.tsx
@@ -111,12 +111,11 @@ function SearchFilters({ datasets, className = '' }: SearchFiltersProps) {
         if (!showSchemaFilter(schemaFilter)) {
           return null
         }
-        const { id, tooltip, disabled, options, optionsSelected } = schemaFilter
+        const { id, disabled, options, optionsSelected } = schemaFilter
         return (
           <MultiSelect
             key={id}
             disabled={disabled}
-            disabledMsg={tooltip}
             label={t(`vessel.${id}` as any, id)}
             placeholder={getPlaceholderBySelections(optionsSelected)}
             options={options}

--- a/apps/fishing-map/features/workspace/activity/ActivityFilters.tsx
+++ b/apps/fishing-map/features/workspace/activity/ActivityFilters.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment, useMemo } from 'react'
+import React, { Fragment } from 'react'
 import { useTranslation } from 'react-i18next'
 import { event as uaEvent } from 'react-ga'
 import { debounce } from 'lodash'
@@ -8,14 +8,11 @@ import {
   MultiSelectOption,
 } from '@globalfishingwatch/ui-components'
 import { UrlDataviewInstance } from '@globalfishingwatch/dataviews-client'
-import { getFlags, getFlagsByIds } from 'utils/flags'
 import { useDataviewInstancesConnect } from 'features/workspace/workspace.hook'
 import { getPlaceholderBySelections } from 'features/i18n/utils'
 import {
-  getFiltersBySchema,
   getCommonSchemaFieldsInDataview,
-  isDataviewSchemaSupported,
-  SupportedDatasetSchema,
+  geSchemaFiltersInDataview,
 } from 'features/datasets/datasets.utils'
 import { getActivityFilters, getActivitySources, getEventLabel } from 'utils/analytics'
 import ActivitySchemaFilter, {
@@ -64,10 +61,6 @@ function ActivityFilters({ dataview }: ActivityFiltersProps): React.ReactElement
   const allSelected = areAllSourcesSelectedInDataview(dataview)
   const sourcesSelected = allSelected ? [allOption] : getSourcesSelectedInDataview(dataview)
 
-  const flagOptions = getFlagsByIds(dataview.config?.filters?.flag || [])
-  const flags = useMemo(getFlags, [])
-
-  const flagFiltersSupported = isDataviewSchemaSupported(dataview, 'flag')
   const showSourceFilter = sourceOptions && sourceOptions?.length > 1
 
   const schemaFilters = filterIds.map((id) => getFiltersBySchema(dataview, id))
@@ -185,8 +178,7 @@ function ActivityFilters({ dataview }: ActivityFiltersProps): React.ReactElement
     })
   }
 
-  const showSchemaFilters =
-    flagFiltersSupported || showSourceFilter || schemaFilters.some(showSchemaFilter)
+  const showSchemaFilters = showSourceFilter || schemaFilters.some(showSchemaFilter)
 
   if (!showSchemaFilters) {
     return <p className={styles.placeholder}>{t('dataset.emptyFilters', 'No filters available')}</p>
@@ -202,18 +194,6 @@ function ActivityFilters({ dataview }: ActivityFiltersProps): React.ReactElement
           selectedOptions={sourcesSelected}
           onSelect={onSelectSourceClick}
           onRemove={sourcesSelected?.length > 1 ? onRemoveSourceClick : undefined}
-        />
-      )}
-      {flagFiltersSupported && (
-        <MultiSelect
-          label={t('layer.flagState_other', 'Flag States')}
-          placeholder={getPlaceholderBySelections(flagOptions)}
-          options={flags}
-          selectedOptions={flagOptions}
-          className={styles.multiSelect}
-          onSelect={(selection) => onSelectFilterClick('flag', selection)}
-          onRemove={(selection, rest) => onRemoveFilterClick('flag', rest)}
-          onCleanClick={() => onCleanFilterClick('flag')}
         />
       )}
       {schemaFilters.map((schemaFilter) => {

--- a/apps/fishing-map/features/workspace/activity/ActivityFilters.tsx
+++ b/apps/fishing-map/features/workspace/activity/ActivityFilters.tsx
@@ -29,19 +29,6 @@ type ActivityFiltersProps = {
   dataview: UrlDataviewInstance
 }
 
-const filterIds: SupportedDatasetSchema[] = [
-  'geartype',
-  'fleet',
-  'shiptype',
-  'origin',
-  'matched',
-  'source',
-  'radiance',
-  'target_species',
-  'license_category',
-  'vessel_type',
-]
-
 const trackEvent = debounce((filterKey: string, label: string) => {
   uaEvent({
     category: 'Activity data',
@@ -63,7 +50,7 @@ function ActivityFilters({ dataview }: ActivityFiltersProps): React.ReactElement
 
   const showSourceFilter = sourceOptions && sourceOptions?.length > 1
 
-  const schemaFilters = filterIds.map((id) => getFiltersBySchema(dataview, id))
+  const schemaFilters = geSchemaFiltersInDataview(dataview)
 
   const onSelectSourceClick: MultiSelectOnChange = (source) => {
     let datasets: string[] = []

--- a/apps/fishing-map/features/workspace/activity/ActivitySchemaFilter.tsx
+++ b/apps/fishing-map/features/workspace/activity/ActivitySchemaFilter.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useState, useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
 import { debounce } from 'lodash'
-import { MultiSelect, MultiSelectOption, Slider } from '@globalfishingwatch/ui-components'
+import { MultiSelect, MultiSelectOption, Select, Slider } from '@globalfishingwatch/ui-components'
 import { getPlaceholderBySelections } from 'features/i18n/utils'
 import { SchemaFilter } from 'features/datasets/datasets.utils'
 import styles from './ActivityFilters.module.css'
@@ -13,7 +13,7 @@ type ActivitySchemaFilterProps = {
   onClean: (filterKey: string) => void
 }
 export const showSchemaFilter = (schemaFilter: SchemaFilter) => {
-  return schemaFilter.active && schemaFilter.options.length > 1
+  return !schemaFilter.disabled && schemaFilter.options.length > 1
 }
 
 const getRangeLimitsBySchema = (schemaFilter: SchemaFilter): [number, number] => {
@@ -40,7 +40,7 @@ function ActivitySchemaFilter({
   onRemove,
   onClean,
 }: ActivitySchemaFilterProps): React.ReactElement {
-  const { id, tooltip, disabled, options, optionsSelected, type } = schemaFilter
+  const { id, disabled, options, optionsSelected, type } = schemaFilter
   const [range, setRange] = useState<number[] | null>(
     type === 'number' ? getRangeBySchema(schemaFilter) : null
   )
@@ -91,11 +91,27 @@ function ActivitySchemaFilter({
     )
   }
 
+  if (type === 'boolean') {
+    return (
+      <Select
+        key={id}
+        disabled={disabled}
+        label={t(`vessel.${id}` as any, id)}
+        placeholder={getPlaceholderBySelections(optionsSelected)}
+        options={options}
+        selectedOption={optionsSelected?.[0]}
+        containerClassName={styles.multiSelect}
+        onSelect={(selection) => onSelect(id, [selection])}
+        onRemove={() => onRemove(id, [])}
+        onCleanClick={() => onClean(id)}
+      />
+    )
+  }
+
   return (
     <MultiSelect
       key={id}
       disabled={disabled}
-      disabledMsg={tooltip}
       label={t(`vessel.${id}` as any, id)}
       placeholder={getPlaceholderBySelections(optionsSelected)}
       options={options}


### PR DESCRIPTION
- Remove fixed filters ids to use fieldsAllowed from dataset to render filters
- Support sorting by dataset.config.fieldsOrder
- Support conditional rendering for filters based on [configuration](https://github.com/GlobalFishingWatch/frontend/compare/fishing-map/activity-filters?expand=1#diff-98ce0532eaaa9234e44e8380f15e942ae62e981698a6a4f6e67add3c292c9b85R49)
- Use same workflow for flags with some workarounds to allow sorting

https://user-images.githubusercontent.com/10500650/158187918-89cfeb7e-7984-40a7-9e7c-07d07bd89c6f.mp4
