### PR TITLE
Fishing map/clusters dynamic ramps

### DIFF
--- a/apps/fishing-map/features/map/map-sources.hooks.ts
+++ b/apps/fishing-map/features/map/map-sources.hooks.ts
@@ -4,15 +4,11 @@ import { GeoJSONFeature, MapDataEvent } from '@globalfishingwatch/maplibre-gl'
 import {
   ExtendedStyle,
   HeatmapLayerMeta,
-  DEFAULT_CONTEXT_SOURCE_LAYER,
   TEMPORALGRID_SOURCE_LAYER_INTERACTIVE,
 } from '@globalfishingwatch/layer-composer'
 import {
-  isDetectionsDataview,
   isHeatmapAnimatedDataview,
   isMergedAnimatedGenerator,
-  MERGED_ACTIVITY_ANIMATED_HEATMAP_GENERATOR_ID,
-  MERGED_DETECTIONS_ANIMATED_HEATMAP_GENERATOR_ID,
   UrlDataviewInstance,
 } from '@globalfishingwatch/dataviews-client'
 import { TimeseriesFeatureProps } from '@globalfishingwatch/fourwings-aggregate'
@@ -21,7 +17,11 @@ import { ChunkFeature, LayerFeature } from '@globalfishingwatch/features-aggrega
 import useMapInstance from 'features/map/map-context.hooks'
 import { useMapStyle } from 'features/map/map-style.hooks'
 import { mapTilesAtom, TilesAtomSourceState } from 'features/map/map-sources.atom'
