### PR TITLE
Dataviews normalization

### DIFF
--- a/apps/fishing-map/features/datasets/datasets.utils.ts
+++ b/apps/fishing-map/features/datasets/datasets.utils.ts
@@ -39,25 +39,9 @@ export type SupportedActivityDatasetSchema =
 
 export type SupportedEnvDatasetSchema = 'type'
 
-type IncompatibleFilter = {
-  id: SupportedDatasetSchema
-  value: any
-  disabled: SupportedDatasetSchema[]
-}
-type IncompatibleFiltersDict = Record<string, IncompatibleFilter[]>
-const INCOMPATIBLE_FILTERS_DICT: IncompatibleFiltersDict = {
-  'public-presence-viirs-match-prototype:v20220112': [
-    { id: 'matched', value: false, disabled: ['source', 'flag', 'shiptype', 'geartype'] },
-  ],
-  'public-ais-presence-viirs-match-prototype:v20220112': [
-    { id: 'matched', value: false, disabled: ['source', 'flag', 'shiptype', 'geartype'] },
-  ],
-  'public-global-sar-presence:v20210924': [
-    { id: 'matched', value: false, disabled: ['flag', 'geartype'] },
-  ],
-}
-
-export type SchemaFieldDataview = UrlDataviewInstance | Pick<Dataview, 'config' | 'datasets'>
+export type SchemaFieldDataview =
+  | UrlDataviewInstance
+  | Pick<Dataview, 'config' | 'datasets' | 'filtersConfig'>
 
 export const isPrivateDataset = (dataset: Partial<Dataset>) =>
   (dataset?.id || '').includes(PRIVATE_SUFIX)
@@ -279,9 +263,11 @@ export const getIncompatibleFilterSelection = (
   schema: SupportedDatasetSchema
 ) => {
   return dataview?.datasets?.flatMap((dataset) => {
-    const hasIncompatibility = INCOMPATIBLE_FILTERS_DICT[dataset.id] !== undefined
-    if (!hasIncompatibility) return []
-    return INCOMPATIBLE_FILTERS_DICT[dataset.id].filter(({ id, value, disabled }) => {
+    const incompatibilityDict = dataview.filtersConfig?.incompatibility?.[dataset.id]
+    if (!incompatibilityDict?.length) {
+      return []
+    }
+    return incompatibilityDict.filter(({ id, value, disabled }) => {
       const selectedFilterValue = dataview.config?.filters?.[id]
       return (
         disabled.includes(schema) &&
@@ -395,17 +381,16 @@ export const geSchemaFiltersInDataview = (dataview: SchemaFieldDataview): Schema
   const fieldsIds = uniq(
     dataview.datasets?.flatMap((d) => d.fieldsAllowed || [])
   ) as SupportedDatasetSchema[]
-  const fieldsOrder =
-    dataview.datasets.length === 1 &&
-    (dataview.datasets[0].configuration?.fieldsOrder as SupportedDatasetSchema[])
+  const fieldsOrder = dataview.filtersConfig?.order as SupportedDatasetSchema[]
   const fieldsAllowed = fieldsIds.filter((f) => isDataviewSchemaSupported(dataview, f))
-  const fielsAllowedOrdered = fieldsOrder
-    ? fieldsAllowed.sort((a, b) => {
-        const aIndex = fieldsOrder.findIndex((f) => f === a)
-        const bIndex = fieldsOrder.findIndex((f) => f === b)
-        return aIndex - bIndex
-      })
-    : fieldsAllowed
+  const fielsAllowedOrdered =
+    fieldsOrder && fieldsOrder.length > 0
+      ? fieldsAllowed.sort((a, b) => {
+          const aIndex = fieldsOrder.findIndex((f) => f === a)
+          const bIndex = fieldsOrder.findIndex((f) => f === b)
+          return aIndex - bIndex
+        })
+      : fieldsAllowed
   const schemaFilters = fielsAllowedOrdered.map((id) => getFiltersBySchema(dataview, id))
   return schemaFilters
 }

--- a/libs/api-types/src/dataviews.ts
+++ b/libs/api-types/src/dataviews.ts
@@ -46,6 +46,24 @@ export interface DataviewInfoConfig {
   fields: DataviewInfoConfigField[]
 }
 
+export interface DataviewEventsConfig {
+  showIcons: boolean
+  showAuthorizationStatus: boolean
+  pointsToSegmentsSwitchLevel: boolean
+}
+
+export interface IncomatibleFilterConfig {
+  id: string // id of the filter
+  value: boolean // value to match
+  disabled: string[] // disabled filter on matches
+}
+
+export interface DataviewFiltersConfig {
+  order: string[]
+  // Dictionary for datasets filters selection not allowed
+  incompatibility: Record<string, IncomatibleFilterConfig[]>
+}
+
 export enum DataviewCategory {
   Context = 'context',
   Events = 'events',
@@ -68,6 +86,8 @@ export interface Dataview<Type = any, Category = DataviewCategory> {
   config: DataviewConfig<Type>
   datasets?: Dataset[]
   infoConfig?: DataviewInfoConfig
+  eventsConfig?: DataviewEventsConfig
+  filtersConfig?: DataviewFiltersConfig
   datasetsConfig?: DataviewDatasetConfig[]
 }
 


### PR DESCRIPTION
This PR updates the needed configuration in dataviews to normalise the structure to be ready for the terraform migration:

- [x] migrate fieldsOrder from dataset.configuration to dataview.filtersConfig.order
- [ ] migrate config.interval string to config.intervals array
- [ ] dataview.config.layers is now an array of { id:'string', dataset: 'id' }
- [ ] migrate dataview.config.layer & basemap to the new structure ☝️
- [ ] migrate dataview.config.steps to config.breaks to reuse same config (vessels dataviews)
- [ ] migrate custom events config to the new root property `eventsConfig`
	show_icons
	show_authorization_status
	points_to_segments_switch_level
