### PR TITLE
set timebarSelectedEnvId fallback in selector

### DIFF
--- a/apps/fishing-map/features/app/app.selectors.ts
+++ b/apps/fishing-map/features/app/app.selectors.ts
@@ -29,6 +29,7 @@ import {
   selectDataviewInstancesMerged,
 } from 'features/dataviews/dataviews.slice'
 import { RootState } from 'store'
+import { selectEnvironmentalDataviews } from 'features/dataviews/dataviews.selectors'
 
 export const selectViewport = createSelector(
   [selectUrlViewport, selectWorkspaceViewport],
@@ -123,8 +124,15 @@ export const selectTimebarVisualisation = createSelector(
 )
 
 export const selectTimebarSelectedEnvId = createSelector(
-  [selectWorkspaceStateProperty('timebarSelectedEnvId')],
-  (timebarSelectedEnvId): string => {
+  [
+    selectWorkspaceStateProperty('timebarSelectedEnvId'),
+    selectTimebarVisualisation,
+    selectEnvironmentalDataviews,
+  ],
+  (timebarSelectedEnvId, timebarVisualisation, envDataviews): string => {
+    if (timebarVisualisation === TimebarVisualisations.Environment) {
+      return timebarSelectedEnvId || envDataviews[0]?.id
+    }
     return timebarSelectedEnvId
   }
 )

--- a/apps/fishing-map/features/timebar/TimebarSettings.tsx
+++ b/apps/fishing-map/features/timebar/TimebarSettings.tsx
@@ -253,7 +253,7 @@ const TimebarSettings = ({ loading = false }: { loading: boolean }) => {
                   }
                   active={
                     timebarVisualisation === TimebarVisualisations.Environment &&
-                    (timebarSelectedEnvId === envDataview.id || (!timebarSelectedEnvId && i === 0))
+                    timebarSelectedEnvId === envDataview.id
                   }
                   tooltip={activityTooltipLabel}
                   onClick={() => setEnvironmentActive(envDataview.id)}


### PR DESCRIPTION
to fix the environmental layers with different interval in the `stickToUnit` function when the environment dataview was selected by default, this PR set a value `timebarSelectedEnvId` using the first dataview as fallback in the selector
