### PR TITLE
Timebar fixes

### DIFF
--- a/apps/fishing-map/features/resources/resources.utils.ts
+++ b/apps/fishing-map/features/resources/resources.utils.ts
@@ -18,7 +18,7 @@ export const trackDatasetConfigsCallback = (
       trackGraph = { ...track }
       const fieldsQuery = {
         id: 'fields',
-        value: timebarGraph,
+        value: ['timestamp', timebarGraph].join(','),
       }
       if (fieldsQueryIndex > -1) {
         query[fieldsQueryIndex] = fieldsQuery

--- a/apps/fishing-map/features/timebar/TimebarSettings.module.css
+++ b/apps/fishing-map/features/timebar/TimebarSettings.module.css
@@ -15,11 +15,11 @@
 
 .optionsContainer {
   position: absolute;
-  width: 24rem;
   padding: var(--space-M);
   background-color: var(--color-white);
   bottom: 5rem;
   right: 0;
+  white-space: nowrap;
 }
 
 .optionsContainer::after {

--- a/apps/fishing-map/features/timebar/timebar.selectors.ts
+++ b/apps/fishing-map/features/timebar/timebar.selectors.ts
@@ -75,6 +75,7 @@ export const selectTracksData = createSelector(
         const useOwnColor = trackDataviews.length === 1 && endpointType === EndpointId.UserTracks
         return {
           start: segment[0].timestamp || Number.POSITIVE_INFINITY,
+          // TODO This assumes that segments ends at last value's timestamp, which is probably incorrect
           end: segment[segment.length - 1].timestamp || Number.NEGATIVE_INFINITY,
           values: segment as TimebarChartValue[],
           props: {
@@ -117,72 +118,56 @@ const getTrackGraphElevationighlighterLabel = ({ value }: HighlighterCallbackFnA
   value ? `${value.value} m` : ''
 
 export const selectTracksGraphData = createSelector(
-  [selectTracksData, selectActiveVesselsDataviews, selectResources, selectTimebarGraph],
-  (tracksData, vesselDataviews, resources, timebarGraphType) => {
-    if (!tracksData || !resources) return
-    const tracksGraphsData: TimebarChartData = vesselDataviews.flatMap(
-      (dataview, dataviewIndex) => {
-        const trackGraphData: TimebarChartItem = {
-          color: dataview.config?.color,
-          chunks: [],
-          status: ResourceStatus.Idle,
-          getHighlighterLabel:
-            timebarGraphType === 'speed'
-              ? getTrackGraphSpeedHighlighterLabel
-              : getTrackGraphElevationighlighterLabel,
-        }
-
-        const resourcesQueries = resolveDataviewDatasetResources(dataview, DatasetTypes.Tracks)
-        const resourceQuery = resourcesQueries.find((r) =>
-          r.datasetConfig.query?.find((q) => q.id === 'fields' && q.value === timebarGraphType)
-        )
-
-        const graphUrl = resourceQuery?.url
-        if (!graphUrl) return trackGraphData
-        const graphResource = resources[graphUrl] as Resource<TrackResourceData>
-
-        // TODO better by id?
-        const track = tracksData[dataviewIndex]
-
-        if (
-          track.status === ResourceStatus.Loading ||
-          !graphResource ||
-          graphResource.status === ResourceStatus.Loading
-        ) {
-          return { ...trackGraphData, status: ResourceStatus.Loading }
-        } else if (
-          track.status === ResourceStatus.Error ||
-          graphResource.status === ResourceStatus.Error ||
-          (graphResource.status === ResourceStatus.Finished && !graphResource?.data)
-        ) {
-          return { ...trackGraphData, status: ResourceStatus.Error }
-        }
-
-        const graphChunksWithCurrentFeature: TimebarChartChunk[] = track.chunks.map(
-          (trackChunk, trackChunkIndex) => {
-            const graphSegment = graphResource?.data?.[trackChunkIndex]
-            const graphChunkValues: TimebarChartValue[] = trackChunk.values?.flatMap(
-              (trackSegmentPoint, trackSegmentPointIndex) => {
-                const graphSegmentPoint = graphSegment?.[trackSegmentPointIndex]
-                const value = (graphSegmentPoint as any)?.[timebarGraphType]
-                if (!value) return []
-                return {
-                  timestamp: trackSegmentPoint.timestamp,
-                  value,
-                }
-              }
-            )
-            const graphChunk: TimebarChartChunk = {
-              ...trackChunk,
-              values: graphChunkValues,
-            }
-            return graphChunk
-          }
-        )
-        trackGraphData.chunks = graphChunksWithCurrentFeature
-        return trackGraphData
+  [selectActiveVesselsDataviews, selectResources, selectTimebarGraph],
+  (vesselDataviews, resources, timebarGraphType) => {
+    if (!resources) return
+    const tracksGraphsData: TimebarChartData = vesselDataviews.flatMap((dataview) => {
+      const trackGraphData: TimebarChartItem = {
+        color: dataview.config?.color,
+        chunks: [],
+        status: ResourceStatus.Idle,
+        getHighlighterLabel:
+          timebarGraphType === 'speed'
+            ? getTrackGraphSpeedHighlighterLabel
+            : getTrackGraphElevationighlighterLabel,
       }
-    )
+
+      const resourcesQueries = resolveDataviewDatasetResources(dataview, DatasetTypes.Tracks)
+      const resourceQuery = resourcesQueries.find((r) =>
+        r.datasetConfig.query?.find(
+          (q) => q.id === 'fields' && q.value.toString().includes(timebarGraphType)
+        )
+      )
+      const graphUrl = resourceQuery?.url
+      if (!graphUrl) return trackGraphData
+      const graphResource = resources[graphUrl] as Resource<TrackResourceData>
+
+      if (!graphResource || graphResource.status === ResourceStatus.Loading) {
+        return { ...trackGraphData, status: ResourceStatus.Loading }
+      } else if (
+        graphResource.status === ResourceStatus.Error ||
+        (graphResource.status === ResourceStatus.Finished && !graphResource?.data)
+      ) {
+        return { ...trackGraphData, status: ResourceStatus.Error }
+      }
+      const graphChunks: TimebarChartChunk[] = graphResource.data.map((segment) => {
+        return {
+          start: segment[0].timestamp || Number.POSITIVE_INFINITY,
+          // TODO This assumes that segments ends at last value's timestamp, which is probably incorrect
+          end: segment[segment.length - 1].timestamp || Number.NEGATIVE_INFINITY,
+          values: segment.map((segmentPoint) => {
+            const value = (segmentPoint as any)?.[timebarGraphType]
+            return {
+              timestamp: segmentPoint.timestamp,
+              value,
+            }
+          }),
+        }
+      })
+
+      trackGraphData.chunks = graphChunks
+      return trackGraphData
+    })
     return tracksGraphsData
   }
 )

--- a/apps/fishing-map/features/workspace/vessels/VesselEventsLegend.module.css
+++ b/apps/fishing-map/features/workspace/vessels/VesselEventsLegend.module.css
@@ -34,7 +34,6 @@
   display: block;
   width: 12px;
   height: 12px;
-  z-index: 1;
 }
 
 .iconWrapper::before {
@@ -68,7 +67,7 @@
 .encounter::before,
 .loitering::before {
   top: 5px;
-  left: -3px;
+  left: -2px;
 }
 
 .encounter > .icon {

--- a/libs/dataviews-client/src/resolve-dataviews-generators.ts
+++ b/libs/dataviews-client/src/resolve-dataviews-generators.ts
@@ -154,7 +154,7 @@ export function getGeneratorConfig(
           params?.customGeneratorMapping && params?.customGeneratorMapping.VESSEL_EVENTS
             ? params?.customGeneratorMapping.VESSEL_EVENTS
             : GeneratorType.VesselEvents
-        console.log(params?.disableHighlight)
+
         const eventsGenerator = {
           id: `${dataview.id}${MULTILAYER_SEPARATOR}vessel_events`,
           vesselId,

--- a/libs/timebar/src/charts/tracks-events.module.css
+++ b/libs/timebar/src/charts/tracks-events.module.css
@@ -64,11 +64,11 @@
 }
 
 .encounter.compact {
-  border-width: 3.5px;
+  border-width: 3px;
 }
 
 .loitering.compact {
-  border-width: 3.5px;
+  border-width: 3px;
 }
 
 .encounter:hover,

--- a/libs/timebar/src/charts/tracks-events.module.css
+++ b/libs/timebar/src/charts/tracks-events.module.css
@@ -53,6 +53,24 @@
   border-image-slice: 50% 6 fill;
 }
 
+.fishing.compact {
+  height: 3px;
+  min-width: 3px;
+}
+
+.port_visit.compact {
+  height: 6px;
+  min-width: 6px;
+}
+
+.encounter.compact {
+  border-width: 3.5px;
+}
+
+.loitering.compact {
+  border-width: 3.5px;
+}
+
 .encounter:hover,
 .encounter.highlighted,
 .loitering:hover,

--- a/libs/timebar/src/charts/tracks-events.tsx
+++ b/libs/timebar/src/charts/tracks-events.tsx
@@ -103,6 +103,7 @@ const TracksEvents = ({
             <div
               key={event.id}
               className={cx(styles.event, styles[event.type || 'none'], {
+                [styles.compact]: tracksEventsWithCoords.length >= 5,
                 [styles.highlighted]:
                   highlightedEventsIds && highlightedEventsIds.includes(event.id as string),
               })}

--- a/libs/timebar/src/charts/tracks-events.tsx
+++ b/libs/timebar/src/charts/tracks-events.tsx
@@ -103,7 +103,7 @@ const TracksEvents = ({
             <div
               key={event.id}
               className={cx(styles.event, styles[event.type || 'none'], {
-                [styles.compact]: tracksEventsWithCoords.length >= 5,
+                [styles.compact]: tracksEventsWithCoords.length > 5,
                 [styles.highlighted]:
                   highlightedEventsIds && highlightedEventsIds.includes(event.id as string),
               })}

--- a/libs/timebar/src/charts/tracks-events.tsx
+++ b/libs/timebar/src/charts/tracks-events.tsx
@@ -103,7 +103,7 @@ const TracksEvents = ({
             <div
               key={event.id}
               className={cx(styles.event, styles[event.type || 'none'], {
-                [styles.compact]: tracksEventsWithCoords.length > 5,
+                [styles.compact]: tracksEventsWithCoords.length >= 5,
                 [styles.highlighted]:
                   highlightedEventsIds && highlightedEventsIds.includes(event.id as string),
               })}


### PR DESCRIPTION
Small superficial fixes and one critical: https://github.com/GlobalFishingWatch/frontend/pull/1392/commits/039ae714ad20b15bf0d087a7a3e19ecd5ffa671a
Graph data was supposed to follow track data structure, but since tracks now comes as chunks, the base track data was wrong, which led to graph data being completely off. Now when calling the tracks API for graph data, timestamps are requested as well, so that graph data is now built independently of track data.