### PR TITLE
Display activity layer stats only when time range is less than 1 year

### DIFF
--- a/apps/fishing-map/features/workspace/activity/ActivityLayerPanel.tsx
+++ b/apps/fishing-map/features/workspace/activity/ActivityLayerPanel.tsx
@@ -241,11 +241,11 @@ function ActivityLayerPanel({
                         stats.type === 'vessels'
                           ? t(
                               'layer.statsHelp',
-                              'The number of vessels and flag states is calculated for your current filters and time range globally. Some double counting may occur.'
+                              'The number of vessels and flag states is calculated for your current filters and time range globally (up to 1 year). Some double counting may occur.'
                             )
                           : t(
                               'layer.statsHelpDetection',
-                              'The number of detections is calculated for your current filters and time range globally. Some double counting may occur.'
+                              'The number of detections is calculated for your current filters and time range globally (up to 1 year). Some double counting may occur.'
                             )
                       }
                     >

--- a/apps/fishing-map/queries/stats-api.ts
+++ b/apps/fishing-map/queries/stats-api.ts
@@ -33,6 +33,7 @@ const serializeStatsDataviewKey: SerializeQueryArgs<CustomBaseQueryArg> = ({ que
   ].join('-')
 }
 
+export const MAX_STATS_YEARS = 1
 export const DEFAULT_STATS_FIELDS = ['vessel_id', 'flag']
 // Define a service using a base URL and expected endpoints
 export const dataviewStatsApi = createApi({


### PR DESCRIPTION
Requires updating the 'statsHelp' and 'statsHelpDetection' keys on CrowdIn so that tooltips say "time range up to 1 year".