### PR TITLE
allow vessel groups feature from permissions instead of user group

### DIFF
--- a/apps/fishing-map/features/sidebar/Sidebar.tsx
+++ b/apps/fishing-map/features/sidebar/Sidebar.tsx
@@ -8,9 +8,8 @@ import { USER, WORKSPACES_LIST } from 'routes/routes'
 import { AsyncReducerStatus } from 'utils/async-slice'
 import { selectHighlightedWorkspacesStatus } from 'features/workspaces-list/workspaces-list.slice'
 import { selectIsAnalyzing } from 'features/analysis/analysis.selectors'
-import { isUserLogged } from 'features/user/user.selectors'
+import { isUserLogged, selectUserGroupsPermissions } from 'features/user/user.selectors'
 import { useDatasetModalConnect } from 'features/datasets/datasets.hook'
-import { isGFWUser } from 'features/user/user.slice'
 import { fetchUserVesselGroupsThunk } from 'features/vessel-groups/vessel-groups.slice'
 import { useAppDispatch } from 'features/app/app.hooks'
 import styles from './Sidebar.module.css'
@@ -43,15 +42,15 @@ function Sidebar({ onMenuClick }: SidebarProps) {
   const searchQuery = useSelector(selectSearchQuery)
   const locationType = useSelector(selectLocationType)
   const userLogged = useSelector(isUserLogged)
-  const gfwUser = useSelector(isGFWUser)
+  const hasUserGroupsPermissions = useSelector(selectUserGroupsPermissions)
   const highlightedWorkspacesStatus = useSelector(selectHighlightedWorkspacesStatus)
   const { datasetModal } = useDatasetModalConnect()
 
   useEffect(() => {
-    if (gfwUser) {
+    if (hasUserGroupsPermissions) {
       dispatch(fetchUserVesselGroupsThunk())
     }
-  }, [dispatch, gfwUser])
+  }, [dispatch, hasUserGroupsPermissions])
 
   const sidebarComponent = useMemo(() => {
     if (!userLogged) {

--- a/apps/fishing-map/features/user/User.tsx
+++ b/apps/fishing-map/features/user/User.tsx
@@ -15,8 +15,8 @@ import { useDatasetModalConnect } from 'features/datasets/datasets.hook'
 import { useAppDispatch } from 'features/app/app.hooks'
 import { fetchUserVesselGroupsThunk } from 'features/vessel-groups/vessel-groups.slice'
 import styles from './User.module.css'
-import { isGFWUser, selectUserData } from './user.slice'
-import { isUserLogged } from './user.selectors'
+import { selectUserData } from './user.slice'
+import { isUserLogged, selectUserGroupsPermissions } from './user.selectors'
 import UserWorkspaces from './UserWorkspaces'
 import UserWorkspacesPrivate from './UserWorkspacesPrivate'
 import UserDatasets from './UserDatasets'
@@ -28,7 +28,7 @@ function User() {
   const dispatch = useAppDispatch()
   const userLogged = useSelector(isUserLogged)
   const userData = useSelector(selectUserData)
-  const gfwUser = useSelector(isGFWUser)
+  const hasUserGroupsPermissions = useSelector(selectUserGroupsPermissions)
   const { datasetModal, editingDatasetId } = useDatasetModalConnect()
 
   const userTabs = useMemo(() => {
@@ -59,7 +59,7 @@ function User() {
         ),
       },
     ]
-    if (gfwUser) {
+    if (hasUserGroupsPermissions) {
       tabs.push({
         id: 'vesselGroups',
         title: t('vesselGroup.vesselGroups', 'Vessel Groups'),
@@ -67,7 +67,7 @@ function User() {
       })
     }
     return tabs
-  }, [gfwUser, t])
+  }, [hasUserGroupsPermissions, t])
   const [activeTab, setActiveTab] = useState<Tab | undefined>(userTabs?.[0])
 
   useEffect(() => {
@@ -82,10 +82,10 @@ function User() {
   }, [dispatch])
 
   useEffect(() => {
-    if (gfwUser) {
+    if (hasUserGroupsPermissions) {
       dispatch(fetchUserVesselGroupsThunk())
     }
-  }, [dispatch, gfwUser])
+  }, [dispatch, hasUserGroupsPermissions])
 
   useEffect(() => {
     if (userData?.type === GUEST_USER_TYPE) {

--- a/apps/fishing-map/features/user/user.selectors.ts
+++ b/apps/fishing-map/features/user/user.selectors.ts
@@ -32,7 +32,7 @@ export const isUserLogged = createSelector(
 )
 
 export const hasUserPermission = (permission: UserPermission) =>
-  createSelector([selectUserData], (userData) => {
+  createSelector([selectUserData], (userData): boolean => {
     if (!userData?.permissions) return false
     return checkExistPermissionInList(userData.permissions, permission)
   })
@@ -47,6 +47,12 @@ export const selectUserDataviewEditPermissions = hasUserPermission({
   type: 'entity',
   value: 'dataview',
   action: 'create-all',
+})
+
+export const selectUserGroupsPermissions = hasUserPermission({
+  type: 'entity',
+  value: 'vessel-group',
+  action: 'create',
 })
 
 export const selectUserId = createSelector([selectUserData], (userData) => {

--- a/apps/fishing-map/features/vessel-groups/vessel-groups.selectors.ts
+++ b/apps/fishing-map/features/vessel-groups/vessel-groups.selectors.ts
@@ -4,7 +4,6 @@ import { selectAllDatasets } from 'features/datasets/datasets.slice'
 import { selectAllDataviewsInWorkspace } from 'features/dataviews/dataviews.selectors'
 import { isAdvancedSearchAllowed } from 'features/search/search.selectors'
 import { getDatasetsInDataviews } from 'features/datasets/datasets.utils'
-import { isGFWUser } from 'features/user/user.slice'
 import { selectUrlDataviewInstances } from 'routes/routes.selectors'
 import {
   MAX_VESSEL_GROUP_VESSELS,
@@ -12,6 +11,7 @@ import {
   selectVesselGroupSearchVessels,
 } from 'features/vessel-groups/vessel-groups.slice'
 import { selectWorkspaceDataviewInstances } from 'features/workspace/workspace.selectors'
+import { selectUserGroupsPermissions } from 'features/user/user.selectors'
 
 export const selectAllVesselGroupSearchVessels = createSelector(
   [selectVesselGroupSearchVessels, selectNewVesselGroupSearchVessels],
@@ -35,9 +35,9 @@ export const selectHasVesselGroupSearchVessels = createSelector(
 )
 
 export const selectVessselGroupsAllowed = createSelector(
-  [isAdvancedSearchAllowed, isGFWUser],
-  (advancedSearchAllowed, gfwUser) => {
-    return gfwUser && advancedSearchAllowed
+  [selectUserGroupsPermissions, isAdvancedSearchAllowed],
+  (hasUserGroupsPermissions, advancedSearchAllowed) => {
+    return hasUserGroupsPermissions && advancedSearchAllowed
   }
 )
 

--- a/libs/api-types/src/user.ts
+++ b/libs/api-types/src/user.ts
@@ -2,16 +2,18 @@ import { UserApplicationIntendedUse } from './user-applications'
 
 export type UserPermissionType = 'application' | 'dataset' | 'entity'
 export type UserPermissionValue =
-  | 'workspace'
-  | 'dataview'
-  | 'map-client'
-  | 'data-portal'
   | 'carrier-portal'
+  | 'carriers:*'
+  | 'data-portal'
+  | 'dataview'
   | 'fishing-map'
   | 'indonesia:*'
-  | 'carriers:*'
+  | 'map-client'
   | 'public'
   | 'user-application'
+  | 'vessel-group'
+  | 'workspace'
+
 export type UserPermissionAction =
   | 'read'
   | 'read-all'


### PR DESCRIPTION
Show the vessel group features by checking the `vessel-group` permission instead of belonging to a particular user group.