### PR TITLE
Feature/file upload issues

### DIFF
--- a/apps/fishing-map/features/datasets/NewDataset.tsx
+++ b/apps/fishing-map/features/datasets/NewDataset.tsx
@@ -269,20 +269,7 @@ function NewDataset(): React.ReactElement {
     if (file) {
       let validityError
       let onTheFlyGeoJSONFile
-      if (
-        metadata?.category === DatasetCategory.Environment &&
-        datasetGeometryType === 'polygons'
-      ) {
-        if (!metadata?.configuration?.propertyToInclude) {
-          validityError = t('dataset.requiredFields', {
-            fields: 'value',
-            defaultValue: 'Required field value',
-          }) as string
-        }
-      } else if (
-        metadata?.category === DatasetCategory.Environment &&
-        datasetGeometryType === 'tracks'
-      ) {
+      if (metadata?.category === DatasetCategory.Environment && datasetGeometryType === 'tracks') {
         if (
           !metadata.configuration?.latitude ||
           !metadata.configuration?.longitude ||

--- a/apps/fishing-map/features/datasets/NewDataset.tsx
+++ b/apps/fishing-map/features/datasets/NewDataset.tsx
@@ -129,7 +129,21 @@ function NewDataset(): React.ReactElement {
             const shpjs = await import('shpjs').then((module) => module.default)
             const fileData = await readBlobAs(file, 'arrayBuffer')
             // TODO support multiple files in shapefile
-            geojson = (await shpjs(fileData)) as FeatureCollectionWithFilename
+            const expandedShp = (await shpjs(fileData)) as FeatureCollectionWithFilename
+            if (Array.isArray(expandedShp)) {
+              // geojson = expandedShp[0]
+              setFileData(undefined)
+              setLoading(false)
+              setError(
+                t(
+                  'errors.datasetShapefileMultiple',
+                  'Shapefiles containing multiple components (multiple file names) are not supported yet'
+                )
+              )
+              return
+            } else {
+              geojson = expandedShp
+            }
           } catch (e: any) {
             console.warn('Error reading file:', e)
           }

--- a/apps/fishing-map/features/datasets/datasets.slice.ts
+++ b/apps/fishing-map/features/datasets/datasets.slice.ts
@@ -134,6 +134,8 @@ export const createDatasetThunk = createAsyncThunk<
       },
     }
 
+    delete (datasetWithFilePath as any).public
+
     const createdDataset = await GFWAPI.fetch<Dataset>('/v1/datasets', {
       method: 'POST',
       body: datasetWithFilePath as any,

--- a/apps/fishing-map/public/locales/source/translations.json
+++ b/apps/fishing-map/public/locales/source/translations.json
@@ -218,6 +218,7 @@
     "contactUs": "Please <1>contact us</1> to report the problem.",
     "datasetNotFound": "Dataset not found",
     "datasetNotValid": "It seems to be something wrong with your file",
+    "datasetShapefileMultiple": "Shapefiles containing multiple components (mutiple file names) are not supported yet",
     "fields": "Errors with fields {{fields}}",
     "generic": "Something went wrong, try again or contact:",
     "genericShort": "Something went wrong",

--- a/libs/dataviews-client/src/resolve-dataviews-generators.ts
+++ b/libs/dataviews-client/src/resolve-dataviews-generators.ts
@@ -320,7 +320,10 @@ export function getGeneratorConfig(
         if (dataset?.source) {
           generator.attribution = dataset.source
         }
-        if (dataset.category === DatasetCategory.Environment) {
+
+        const propertyToInclude = (dataset.configuration as EnviromentalDatasetConfiguration)
+          ?.propertyToInclude
+        if (dataset.category === DatasetCategory.Environment && propertyToInclude) {
           const { min, max } =
             (dataset.configuration as EnviromentalDatasetConfiguration)?.propertyToIncludeRange ||
             {}

--- a/libs/layer-composer/src/generators/user-context/user-context.ts
+++ b/libs/layer-composer/src/generators/user-context/user-context.ts
@@ -82,11 +82,6 @@ class UserContextGenerator {
         color: config.color,
         interactive: false,
         generatorId,
-        legend: {
-          type: 'solid',
-          ...config.metadata?.legend,
-          group: Group.OutlinePolygonsHighlighted,
-        },
       },
     }
 


### PR DESCRIPTION
https://globalfishingwatch.atlassian.net/jira/software/c/projects/MAP/boards/46?modal=detail&selectedIssue=MAP-800&assignee=5f1f29eea1648700150d0631

1. Removes newly unsupported `public` field when uploading a dataset (https://globalfishingwatch.slack.com/archives/C909RQ6QG/p1652180394957589?thread_ts=1652175962.517999&cid=C909RQ6QG)
2. Display an error when a user tries to upload a shapefile containing multiple components (ie export from QGIS). As a further improvement I would like to add a component selector in the dataset config, should be possible by uploading the geoJSON generated on the fly rather than the original shapefile, correct?
3. If a user doesn't specify a field when uploading a polygon env layer, do not display the error and just display the layer as lines 
