### PR TITLE
Vessel groups polish

### DIFF
--- a/apps/fishing-map/features/download/DownloadActivityModal.tsx
+++ b/apps/fishing-map/features/download/DownloadActivityModal.tsx
@@ -182,7 +182,7 @@ function DownloadActivityModal() {
         return {
           filter: dataview.config?.filter || [],
           filters: dataview.config?.filters || {},
-          ...(dataview.config?.['vessel-groups'].length && {
+          ...(dataview.config?.['vessel-groups']?.length && {
             'vessel-groups': dataview.config?.['vessel-groups'],
           }),
           datasets: activityDatasets,

--- a/apps/fishing-map/features/search/Search.tsx
+++ b/apps/fishing-map/features/search/Search.tsx
@@ -39,6 +39,7 @@ import {
   setVesselGroupVessels,
 } from 'features/vessel-groups/vessel-groups.slice'
 import DatasetLabel from 'features/datasets/DatasetLabel'
+import { isGFWUser } from 'features/user/user.slice'
 import {
   fetchVesselSearchThunk,
   selectSearchResults,
@@ -83,6 +84,7 @@ function Search() {
   const searchResults = useSelector(selectSearchResults)
   const searchStatus = useSelector(selectSearchStatus)
   const searchStatusCode = useSelector(selectSearchStatusCode)
+  const gfwUser = useSelector(isGFWUser)
   const hasSearchFilters = checkSearchFiltersEnabled(searchFilters)
   const vesselDataviews = useSelector(selectVesselsDataviews)
   const [vesselsSelected, setVesselsSelected] = useState<VesselWithDatasets[]>([])
@@ -525,7 +527,7 @@ function Search() {
             </div>
           )}
           <div className={cx(styles.footer, { [styles.hidden]: vesselsSelected.length === 0 })}>
-            {vesselsSelected.length > 1 && (
+            {gfwUser && vesselsSelected.length > 1 && (
               <Button type="secondary" className={styles.footerAction} onClick={onAddToVesselGroup}>
                 {t('vesselGroup.new', 'New vessel group')}({vesselsSelected.length})
               </Button>

--- a/apps/fishing-map/features/user/User.tsx
+++ b/apps/fishing-map/features/user/User.tsx
@@ -14,7 +14,7 @@ import { useDatasetModalConnect } from 'features/datasets/datasets.hook'
 import { useAppDispatch } from 'features/app/app.hooks'
 import { fetchAllVesselGroupsThunk } from 'features/vessel-groups/vessel-groups.slice'
 import styles from './User.module.css'
-import { GUEST_USER_TYPE, selectUserData } from './user.slice'
+import { GUEST_USER_TYPE, isGFWUser, selectUserData } from './user.slice'
 import { isUserLogged } from './user.selectors'
 import UserWorkspaces from './UserWorkspaces'
 import UserWorkspacesPrivate from './UserWorkspacesPrivate'
@@ -27,10 +27,11 @@ function User() {
   const dispatch = useAppDispatch()
   const userLogged = useSelector(isUserLogged)
   const userData = useSelector(selectUserData)
+  const gfwUser = useSelector(isGFWUser)
   const { datasetModal, editingDatasetId } = useDatasetModalConnect()
 
-  const userTabs = useMemo(
-    () => [
+  const userTabs = useMemo(() => {
+    const tabs = [
       {
         id: 'info',
         title: t('user.info', 'User Info'),
@@ -56,14 +57,16 @@ function User() {
           </Fragment>
         ),
       },
-      {
+    ]
+    if (gfwUser) {
+      tabs.push({
         id: 'vesselGroups',
         title: t('vesselGroup.vesselGroups', 'Vessel Groups'),
         content: <UserVesselGroups />,
-      },
-    ],
-    [t]
-  )
+      })
+    }
+    return tabs
+  }, [gfwUser, t])
   const [activeTab, setActiveTab] = useState<Tab | undefined>(userTabs?.[0])
 
   useEffect(() => {

--- a/apps/fishing-map/features/vessel-groups/VesselGroupModal.tsx
+++ b/apps/fishing-map/features/vessel-groups/VesselGroupModal.tsx
@@ -67,7 +67,7 @@ function VesselGroupModal(): React.ReactElement {
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState('')
 
-  const [groupName, setGroupName] = useState<string>()
+  const [groupName, setGroupName] = useState<string>('')
   const [showBackButton, setShowBackButton] = useState(false)
   const [IDs, setIDs] = useState<string[]>([])
   const [selectedIDColumn, setSelectedIDColumn] = useState<IdColumn>('mmsi')
@@ -375,7 +375,7 @@ function VesselGroupModal(): React.ReactElement {
                 value={IDs?.join(', ')}
                 label={
                   IDs?.length
-                    ? `${selectedIDColumnOption.label} (${selectedIDColumnOption.label})`
+                    ? `${selectedIDColumnOption.label} (${IDs?.length})`
                     : selectedIDColumnOption.label
                 }
                 placeholder={t('vesselGroup.idsPlaceholder', {

--- a/apps/fishing-map/features/workspace/activity/ActivityLayerPanel.tsx
+++ b/apps/fishing-map/features/workspace/activity/ActivityLayerPanel.tsx
@@ -26,7 +26,7 @@ import Hint from 'features/help/hints/Hint'
 import { setHintDismissed } from 'features/help/hints/hints.slice'
 import { useAppDispatch } from 'features/app/app.hooks'
 import I18nNumber from 'features/i18n/i18nNumber'
-import { isGuestUser } from 'features/user/user.slice'
+import { isGFWUser, isGuestUser } from 'features/user/user.slice'
 import { selectUrlTimeRange } from 'routes/routes.selectors'
 import ActivityAuxiliaryLayerPanel from 'features/workspace/activity/ActivityAuxiliaryLayer'
 import { SAR_DATAVIEW_ID } from 'data/workspaces'
@@ -64,6 +64,7 @@ function ActivityLayerPanel({
   const urlTimeRange = useSelector(selectUrlTimeRange)
   const bivariateDataviews = useSelector(selectBivariateDataviews)
   const guestUser = useSelector(isGuestUser)
+  const gfwUser = useSelector(isGFWUser)
   const readOnly = useSelector(selectReadOnly)
   const layerActive = dataview?.config?.visible ?? true
   const datasetStatsFields = dataview.datasets.flatMap((d) =>
@@ -150,8 +151,8 @@ function ActivityLayerPanel({
     />
   )
 
-  const datasetFields: { field: SupportedDatasetSchema; label: string }[] = useMemo(
-    () => [
+  const datasetFields = useMemo(() => {
+    const fields: { field: SupportedDatasetSchema; label: string }[] = [
       { field: 'radiance', label: t('layer.radiance', 'Radiance') },
       { field: 'geartype', label: t('layer.gearType_other', 'Gear types') },
       { field: 'fleet', label: t('layer.fleet_other', 'Fleets') },
@@ -162,10 +163,15 @@ function ActivityLayerPanel({
       { field: 'target_species', label: t('vessel.target_species', 'Target species') },
       { field: 'license_category', label: t('vessel.license_category', 'License category') },
       { field: 'vessel_type', label: t('vessel.vesselType_other', 'Vessel types') },
-      { field: 'vessel-groups', label: t('vesselGroup.vesselGroups', 'Vessel Groups') },
-    ],
-    [t]
-  )
+    ]
+    if (gfwUser) {
+      fields.push({
+        field: 'vessel-groups',
+        label: t('vesselGroup.vesselGroups', 'Vessel Groups'),
+      })
+    }
+    return fields
+  }, [gfwUser, t])
 
   const statsValue = stats && (stats.vessel_id || stats.id)
   const showStats = duration?.years <= 1


### PR DESCRIPTION
- [x] Show vessel groups tab only for gfw users
- [ ] Add the recently created group to the current filters on save
- [x] Avoid request vessel-group list fetch twice
- [x] Use activity datasets for sources
- [x] Increase search results limit
- [x] Add error warning when vessel group selected and timerange bigger than day interval

