### PR TITLE
update event shapes highlight style

### DIFF
--- a/libs/layer-composer/src/generators/vessel-events/vessel-events-shapes.ts
+++ b/libs/layer-composer/src/generators/vessel-events/vessel-events-shapes.ts
@@ -128,7 +128,7 @@ class VesselsEventsShapesGenerator {
       id: `${config.id}_fishingEvents`,
       source: `${config.id}_fishingEvents`,
       paint: {
-        'circle-color': getExpression('#ffffff', ['get', 'color']),
+        'circle-color': ['get', 'color'],
         'circle-radius': [
           'interpolate',
           ['linear'],
@@ -136,8 +136,10 @@ class VesselsEventsShapesGenerator {
           4,
           getExpression(5, 3),
           9,
-          getExpression(10, 6),
+          getExpression(8, 6),
         ],
+        'circle-stroke-color': getExpression('#ffffff', 'transparent'),
+        'circle-stroke-width': 2,
       },
       metadata: {
         group: Group.Point,


### PR DESCRIPTION
Updates event highlight style
- Event shapes: 
![image](https://user-images.githubusercontent.com/10500650/165986838-d3803be9-5fa3-4442-afd8-86fe4e479b46.png)
- [Encounter](https://github.com/GlobalFishingWatch/map-gl-sprites/commit/6892efe1baecb18889ed8c13b543033f7f31bde9) and [loitering](https://github.com/GlobalFishingWatch/map-gl-sprites/commit/7c8d543e6d22d75e3fa61c45d32afa11bf0b0b9f) highlight sprite
![image](https://user-images.githubusercontent.com/10500650/165986925-34307972-7982-4491-bb1d-c68d507d3d9a.png)
