### PR TITLE
move histogram filter to activity filters

### DIFF
--- a/apps/fishing-map/features/hints/HelpHub.tsx
+++ b/apps/fishing-map/features/hints/HelpHub.tsx
@@ -31,14 +31,19 @@ function HelpHub() {
     dispatch(resetHints())
   }
 
-  const getUserGuideLink = () => {
-    if (i18n.language === 'es') return 'https://globalfishingwatch.org/es/guia-de-usuario/'
-    return 'https://globalfishingwatch.org/user-guide'
-  }
+  // const getUserGuideLink = () => {
+  //   if (i18n.language === 'es') return 'https://globalfishingwatch.org/es/guia-de-usuario/'
+  //   return 'https://globalfishingwatch.org/user-guide'
+  // }
 
   const getFAQsLink = () => {
     if (i18n.language === 'es') return 'https://globalfishingwatch.org/es/ayuda-faqs/'
     return 'https://globalfishingwatch.org/help-faqs/'
+  }
+
+  const getVideoTutorialsLink = () => {
+    if (i18n.language === 'es') return 'https://globalfishingwatch.org/tutoriales'
+    return 'https://globalfishingwatch.org/tutorials'
   }
 
   return (
@@ -67,9 +72,19 @@ function HelpHub() {
             </span>
           )}
         </li>
-        <li>
+        {/* <li>
           <a href={getUserGuideLink()} target="_blank" rel="noreferrer" className={cx(styles.link)}>
             {t('common.userGuide', 'User guide')}
+          </a>
+        </li> */}
+        <li>
+          <a
+            href={getVideoTutorialsLink()}
+            target="_blank"
+            rel="noreferrer"
+            className={cx(styles.link)}
+          >
+            {t('common.tutorials', 'Tutorials')}
           </a>
         </li>
         <li>

--- a/apps/fishing-map/features/workspace/environmental/HistogramRangeFilter.tsx
+++ b/apps/fishing-map/features/workspace/environmental/HistogramRangeFilter.tsx
@@ -37,11 +37,8 @@ function HistogramRangeFilter({ dataview }: HistogramRangeFilterProps) {
   const { t } = useTranslation()
   const { upsertDataviewInstance } = useDataviewInstancesConnect()
   const histogram = useDataviewHistogram(dataview)
-  const dataset = dataview.datasets?.find(
-    (d) => d.type === DatasetTypes.Fourwings || d.type === DatasetTypes.Context
-  )
+  const dataset = dataview.datasets?.find((d) => d.type === DatasetTypes.Fourwings)
   const { max, min } = dataset?.configuration
-  const showRange = max !== undefined && min !== undefined && max !== null && min !== null
   const layerRange = getLayerDatasetRange(dataset)
   const minSliderValue = dataview.config?.minVisibleValue ?? layerRange.min
   const maxSliderValue = dataview.config?.maxVisibleValue ?? layerRange.max
@@ -67,8 +64,6 @@ function HistogramRangeFilter({ dataview }: HistogramRangeFilterProps) {
     },
     [dataview.id, max, min, upsertDataviewInstance]
   )
-
-  if (!showRange) return null
 
   return (
     <div className={styles.container}>

--- a/apps/fishing-map/public/locales/source/translations.json
+++ b/apps/fishing-map/public/locales/source/translations.json
@@ -134,6 +134,7 @@
     "seeDefault": "See default view",
     "share": "Share the current view",
     "sources": "Sources",
+    "tutorials": "Tutorials",
     "unknown": "Unknown",
     "unknownVessel": "Unknown vessel",
     "update": "Update",


### PR DESCRIPTION
Follow the same workflow for histogram filter in  global environmental layers:

![image](https://user-images.githubusercontent.com/10500650/203579192-21bcc130-093f-4e9e-8169-53e5d42d9c63.png)

As the histogram sometimes takes some time to render this uses [useTransition](https://reactjs.org/docs/hooks-reference.html#usetransition) to add an loading spinner in the icon while rendering