### PR TITLE
ensure timebar graph data is sorted by date

### DIFF
--- a/apps/fourwings-explorer/features/timebar/TimebarActivityGraph.hooks.ts
+++ b/apps/fourwings-explorer/features/timebar/TimebarActivityGraph.hooks.ts
@@ -38,7 +38,9 @@ export const useStackedActivity = (layers: DatasetLayer | DatasetLayer[]) => {
           }),
         }
       })
-      const stackedActivity = getTimeseriesFromFeatures(layerFeaturesFiltered)
+      const stackedActivity = getTimeseriesFromFeatures(layerFeaturesFiltered).sort(
+        (a, b) => a.date - b.date
+      )
       setStackedActivity(stackedActivity)
       setGeneratingStackedActivity(false)
     }, 400),


### PR DESCRIPTION
Not having the time series sorted by date causes broken svg paths:
![image](https://user-images.githubusercontent.com/10500650/193582062-e7e4cc9a-3640-415b-a076-465e5fb81fa9.png)

This ensures the data is sorted before sending it to the timebar:
![image](https://user-images.githubusercontent.com/10500650/193582196-a4b81830-f2b9-490c-90e6-d0b92c3eada4.png)
