### PR TITLE
simplify generator and hook

### DIFF
--- a/apps/fishing-map/features/map/map-sources.hooks.ts
+++ b/apps/fishing-map/features/map/map-sources.hooks.ts
@@ -123,15 +123,13 @@ export const useMapSourceTiles = (sourcesId?: SourcesHookInput) => {
   return useMemoCompare(sourcesLoaded)
 }
 
-export const useMapSourceTilesLoaded = (sourcesId: SourcesHookInput, returnAll?: boolean) => {
+export const useMapSourceTilesLoaded = (sourcesId: SourcesHookInput) => {
   const style = useMapStyle()
   const sourceTilesLoaded = useMapSourceTiles()
   const sourceInStyle = useSourceInStyle(sourcesId)
   const sourcesIdsList = getGeneratorSourcesIds(style, sourcesId)
   const allSourcesLoaded = sourcesIdsList.map((source) => sourceTilesLoaded[source]?.loaded)
-
-  if (returnAll) return allSourcesLoaded
-  else return sourceInStyle && allSourcesLoaded.every((loaded) => loaded)
+  return sourceInStyle && allSourcesLoaded.every((loaded) => loaded)
 }
 
 const CLUSTERS_SOURCES_IDS = [ENCOUNTER_EVENTS_SOURCE_ID, BIG_QUERY_EVENTS_PREFIX]

--- a/apps/fishing-map/features/map/map.hooks.ts
+++ b/apps/fishing-map/features/map/map.hooks.ts
@@ -32,7 +32,7 @@ import {
   selectShowTimeComparison,
   selectTimeComparisonValues,
 } from 'features/analysis/analysis.selectors'
-import { useMapClusterTilesLoaded, useMapSourceTilesLoaded } from 'features/map/map-sources.hooks'
+import { useMapClusterTilesLoaded, useMapSourceTiles } from 'features/map/map-sources.hooks'
 import { ENCOUNTER_EVENTS_SOURCE_ID } from 'features/dataviews/dataviews.utils'
 import { useAppDispatch } from 'features/app/app.hooks'
 import {
@@ -78,21 +78,18 @@ export const useGeneratorsConnect = () => {
   const showTimeComparison = useSelector(selectShowTimeComparison)
   const timeComparisonValues = useSelector(selectTimeComparisonValues)
 
-  // TODO memoize allIds?
-  const allIds = generatorsConfig.map((g) => g.id)
-  const layersLoaded = useMapSourceTilesLoaded(allIds || [], true)
-  const layersLoadedSerialized = (layersLoaded as boolean[]).join('')
-  const updatedGeneratosConfig = useMemo(() => {
+  const sourceTilesLoaded = useMapSourceTiles()
+  const updatedGeneratorConfig = useMemo(() => {
     return generatorsConfig.map((generatorConfig, i) => {
       if (generatorConfig.type === GeneratorType.Polygons) {
         return {
           ...generatorConfig,
-          loaded: layersLoaded[i],
+          opacity: sourceTilesLoaded[generatorConfig.id]?.loaded ? 1 : 0,
         }
       }
       return generatorConfig
     })
-  }, [generatorsConfig, layersLoadedSerialized])
+  }, [generatorsConfig])
 
   return useMemo(() => {
     let globalConfig: GlobalGeneratorConfig = {
@@ -108,10 +105,10 @@ export const useGeneratorsConnect = () => {
       }
     }
     return {
-      generatorsConfig: updatedGeneratosConfig,
+      generatorsConfig: updatedGeneratorConfig,
       globalConfig,
     }
-  }, [updatedGeneratosConfig, viewport.zoom, start, end, timeComparisonValues, showTimeComparison])
+  }, [updatedGeneratorConfig, viewport.zoom, start, end, timeComparisonValues, showTimeComparison])
 }
 
 export const useClickedEventConnect = () => {

--- a/libs/layer-composer/src/generators/polygons/polygons.ts
+++ b/libs/layer-composer/src/generators/polygons/polygons.ts
@@ -36,7 +36,7 @@ class PolygonsGenerator {
     const paint = {
       'line-color': config.color || DEFAULT_COLOR,
       'line-width': 0.5,
-      'line-opacity': config.opacity || config.loaded ? 1 : 0.35,
+      'line-opacity': config.opacity || 1,
     }
 
     const visibility = isConfigVisible(config)

--- a/libs/layer-composer/src/generators/types.ts
+++ b/libs/layer-composer/src/generators/types.ts
@@ -70,7 +70,6 @@ export interface GeneratorConfig {
   visible?: boolean
   opacity?: number
   metadata?: GeneratorMetadata
-  loaded?: boolean
 }
 
 /**


### PR DESCRIPTION
- I don't think we need another param in the generator config for `loaded` because we can already handle the opacity at the [app level](https://github.com/GlobalFishingWatch/frontend/pull/1413/files#diff-36b02ca52df9696dd5bf7a310036c24a3f7a6890c3fee29e951f42cd99bb3af8R39)
- I also think adding an extra parameter for the hook is unnecessary because adds complexity and we can read the source status by id using the existing `useMapSourceTiles` [hook](https://github.com/GlobalFishingWatch/frontend/pull/1413/files#diff-224a0a8337cd448587a358158edf27b37fe7a1b5d58f6f4e1f8000af706c3ff2R81)