-import { getHeatmapSourceMetadata, isInteractionSource } from 'features/map/map-sources.utils'
+import {
+  getHeatmapSourceMetadata,
+  getSourceMetadata,
+  isInteractionSource,
+} from 'features/map/map-sources.utils'
 import {
   BIG_QUERY_EVENTS_PREFIX,
   ENCOUNTER_EVENTS_SOURCE_ID,
@@ -187,24 +187,16 @@ export const useMapDataviewFeatures = (dataviews: UrlDataviewInstance | UrlDatav
     }
     const dataviewsMetadata: DataviewMetadata[] = dataviewsArray.reduce((acc, dataview) => {
       const activityDataview = isHeatmapAnimatedDataview(dataview)
-      const animatedMergedId = isDetectionsDataview(dataview)
-        ? MERGED_DETECTIONS_ANIMATED_HEATMAP_GENERATOR_ID
-        : MERGED_ACTIVITY_ANIMATED_HEATMAP_GENERATOR_ID
+      const { metadata, generatorSourceId } = getSourceMetadata(style, dataview)
       if (activityDataview) {
         const existingMergedAnimatedDataviewIndex = acc.findIndex(
-          (d) => d.generatorSourceId === animatedMergedId
+          (d) => d.generatorSourceId === generatorSourceId
         )
         if (existingMergedAnimatedDataviewIndex >= 0) {
           acc[existingMergedAnimatedDataviewIndex].dataviewsId.push(dataview.id)
           return acc
         }
       }
-      const generatorSourceId = activityDataview ? animatedMergedId : dataview.id
-
-      const metadata =
-        getHeatmapSourceMetadata(style, generatorSourceId) ||
-        ({ sourceLayer: DEFAULT_CONTEXT_SOURCE_LAYER } as HeatmapLayerMeta)
-
       const sourcesId =
         metadata?.timeChunks?.chunks.flatMap(({ sourceId }) => sourceId) || dataview?.id
       return acc.concat({

--- a/apps/fishing-map/features/map/map-sources.utils.ts
+++ b/apps/fishing-map/features/map/map-sources.utils.ts
@@ -1,4 +1,18 @@
-import { ExtendedStyle, TRACK_HIGHLIGHT_SUFFIX } from '@globalfishingwatch/layer-composer'
+import {
+  isDetectionsDataview,
+  isHeatmapAnimatedDataview,
+  MERGED_ACTIVITY_ANIMATED_HEATMAP_GENERATOR_ID,
+  MERGED_DETECTIONS_ANIMATED_HEATMAP_GENERATOR_ID,
+  UrlDataviewInstance,
+} from '@globalfishingwatch/dataviews-client'
+import {
+  DEFAULT_CONTEXT_SOURCE_LAYER,
+  DEFAULT_POINTS_SOURCE_LAYER,
+  ExtendedStyle,
+  GeneratorType,
+  HeatmapLayerMeta,
+  TRACK_HIGHLIGHT_SUFFIX,
+} from '@globalfishingwatch/layer-composer'
 
 export const MAPBOX_GL_DRAW_PREFIX = 'mapbox-gl-draw'
 // Don't consider loading states for our interaction layers
@@ -8,4 +22,24 @@ export const isInteractionSource = (sourceId: string) => {
 
 export const getHeatmapSourceMetadata = (style: ExtendedStyle, id: string) => {
   return style?.metadata?.generatorsMetadata?.[id]
+}
+
+export const getSourceMetadata = (style: ExtendedStyle, dataview: UrlDataviewInstance) => {
+  const activityDataview = isHeatmapAnimatedDataview(dataview)
+  if (activityDataview) {
+    const generatorSourceId = isDetectionsDataview(dataview)
+      ? MERGED_DETECTIONS_ANIMATED_HEATMAP_GENERATOR_ID
+      : MERGED_ACTIVITY_ANIMATED_HEATMAP_GENERATOR_ID
+    const metadata = getHeatmapSourceMetadata(style, generatorSourceId)
+    return { metadata, generatorSourceId }
+  }
+  return {
+    metadata: {
+      sourceLayer:
+        dataview.config?.type === GeneratorType.TileCluster
+          ? DEFAULT_POINTS_SOURCE_LAYER
+          : DEFAULT_CONTEXT_SOURCE_LAYER,
+    } as HeatmapLayerMeta,
+    generatorSourceId: dataview.id,
+  }
 }

--- a/apps/fishing-map/features/timebar/TimebarActivityGraph.hooks.ts
+++ b/apps/fishing-map/features/timebar/TimebarActivityGraph.hooks.ts
@@ -22,7 +22,7 @@ export const useStackedActivity = (dataviews: UrlDataviewInstance[]) => {
   const error = hasDataviewsFeatureError(dataviewFeatures)
   const boundsChanged = !checkEqualBounds(bounds, debouncedBounds)
   const layersFilterHash = dataviewFeatures
-    .flatMap(({ metadata }) => `${metadata.minVisibleValue}-${metadata.maxVisibleValue}`)
+    .flatMap(({ metadata }) => `${metadata?.minVisibleValue}-${metadata?.maxVisibleValue}`)
     .join(',')
   const loading =
     boundsChanged || !areDataviewsFeatureLoaded(dataviewFeatures) || generatingStackedActivity

--- a/apps/fishing-map/features/workspace/events/EventsLayerPanel.tsx
+++ b/apps/fishing-map/features/workspace/events/EventsLayerPanel.tsx
@@ -4,6 +4,7 @@ import { IconButton, Tooltip } from '@globalfishingwatch/ui-components'
 import { UrlDataviewInstance } from '@globalfishingwatch/dataviews-client'
 import styles from 'features/workspace/shared/LayerPanel.module.css'
 import { getDatasetLabel } from 'features/datasets/datasets.utils'
+import { useEventsDynamicRamp } from 'features/workspace/events/events.hooks'
 import { useLayerPanelDataviewSort } from 'features/workspace/shared/layer-panel-sort.hook'
 import DatasetNotFound from '../shared/DatasetNotFound'
 import LayerSwitch from '../common/LayerSwitch'
@@ -15,6 +16,7 @@ type LayerPanelProps = {
 }
 
 function LayerPanel({ dataview }: LayerPanelProps): React.ReactElement {
+  useEventsDynamicRamp(dataview)
   const layerActive = dataview?.config?.visible ?? true
   const { items, attributes, listeners, setNodeRef, setActivatorNodeRef, style } =
     useLayerPanelDataviewSort(dataview.id)

--- a/apps/fishing-map/features/workspace/events/events.hooks.ts
+++ b/apps/fishing-map/features/workspace/events/events.hooks.ts
@@ -3,16 +3,18 @@ import { ckmeans } from 'simple-statistics'
 import { MiniglobeBounds } from '@globalfishingwatch/ui-components'
 import { filterFeaturesByBounds } from '@globalfishingwatch/data-transforms'
 import { UrlDataviewInstance } from '@globalfishingwatch/dataviews-client'
+import { MAX_ZOOM_TO_CLUSTER_POINTS } from '@globalfishingwatch/layer-composer'
 import { useDataviewInstancesConnect } from 'features/workspace/workspace.hook'
 import {
   DataviewFeature,
   areDataviewsFeatureLoaded,
   useMapDataviewFeatures,
 } from 'features/map/map-sources.hooks'
-import { useMapBounds } from 'features/map/map-viewport.hooks'
+import useViewport, { useMapBounds } from 'features/map/map-viewport.hooks'
 
 export const useEventsDynamicRamp = (dataview: UrlDataviewInstance) => {
   const { bounds } = useMapBounds()
+  const { viewport } = useViewport()
   const dataviewFeatures = useMapDataviewFeatures(dataview)
   const sourcesLoaded = areDataviewsFeatureLoaded(dataviewFeatures)
   const { upsertDataviewInstance } = useDataviewInstancesConnect()
@@ -24,29 +26,25 @@ export const useEventsDynamicRamp = (dataview: UrlDataviewInstance) => {
         const data = filteredFeatures.map((feature) => feature.properties?.count)
         const steps = Math.min(data.length, 3)
         // using ckmeans as jenks
-        const ck = ckmeans(data, steps).map(([clusterFirst]) => parseFloat(clusterFirst.toFixed(3)))
-        let breaks = []
-        ck.forEach((k, i) => {
-          if (i > 1) {
-            const cleanBreak = k === 0 || k <= breaks?.[i - 1] ? breaks[i - 1] + 0.01 : k
-            breaks.push(cleanBreak)
-          } else {
-            breaks.push(k)
-          }
-        })
+        const ck = ckmeans(data, steps).map(([clusterFirst]) => parseInt(clusterFirst))
+        const max = data.reduce((acc, data) => (data > acc ? data : acc), 0)
         upsertDataviewInstance({
           id: dataviewsId[0],
-          config: { breaks },
+          config: {
+            breaks: [ck[0], ck[0] === ck[1] ? ck[1] + 1 : ck[1], ck[1] === max ? max + 1 : max],
+          },
         })
       }
     },
     [upsertDataviewInstance]
   )
 
+  const roundZoom = Math.floor(viewport.zoom)
   useEffect(() => {
-    if (sourcesLoaded) {
+    const maxZoomCluster = dataview.config?.maxZoomCluster || MAX_ZOOM_TO_CLUSTER_POINTS
+    if (sourcesLoaded && roundZoom < maxZoomCluster) {
       updateBreaksByViewportValues(dataviewFeatures[0], bounds)
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [sourcesLoaded])
+  }, [sourcesLoaded, roundZoom])
 }

--- a/apps/fishing-map/features/workspace/events/events.hooks.ts
+++ b/apps/fishing-map/features/workspace/events/events.hooks.ts
@@ -1,0 +1,52 @@
+import { useCallback, useEffect } from 'react'
+import { ckmeans } from 'simple-statistics'
+import { MiniglobeBounds } from '@globalfishingwatch/ui-components'
+import { filterFeaturesByBounds } from '@globalfishingwatch/data-transforms'
+import { UrlDataviewInstance } from '@globalfishingwatch/dataviews-client'
+import { useDataviewInstancesConnect } from 'features/workspace/workspace.hook'
+import {
+  DataviewFeature,
+  areDataviewsFeatureLoaded,
+  useMapDataviewFeatures,
+} from 'features/map/map-sources.hooks'
+import { useMapBounds } from 'features/map/map-viewport.hooks'
+
+export const useEventsDynamicRamp = (dataview: UrlDataviewInstance) => {
+  const { bounds } = useMapBounds()
+  const dataviewFeatures = useMapDataviewFeatures(dataview)
+  const sourcesLoaded = areDataviewsFeatureLoaded(dataviewFeatures)
+  const { upsertDataviewInstance } = useDataviewInstancesConnect()
+
+  const updateBreaksByViewportValues = useCallback(
+    ({ features, dataviewsId } = {} as DataviewFeature, bounds: MiniglobeBounds) => {
+      const filteredFeatures = filterFeaturesByBounds(features, bounds)
+      if (filteredFeatures?.length > 0) {
+        const data = filteredFeatures.map((feature) => feature.properties?.count)
+        const steps = Math.min(data.length, 3)
+        // using ckmeans as jenks
+        const ck = ckmeans(data, steps).map(([clusterFirst]) => parseFloat(clusterFirst.toFixed(3)))
+        let breaks = []
+        ck.forEach((k, i) => {
+          if (i > 1) {
+            const cleanBreak = k === 0 || k <= breaks?.[i - 1] ? breaks[i - 1] + 0.01 : k
+            breaks.push(cleanBreak)
+          } else {
+            breaks.push(k)
+          }
+        })
+        upsertDataviewInstance({
+          id: dataviewsId[0],
+          config: { breaks },
+        })
+      }
+    },
+    [upsertDataviewInstance]
+  )
+
+  useEffect(() => {
+    if (sourcesLoaded) {
+      updateBreaksByViewportValues(dataviewFeatures[0], bounds)
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [sourcesLoaded])
+}

--- a/libs/data-transforms/src/features/filter-features-by-bounds.ts
+++ b/libs/data-transforms/src/features/filter-features-by-bounds.ts
@@ -7,10 +7,7 @@ export interface Bounds {
   east: number
 }
 
-export const filterFeaturesByBounds = <P = unknown>(
-  features: GeoJSONFeature<P>[],
-  bounds: Bounds
-) => {
+export const filterFeaturesByBounds = (features: GeoJSONFeature[], bounds: Bounds) => {
   if (!bounds) {
     return []
   }
@@ -18,7 +15,8 @@ export const filterFeaturesByBounds = <P = unknown>(
   const rightWorldCopy = east >= 180
   const leftWorldCopy = west <= -180
   return features.filter((f) => {
-    const [lon, lat] = (f.geometry as any).coordinates[0][0]
+    const lon = (f.geometry as any).coordinates?.[0]?.[0]?.[0] || f.properties.lon
+    const lat = (f.geometry as any).coordinates?.[0]?.[0]?.[1] || f.properties.lat
     if (lat < south || lat > north) {
       return false
     }

--- a/libs/dataviews-client/src/resolve-dataviews-generators.ts
+++ b/libs/dataviews-client/src/resolve-dataviews-generators.ts
@@ -386,8 +386,7 @@ export function isDetectionsDataview(dataview: UrlDataviewInstance) {
 
 export function isTrackDataview(dataview: UrlDataviewInstance) {
   return (
-    dataview.category === DataviewCategory.Vessels &&
-    dataview.config?.type === GeneratorType.Track
+    dataview.category === DataviewCategory.Vessels && dataview.config?.type === GeneratorType.Track
   )
 }
 
@@ -472,8 +471,8 @@ export function getMergedHeatmapAnimatedDataview(
       // apply the minimum max zoom level (the most restrictive approach)
       ...(maxZoomLevels &&
         maxZoomLevels.length > 0 && {
-        maxZoom: Math.min(...maxZoomLevels),
-      }),
+          maxZoom: Math.min(...maxZoomLevels),
+        }),
     },
   }
   dataviewsFiltered.push(mergedActivityDataview)
@@ -538,45 +537,46 @@ export function getDataviewsGeneratorConfigs(
   params: DataviewsGeneratorConfigsParams,
   resources?: Record<string, Resource>
 ) {
-  const { activityDataviews, detectionDataviews, trackDataviews, otherDataviews } = dataviews.reduce(
-    (acc, dataview) => {
-      if (isActivityDataview(dataview)) {
-        acc.activityDataviews.push(dataview)
-      } else if (isDetectionsDataview(dataview)) {
-        acc.detectionDataviews.push(dataview)
-      } else if (isTrackDataview(dataview)) {
-        acc.trackDataviews.push(dataview)
-      } else {
-        acc.otherDataviews.push(dataview)
+  const { activityDataviews, detectionDataviews, trackDataviews, otherDataviews } =
+    dataviews.reduce(
+      (acc, dataview) => {
+        if (isActivityDataview(dataview)) {
+          acc.activityDataviews.push(dataview)
+        } else if (isDetectionsDataview(dataview)) {
+          acc.detectionDataviews.push(dataview)
+        } else if (isTrackDataview(dataview)) {
+          acc.trackDataviews.push(dataview)
+        } else {
+          acc.otherDataviews.push(dataview)
+        }
+        return acc
+      },
+      {
+        activityDataviews: [] as UrlDataviewInstance[],
+        detectionDataviews: [] as UrlDataviewInstance[],
+        trackDataviews: [] as UrlDataviewInstance[],
+        otherDataviews: [] as UrlDataviewInstance[],
       }
-      return acc
-    },
-    {
-      activityDataviews: [] as UrlDataviewInstance[],
-      detectionDataviews: [] as UrlDataviewInstance[],
-      trackDataviews: [] as UrlDataviewInstance[],
-      otherDataviews: [] as UrlDataviewInstance[],
-    }
-  )
+    )
 
   // If activity heatmap animated generators found, merge them into one generator with multiple sublayers
   const mergedActivityDataview = activityDataviews?.length
     ? getMergedHeatmapAnimatedDataview(activityDataviews, {
-      ...params,
-      mergedHeatmapGeneratorId: MERGED_ACTIVITY_ANIMATED_HEATMAP_GENERATOR_ID,
-    })
+        ...params,
+        mergedHeatmapGeneratorId: MERGED_ACTIVITY_ANIMATED_HEATMAP_GENERATOR_ID,
+      })
     : []
   const mergedDetectionsDataview = detectionDataviews.length
     ? getMergedHeatmapAnimatedDataview(detectionDataviews, {
-      ...params,
-      mergedHeatmapGeneratorId: MERGED_DETECTIONS_ANIMATED_HEATMAP_GENERATOR_ID,
-    })
+        ...params,
+        mergedHeatmapGeneratorId: MERGED_DETECTIONS_ANIMATED_HEATMAP_GENERATOR_ID,
+      })
     : []
   const generatorsConfig = [
     ...mergedActivityDataview,
     ...mergedDetectionsDataview,
     ...trackDataviews,
-    ...otherDataviews
+    ...otherDataviews,
   ].flatMap((dataview) => {
     return getGeneratorConfig(dataview, params, resources)
   })

--- a/libs/layer-composer/src/generators/index.ts
+++ b/libs/layer-composer/src/generators/index.ts
@@ -24,6 +24,7 @@ export { TRACK_HIGHLIGHT_SUFFIX } from './track/track'
 export { HEATMAP_COLOR_RAMPS } from './heatmap/colors'
 export { DEFAULT_BACKGROUND_COLOR } from './background/config'
 export { DEFAULT_CONTEXT_SOURCE_LAYER } from './context/config'
+export { DEFAULT_POINTS_SOURCE_LAYER } from './tile-cluster/config'
 export {
   COLOR_RAMP_DEFAULT_NUM_STEPS,
   DEFAULT_HEATMAP_INTERVALS,

--- a/libs/layer-composer/src/generators/index.ts
+++ b/libs/layer-composer/src/generators/index.ts
@@ -24,7 +24,7 @@ export { TRACK_HIGHLIGHT_SUFFIX } from './track/track'
 export { HEATMAP_COLOR_RAMPS } from './heatmap/colors'
 export { DEFAULT_BACKGROUND_COLOR } from './background/config'
 export { DEFAULT_CONTEXT_SOURCE_LAYER } from './context/config'
-export { DEFAULT_POINTS_SOURCE_LAYER } from './tile-cluster/config'
+export { DEFAULT_POINTS_SOURCE_LAYER, MAX_ZOOM_TO_CLUSTER_POINTS } from './tile-cluster/config'
 export {
   COLOR_RAMP_DEFAULT_NUM_STEPS,
   DEFAULT_HEATMAP_INTERVALS,

--- a/libs/layer-composer/src/generators/tile-cluster/config.ts
+++ b/libs/layer-composer/src/generators/tile-cluster/config.ts
@@ -1,1 +1,2 @@
 export const DEFAULT_POINTS_SOURCE_LAYER = 'points'
+export const MAX_ZOOM_TO_CLUSTER_POINTS = 4

--- a/libs/layer-composer/src/generators/tile-cluster/config.ts
+++ b/libs/layer-composer/src/generators/tile-cluster/config.ts
@@ -1,0 +1,1 @@
+export const DEFAULT_POINTS_SOURCE_LAYER = 'points'

--- a/libs/layer-composer/src/generators/tile-cluster/tile-cluster.ts
+++ b/libs/layer-composer/src/generators/tile-cluster/tile-cluster.ts
@@ -51,6 +51,8 @@ class TileClusterGenerator {
 
   _getStyleLayers = (config: GlobalTileClusterGeneratorConfig): LayerSpecification[] => {
     const activeFilter = ['case', ['==', ['get', 'event_id'], config.currentEventId || null]]
+    const breaks = config.breaks || [50, 400, 5000]
+    const breaksRadius = [12, 16, 24]
     const layers = [
       {
         id: `${config.id}-clusters`,
@@ -63,12 +65,7 @@ class TileClusterGenerator {
             'interpolate',
             ['exponential', 0.9],
             ['get', 'count'],
-            50,
-            12,
-            400,
-            16,
-            5000,
-            24,
+            ...breaks.flatMap((b, i) => [b, breaksRadius[i]]),
           ],
           'circle-color': config.color || '#FAE9A0',
         },

--- a/libs/layer-composer/src/generators/tile-cluster/tile-cluster.ts
+++ b/libs/layer-composer/src/generators/tile-cluster/tile-cluster.ts
@@ -3,6 +3,7 @@ import { GeneratorType, TileClusterGeneratorConfig, MergedGeneratorConfig } from
 import { isUrlAbsolute } from '../../utils'
 import { API_GATEWAY } from '../../config'
 import { Group } from '../../types'
+import { DEFAULT_POINTS_SOURCE_LAYER } from './config'
 
 const MAX_ZOOM_TO_CLUSTER_POINTS = 4
 
@@ -55,7 +56,7 @@ class TileClusterGenerator {
         id: `${config.id}-clusters`,
         type: 'circle',
         source: config.id,
-        'source-layer': 'points',
+        'source-layer': DEFAULT_POINTS_SOURCE_LAYER,
         filter: ['>', ['get', 'count'], config.duplicatedEventsWorkaround ? 2 : 1],
         paint: {
           'circle-radius': [
@@ -81,7 +82,7 @@ class TileClusterGenerator {
         id: `${config.id}-cluster_count`,
         type: 'symbol',
         source: config.id,
-        'source-layer': 'points',
+        'source-layer': DEFAULT_POINTS_SOURCE_LAYER,
         filter: ['>', ['get', 'count'], config.duplicatedEventsWorkaround ? 2 : 1],
         layout: {
           'text-size': 14,
@@ -104,7 +105,7 @@ class TileClusterGenerator {
         id: `${config.id}-unclustered_point`,
         type: 'symbol',
         source: config.id,
-        'source-layer': 'points',
+        'source-layer': DEFAULT_POINTS_SOURCE_LAYER,
         filter: ['<=', ['get', 'count'], config.duplicatedEventsWorkaround ? 2 : 1],
         layout: {
           'icon-allow-overlap': true,

--- a/libs/layer-composer/src/generators/types.ts
+++ b/libs/layer-composer/src/generators/types.ts
@@ -175,6 +175,10 @@ export type TileClusterEventType = 'encounter' | 'loitering' | 'port'
 export interface TileClusterGeneratorConfig extends GeneratorConfig {
   type: 'TILE_CLUSTER'
   /**
+   * Defines the steps for the circle radius
+   */
+  breaks?: number[]
+  /**
    * Defines the maximum zoom that returns clusters
    */
   maxZoomCluster?: number

--- a/libs/layer-composer/src/generators/types.ts
+++ b/libs/layer-composer/src/generators/types.ts
@@ -175,7 +175,7 @@ export type TileClusterEventType = 'encounter' | 'loitering' | 'port'
 export interface TileClusterGeneratorConfig extends GeneratorConfig {
   type: 'TILE_CLUSTER'
   /**
-   * Defines the steps for the circle radius
+   * Defines the 3 steps for the circle radius
    */
   breaks?: number[]
   /**

--- a/libs/layer-composer/src/types/index.ts
+++ b/libs/layer-composer/src/types/index.ts
@@ -1,6 +1,5 @@
 import type {
   SourceSpecification,
-  HeatmapLayerSpecification,
   LayerSpecification,
   StyleSpecification,
 } from '@globalfishingwatch/maplibre-gl'


### PR DESCRIPTION
Following the same concept than dynamic ramps for environmental layers. This PR generates breaks for the cluster radius size. [Workspace URL to test](https://fishing-map-fishing-map-clusters-dynamic-ramps-jzzp2ui3wq-uc.a.run.app/map/fishing-activity/testing_events_dynamic_ramp-public?dvIn[0][id]=bq-events-1665487988441&dvIn[0][cfg][breaks][0]=2&dvIn[0][cfg][breaks][1]=544&dvIn[0][cfg][breaks][2]=2022)

![image](https://user-images.githubusercontent.com/10500650/195082792-87c09845-2618-43e5-b311-36d9e89de2df.png)
