### PR TITLE
Feature/error states

### DIFF
--- a/apps/fishing-map/features/map/map-sources.hooks.ts
+++ b/apps/fishing-map/features/map/map-sources.hooks.ts
@@ -256,12 +256,14 @@ export const useMapDataviewFeatures = (dataviews: UrlDataviewInstance | UrlDatav
             }
           })
         : null
-
       const sourceId = metadata?.timeChunks?.activeSourceId || dataviewsId[0]
       const state = chunks
         ? ({
             loaded: chunksFeatures.every(({ state }) => state.loaded !== false),
-            error: chunksFeatures.filter(({ state }) => state.error).join(','),
+            error: chunksFeatures
+              .filter(({ state }) => state.error)
+              .map(({ state }) => state.error)
+              .join(','),
           } as TilesAtomSourceState)
         : sourceTilesLoaded[sourceId] || ({} as TilesAtomSourceState)
 

--- a/apps/fishing-map/features/timebar/Timebar.module.css
+++ b/apps/fishing-map/features/timebar/Timebar.module.css
@@ -35,3 +35,13 @@
   top: 0;
   left: 50%;
 }
+
+.error {
+  transform: translateX(50%);
+  width: 50%;
+  color: var(--color-white);
+  text-align: center;
+  line-height: 1.5rem;
+  margin-top: 14px;
+  opacity: 0.5;
+}

--- a/apps/fishing-map/features/timebar/Timebar.tsx
+++ b/apps/fishing-map/features/timebar/Timebar.tsx
@@ -266,6 +266,50 @@ const TimebarWrapper = () => {
     tracksGraphsData?.some(({ status }) => status === ResourceStatus.Loading) ||
     tracksEvents?.some(({ status }) => status === ResourceStatus.Loading)
 
+  const hasTrackError =
+    tracks?.some(({ status }) => status === ResourceStatus.Error) ||
+    tracksEvents?.some(({ status }) => status === ResourceStatus.Error)
+
+  const getTracksComponents = () => {
+    if (hasTrackError) {
+      return (
+        <div className={styles.error}>
+          {t(
+            'analysis.error',
+            'There was a problem loading the data, please try refreshing the page'
+          )}
+        </div>
+      )
+    } else if (tracks.length > MAX_TIMEBAR_VESSELS) {
+      return (
+        <div className={styles.disclaimer}>
+          <label className={styles.disclaimerLabel}>
+            {upperFirst(
+              t('timebar.maxTracksNumber', 'Track detail not available for more than 10 vessels')
+            )}
+          </label>
+        </div>
+      )
+    }
+    return (
+      <Fragment>
+        <TimebarTracks key="tracks" data={tracks} />
+        {showGraph && tracksGraphsData && (
+          <TimebarTracksGraph key="trackGraph" data={tracksGraphsData} />
+        )}
+        {tracksEvents && (
+          <Fragment>
+            <TimebarTracksEvents
+              data={tracksEvents}
+              highlightedEventsIds={highlightedEvents}
+              onEventClick={onEventClick}
+            />
+          </Fragment>
+        )}
+      </Fragment>
+    )
+  }
+
   return (
     <div className={styles.timebarWrapper}>
       <Timebar
@@ -296,35 +340,7 @@ const TimebarWrapper = () => {
               timebarVisualisation === TimebarVisualisations.Environment) && (
               <TimebarActivityGraph visualisation={timebarVisualisation} />
             )}
-            {timebarVisualisation === TimebarVisualisations.Vessel &&
-              (tracks && tracks.length <= MAX_TIMEBAR_VESSELS ? (
-                <Fragment>
-                  <TimebarTracks key="tracks" data={tracks} />
-                  {showGraph && tracksGraphsData && (
-                    <TimebarTracksGraph key="trackGraph" data={tracksGraphsData} />
-                  )}
-                  {tracksEvents && (
-                    <Fragment>
-                      <TimebarTracksEvents
-                        data={tracksEvents}
-                        highlightedEventsIds={highlightedEvents}
-                        onEventClick={onEventClick}
-                      />
-                    </Fragment>
-                  )}
-                </Fragment>
-              ) : (
-                <div className={styles.disclaimer}>
-                  <label className={styles.disclaimerLabel}>
-                    {upperFirst(
-                      t(
-                        'timebar.maxTracksNumber',
-                        'Track detail not available for more than 10 vessels'
-                      )
-                    )}
-                  </label>
-                </div>
-              ))}
+            {timebarVisualisation === TimebarVisualisations.Vessel && getTracksComponents()}
             <TimebarHighlighterWrapper dispatchHighlightedEvents={dispatchHighlightedEvents} />
           </Fragment>
         ) : null}

--- a/apps/fishing-map/features/timebar/TimebarActivityGraph.hooks.ts
+++ b/apps/fishing-map/features/timebar/TimebarActivityGraph.hooks.ts
@@ -4,7 +4,11 @@ import { useDebounce, useSmallScreen } from '@globalfishingwatch/react-hooks'
 import { Timeseries } from '@globalfishingwatch/timebar'
 import { UrlDataviewInstance } from '@globalfishingwatch/dataviews-client'
 import { checkEqualBounds, useMapBounds } from 'features/map/map-viewport.hooks'
