### PR TITLE
remove vessel groups timerange limit

### DIFF
--- a/apps/fishing-map/features/map/map.selectors.ts
+++ b/apps/fishing-map/features/map/map.selectors.ts
@@ -34,7 +34,7 @@ import { WorkspaceCategories } from 'data/workspaces'
 import { AsyncReducerStatus } from 'utils/async-slice'
 import { BivariateDataviews } from 'types'
 import { selectShowTimeComparison } from 'features/analysis/analysis.selectors'
-import { getTimeRangeDuration } from 'utils/dates'
+// import { getTimeRangeDuration } from 'utils/dates'
 
 type GetGeneratorConfigParams = {
   dataviews: UrlDataviewInstance[] | undefined
@@ -58,22 +58,22 @@ const getGeneratorsConfig = ({
   bivariateDataviews,
   showTimeComparison,
 }: GetGeneratorConfigParams) => {
-  const duration = getTimeRangeDuration(timeRange, 'days')
-  const hasVesselGroupsSelected = dataviews.some(
-    (d) => d.config?.filters?.['vessel-groups']?.length > 0
-  )
+  // const duration = getTimeRangeDuration(timeRange, 'days')
+  // const hasVesselGroupsSelected = dataviews.some(
+  //   (d) => d.config?.filters?.['vessel-groups']?.length > 0
+  // )
   // Removes the HeatmapAnimated dataviews that won't work with the current
   // vessel-groups timerange limitation to avoid requesting known error tiles
-  const dataviewsFiltered = dataviews.filter((dataview) => {
-    const isHeatmap = dataview.config?.type === GeneratorType.HeatmapAnimated
-    return isHeatmap && hasVesselGroupsSelected ? duration?.days <= 31 : true
-  })
+  // const dataviewsFiltered = dataviews.filter((dataview) => {
+  //   const isHeatmap = dataview.config?.type === GeneratorType.HeatmapAnimated
+  //   return isHeatmap && hasVesselGroupsSelected ? duration?.days <= 31 : true
+  // })
 
-  const animatedHeatmapDataviews = dataviewsFiltered.filter((dataview) => {
+  const animatedHeatmapDataviews = dataviews.filter((dataview) => {
     return dataview.config?.type === GeneratorType.HeatmapAnimated
   })
 
-  const visibleDataviewIds = dataviewsFiltered.map(({ id }) => id)
+  const visibleDataviewIds = dataviews.map(({ id }) => id)
   const bivariateVisible =
     bivariateDataviews?.filter((dataviewId) => visibleDataviewIds.includes(dataviewId))?.length ===
     2
@@ -90,7 +90,7 @@ const getGeneratorsConfig = ({
     heatmapAnimatedMode = HeatmapAnimatedMode.TimeCompare
   }
 
-  const trackDataviews = dataviewsFiltered.filter((d) => d.config.type === GeneratorType.Track)
+  const trackDataviews = dataviews.filter((d) => d.config.type === GeneratorType.Track)
   const singleTrack = trackDataviews.length === 1
 
   const generatorOptions: DataviewsGeneratorConfigsParams = {
@@ -106,11 +106,7 @@ const getGeneratorsConfig = ({
   }
 
   try {
-    let generatorsConfig = getDataviewsGeneratorConfigs(
-      dataviewsFiltered,
-      generatorOptions,
-      resources
-    )
+    let generatorsConfig = getDataviewsGeneratorConfigs(dataviews, generatorOptions, resources)
     // In time comparison mode, exclude any heatmap layer that is not activity
     if (showTimeComparison) {
       generatorsConfig = generatorsConfig.filter((config) => {

--- a/apps/fishing-map/features/workspace/shared/DatasetSchemaField.tsx
+++ b/apps/fishing-map/features/workspace/shared/DatasetSchemaField.tsx
@@ -1,6 +1,6 @@
 import { Fragment } from 'react'
-import cx from 'classnames'
-import { useSelector } from 'react-redux'
+// import cx from 'classnames'
+// import { useSelector } from 'react-redux'
 import { useTranslation } from 'react-i18next'
 import { formatNumber, TagList } from '@globalfishingwatch/ui-components'
 import { UrlDataviewInstance } from '@globalfishingwatch/dataviews-client'
@@ -12,8 +12,8 @@ import {
   SupportedDatasetSchema,
 } from 'features/datasets/datasets.utils'
 import { useVesselGroupsOptions } from 'features/vessel-groups/vessel-groups.hooks'
-import { selectTimeRange } from 'features/app/app.selectors'
-import { getTimeRangeDuration } from 'utils/dates'
+// import { selectTimeRange } from 'features/app/app.selectors'
+// import { getTimeRangeDuration } from 'utils/dates'
 
 type LayerPanelProps = {
   dataview: UrlDataviewInstance
@@ -24,8 +24,8 @@ type LayerPanelProps = {
 function DatasetSchemaField({ dataview, field, label }: LayerPanelProps): React.ReactElement {
   const { t } = useTranslation()
   const vesselGroupsOptions = useVesselGroupsOptions()
-  const timeRange = useSelector(selectTimeRange)
-  const duration = getTimeRangeDuration(timeRange, 'days')
+  // const timeRange = useSelector(selectTimeRange)
+  // const duration = getTimeRangeDuration(timeRange, 'days')
   const filterOperation = getSchemaFilterOperationInDataview(dataview, field)
   let valuesSelected = getSchemaFieldsSelectedInDataview(dataview, field, vesselGroupsOptions).sort(
     (a, b) => a.label - b.label
@@ -54,7 +54,7 @@ function DatasetSchemaField({ dataview, field, label }: LayerPanelProps): React.
             {filterOperation === EXCLUDE_FILTER_ID && (
               <span> ({t('common.excluded', 'Excluded')})</span>
             )}
-            {field === 'vessel-groups' && duration?.days > 31 && (
+            {/* {field === 'vessel-groups' && duration?.days > 31 && (
               <span className={cx(styles.dataWarning, styles.error)}>
                 {' '}
                 {t(
@@ -62,7 +62,7 @@ function DatasetSchemaField({ dataview, field, label }: LayerPanelProps): React.
                   'Supported only for time ranges shorter than 30 days'
                 )}
               </span>
-            )}
+            )} */}
           </label>
 
           <TagList


### PR DESCRIPTION
Frontend ready to support vessel groups without date range limit of 31 days.
Pending to do in the API as it returns this validation error:
```{"statusCode":422,"error":"Unprocessable Entity","messages":[{"title":"vessel-groups","detail":"Maximum 1 year of time range with vessel groups filter  "}]}``` 