### PR TITLE
Limit zoom level on animated heatmap layers. MAP-797

### DIFF
--- a/libs/api-types/src/dataviews.ts
+++ b/libs/api-types/src/dataviews.ts
@@ -10,6 +10,7 @@ export interface DataviewConfig<Type = any> {
   visible?: boolean
   filters?: Record<string, any>
   dynamicBreaks?: boolean
+  maxZoom?: number
   [key: string]: any
 }
 

--- a/libs/dataviews-client/src/resolve-dataviews-generators.ts
+++ b/libs/dataviews-client/src/resolve-dataviews-generators.ts
@@ -443,8 +443,8 @@ export function getDataviewsGeneratorConfigs(
     })
 
     const maxZoomLevels = dataviews
-      ?.filter(({ config }) => config && config?.maxZoom)
-      .flatMap(({ config }) => config?.maxZoom)
+      ?.filter(({ config }) => config && config?.maxZoom !== undefined)
+      .flatMap(({ config }) => config?.maxZoom as number)
     const mergedActivityDataview = {
       id: params.mergedActivityGeneratorId || MERGED_ACTIVITY_ANIMATED_HEATMAP_GENERATOR_ID,
       config: {

--- a/libs/dataviews-client/src/resolve-dataviews-generators.ts
+++ b/libs/dataviews-client/src/resolve-dataviews-generators.ts
@@ -453,11 +453,10 @@ export function getDataviewsGeneratorConfigs(
         mode: heatmapAnimatedMode,
         // if any of the activity dataviews has a max zoom level defined
         // apply the minimum max zoom level (the most restrictive approach)
-        ...((maxZoomLevels &&
+        ...(maxZoomLevels &&
           maxZoomLevels.length > 0 && {
             maxZoom: Math.min(...maxZoomLevels),
-          }) ||
-          {}),
+          }),
       },
     }
     dataviewsFiltered.push(mergedActivityDataview)

--- a/libs/dataviews-client/src/resolve-dataviews-generators.ts
+++ b/libs/dataviews-client/src/resolve-dataviews-generators.ts
@@ -442,12 +442,22 @@ export function getDataviewsGeneratorConfigs(
       return sublayer
     })
 
+    const maxZoomLevels = dataviews
+      ?.filter(({ config }) => config && config?.maxZoom)
+      .flatMap(({ config }) => config?.maxZoom)
     const mergedActivityDataview = {
       id: params.mergedActivityGeneratorId || MERGED_ACTIVITY_ANIMATED_HEATMAP_GENERATOR_ID,
       config: {
         type: GeneratorType.HeatmapAnimated,
         sublayers: activitySublayers,
         mode: heatmapAnimatedMode,
+        // if any of the activity dataviews has a max zoom level defined
+        // apply the minimum max zoom level (the most restrictive approach)
+        ...((maxZoomLevels &&
+          maxZoomLevels.length > 0 && {
+            maxZoom: Math.min(...maxZoomLevels),
+          }) ||
+          {}),
       },
     }
     dataviewsFiltered.push(mergedActivityDataview)


### PR DESCRIPTION
- Enable maxZoom on heatmap animated dataviews so that 4wing tiles beyond that zoom level are not requested and loaded.

https://user-images.githubusercontent.com/2205831/170121175-8f3bbe51-a029-4f3b-b56d-4099b0156661.mp4