-import { areDataviewsFeatureLoaded, useMapDataviewFeatures } from 'features/map/map-sources.hooks'
+import {
+  areDataviewsFeatureLoaded,
+  hasDataviewsFeatureError,
+  useMapDataviewFeatures,
+} from 'features/map/map-sources.hooks'
 import { getTimeseriesFromDataviews } from 'features/timebar/TimebarActivityGraph.utils'
 import { filterByViewport } from 'features/map/map.utils'
 
@@ -15,6 +19,7 @@ export const useStackedActivity = (dataviews: UrlDataviewInstance[]) => {
   const { bounds } = useMapBounds()
   const debouncedBounds = useDebounce(bounds, 400)
   const dataviewFeatures = useMapDataviewFeatures(dataviews)
+  const error = hasDataviewsFeatureError(dataviewFeatures)
   const boundsChanged = !checkEqualBounds(bounds, debouncedBounds)
   const loading =
     boundsChanged || !areDataviewsFeatureLoaded(dataviewFeatures) || generatingStackedActivity
@@ -42,12 +47,12 @@ export const useStackedActivity = (dataviews: UrlDataviewInstance[]) => {
 
   const dataviewFeaturesLoaded = areDataviewsFeatureLoaded(dataviewFeatures)
   useEffect(() => {
-    if (!isSmallScreen && dataviewFeaturesLoaded) {
+    if (!isSmallScreen && dataviewFeaturesLoaded && !error) {
       setGeneratingStackedActivity(true)
       debouncedSetStackedActivity(dataviewFeatures, debouncedBounds)
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [dataviewFeaturesLoaded, debouncedBounds, debouncedSetStackedActivity, isSmallScreen])
 
-  return { loading, stackedActivity }
+  return { loading, error, stackedActivity }
 }

--- a/apps/fishing-map/features/timebar/TimebarActivityGraph.tsx
+++ b/apps/fishing-map/features/timebar/TimebarActivityGraph.tsx
@@ -33,7 +33,7 @@ const TimebarActivityGraph = ({ visualisation }: { visualisation: TimebarVisuali
     if (selectedEnvDataview) return [selectedEnvDataview]
     else if (environmentDataviews[0]) return [environmentDataviews[0]]
   }, [activityDataviews, environmentDataviews, timebarSelectedEnvId, visualisation])
-  const { loading, stackedActivity } = useStackedActivity(activeDataviews)
+  const { loading, stackedActivity, error } = useStackedActivity(activeDataviews)
   const style = useMapStyle()
   const mapLegends = useMapLegend(style, activeDataviews)
 
@@ -58,6 +58,16 @@ const TimebarActivityGraph = ({ visualisation }: { visualisation: TimebarVisuali
     [mapLegends, visualisation]
   )
 
+  if (error) {
+    return (
+      <div className={styles.error}>
+        {t(
+          'analysis.error',
+          'There was a problem loading the data, please try refreshing the page'
+        )}
+      </div>
+    )
+  }
   if (!stackedActivity || !stackedActivity.length) return null
 
   return (

--- a/apps/fishing-map/features/timebar/timebar.selectors.ts
+++ b/apps/fishing-map/features/timebar/timebar.selectors.ts
@@ -225,11 +225,12 @@ export const selectTracksEvents = createSelector(
 
         return resources[url].data as TimebarChartChunk<TrackEventChunkProps>[]
       })
-      trackEvents.status = eventsResourcesFiltered.every(
-        ({ url }) => resources[url]?.status === ResourceStatus.Finished
-      )
-        ? ResourceStatus.Finished
-        : ResourceStatus.Loading
+      const statuses = eventsResourcesFiltered.map(({ url }) => resources[url]?.status)
+      if (statuses.some((s) => s === ResourceStatus.Error))
+        trackEvents.status = ResourceStatus.Error
+      else if (statuses.every((s) => s === ResourceStatus.Finished))
+        trackEvents.status = ResourceStatus.Finished
+      else trackEvents.status = ResourceStatus.Loading
 
       return trackEvents
     })

--- a/libs/timebar/src/charts/tracks.tsx
+++ b/libs/timebar/src/charts/tracks.tsx
@@ -61,6 +61,7 @@ const Tracks = ({ data }: { data: TimebarChartData }) => {
   return (
     <Fragment>
       {tracksWithCoords.map((track, i) => {
+        if (track.status === ResourceStatus.Error) return null
         return (
           <div key={i}>
             {track.status === ResourceStatus.Finished ? (


### PR DESCRIPTION
Aggressively display errors when API fails:
- fixed error status in sidebar if one of the track chunk of a set fails to load
- added an error message in the Timebar when one of the activity tiles fails to load:
![Screenshot 2022-05-24 at 10 47 56](https://user-images.githubusercontent.com/1583415/170000645-93901979-c047-42d1-9a05-987c822921eb.png)
- added same error message when one of the track chunk of a set fails to load, or when one of the displayed events resource fails to load