### PR TITLE
Fishing map/choose right dataset based on vessel year

### DIFF
--- a/apps/fishing-map/features/map/map.slice.ts
+++ b/apps/fishing-map/features/map/map.slice.ts
@@ -284,16 +284,12 @@ export const fetchFishingActivityInteractionThunk = createAsyncThunk<
           vessels: sublayerVessels
             .flatMap((vessels) => {
               return vessels.map((vessel) => {
-                const vesselInfo =
-                  vesselsInfo?.find((entry) => {
-                    return (
-                      entry.years &&
-                      startYear &&
-                      endYear &&
-                      entry.years.includes(startYear) &&
-                      entry.years.includes(endYear)
-                    )
-                  }) || vesselsInfo[0]
+                const vesselInfo = vesselsInfo?.find((entry) => {
+                  if (entry.years?.length && startYear && endYear) {
+                    return entry.years.includes(startYear) && entry.years.includes(endYear)
+                  }
+                  return entry.id === vessel.id
+                })
                 const infoDataset = selectDatasetById(vesselInfo?.dataset as string)(state)
                 const trackFromRelatedDataset = infoDataset || vessel.dataset
                 const trackDatasetId = getRelatedDatasetByType(

--- a/apps/fishing-map/features/map/map.slice.ts
+++ b/apps/fishing-map/features/map/map.slice.ts
@@ -294,7 +294,6 @@ export const fetchFishingActivityInteractionThunk = createAsyncThunk<
                       entry.years.includes(endYear)
                     )
                   }) || vesselsInfo[0]
-                console.log('vesselInfo', vesselInfo)
                 const infoDataset = selectDatasetById(vesselInfo?.dataset as string)(state)
                 const trackFromRelatedDataset = infoDataset || vessel.dataset
                 const trackDatasetId = getRelatedDatasetByType(

--- a/libs/api-types/src/vessel.ts
+++ b/libs/api-types/src/vessel.ts
@@ -32,6 +32,7 @@ export interface Vessel {
   authorizations?: Authorization[]
   registeredGearType?: string
   imageList?: string[]
+  years?: number[]
 }
 
 export interface VesselSearch extends Vessel {


### PR DESCRIPTION
In instances like [this sar detection](http://localhost:3003/?latitude=69.8994943608468&longitude=19.996655542591952&zoom=10.335549728181997&start=2022-04-23T00%3A00%3A00.000Z&end=2022-04-24T00%3A00%3A00.000Z&dvIn[0][id]=vessel-~1&dvIn[0][dvId]=92&dvIn[0][cfg][clr]=%23F95E5E&dvIn[0][dsC][0][dsId]=private-global-other-vessels%3Av20201001&dvIn[0][dsC][0][pms][0][id]=~0&dvIn[0][dsC][0][pms][0][val]=~1&dvIn[0][dsC][0][ept]=~2&dvIn[0][dsC][1][dsId]=private-global-presence-tracks%3Av20201001&dvIn[0][dsC][1][pms][0][id]=~0&dvIn[0][dsC][1][pms][0][val]=~1&dvIn[0][dsC][1][ept]=tracks&dvIn[0][dsC][2][dsId]=public-global-loitering-events%3Av20201001&dvIn[0][dsC][2][qry][0][id]=~3&dvIn[0][dsC][2][qry][0][val]=~1&dvIn[0][dsC][2][ept]=~4&dvIn[0][dsC][3][dsId]=public-global-port-visits-c2-events%3Av20201001&dvIn[0][dsC][3][qry][0][id]=~3&dvIn[0][dsC][3][qry][0][val]=~1&dvIn[0][dsC][3][ept]=~4&dvIn[0][dsC][4][dsId]=public-global-encounters-events%3Av20201001&dvIn[0][dsC][4][qry][0][id]=~3&dvIn[0][dsC][4][qry][0][val]=~1&dvIn[0][dsC][4][ept]=~4&dvIn[1][id]=fishing-ais&dvIn[1][cfg][vis]=false&dvIn[2][id]=vms&dvIn[2][cfg][vis]=false&dvIn[3][id]=highlight-sar-match&dvIn[3][cfg][vis]=true&dvIn[4][id]=context-layer-graticules&dvIn[4][cfg][vis]=true&timebarVisualisation=~2&tk[0]=vesselId&tk[1]=dc49fe26d-dce6-8e78-2660-85c145cf0af1&tk[2]=vessel&tk[3]=vessels&tk[4]=events) the interaction API returns the same vessel in 2 different datasets. With this, we choose the correct one based on the `years` property, so the correct track properly loads for the selected time range.
<img width="874" alt="Screenshot 2022-06-30 at 13 41 43" src="https://user-images.githubusercontent.com/38662877/176670660-2c17380f-2976-4d18-b500-471a52fbecb5.png">

