### PR TITLE
Fixed ESLint couldn't determine the plugin "react" uniquely.

### DIFF
--- a/apps/api-portal/package.json
+++ b/apps/api-portal/package.json
@@ -54,7 +54,7 @@
     "eslint-plugin-flowtype": "8.0.3",
     "eslint-plugin-import": "2.26.0",
     "eslint-plugin-jsx-a11y": "6.6.1",
-    "eslint-plugin-react": "7.30.1",
+    "eslint-plugin-react": "7.31.10",
     "eslint-plugin-react-hooks": "4.6.0",
     "husky": "8.0.1",
     "i18next-parser": "6.4.0",

--- a/apps/deck-playground/package.json
+++ b/apps/deck-playground/package.json
@@ -66,7 +66,7 @@
     "eslint-plugin-flowtype": "8.0.3",
     "eslint-plugin-import": "2.26.0",
     "eslint-plugin-jsx-a11y": "6.6.1",
-    "eslint-plugin-react": "7.30.1",
+    "eslint-plugin-react": "7.31.10",
     "eslint-plugin-react-hooks": "4.6.0",
     "husky": "7.0.4",
     "prettier": "2.4.0",

--- a/apps/fishing-map/package.json
+++ b/apps/fishing-map/package.json
@@ -110,7 +110,7 @@
     "eslint-plugin-flowtype": "8.0.3",
     "eslint-plugin-import": "2.26.0",
     "eslint-plugin-jsx-a11y": "6.6.1",
-    "eslint-plugin-react": "7.30.1",
+    "eslint-plugin-react": "7.31.10",
     "eslint-plugin-react-hooks": "4.6.0",
     "husky": "8.0.1",
     "i18next-parser": "6.4.0",

--- a/apps/fourwings-explorer/package.json
+++ b/apps/fourwings-explorer/package.json
@@ -55,7 +55,7 @@
     "eslint-plugin-flowtype": "8.0.3",
     "eslint-plugin-import": "2.26.0",
     "eslint-plugin-jsx-a11y": "6.6.1",
-    "eslint-plugin-react": "7.30.1",
+    "eslint-plugin-react": "7.31.10",
     "eslint-plugin-react-hooks": "4.6.0",
     "husky": "7.0.4",
     "prettier": "2.4.0",

--- a/apps/port-labeler/package.json
+++ b/apps/port-labeler/package.json
@@ -68,7 +68,7 @@
     "eslint-plugin-flowtype": "8.0.3",
     "eslint-plugin-import": "2.26.0",
     "eslint-plugin-jsx-a11y": "6.6.1",
-    "eslint-plugin-react": "7.30.1",
+    "eslint-plugin-react": "7.31.10",
     "eslint-plugin-react-hooks": "4.6.0",
     "husky": "8.0.1",
     "i18next-parser": "6.4.0",

--- a/apps/user-groups-admin/package.json
+++ b/apps/user-groups-admin/package.json
@@ -42,7 +42,7 @@
     "eslint-plugin-flowtype": "8.0.3",
     "eslint-plugin-import": "2.26.0",
     "eslint-plugin-jsx-a11y": "6.6.1",
-    "eslint-plugin-react": "7.30.1",
+    "eslint-plugin-react": "7.31.10",
     "eslint-plugin-react-hooks": "4.6.0",
     "husky": "8.0.1",
     "prettier": "2.6.2",

--- a/tools/generators/app/files/package.json__tmpl__
+++ b/tools/generators/app/files/package.json__tmpl__
@@ -61,7 +61,7 @@
     "eslint-plugin-flowtype": "8.0.3",
     "eslint-plugin-import": "2.26.0",
     "eslint-plugin-jsx-a11y": "6.6.1",
-    "eslint-plugin-react": "7.30.1",
+    "eslint-plugin-react": "7.31.10",
     "eslint-plugin-react-hooks": "4.6.0",
     "husky": "7.0.4",
     "i18next-parser": "5.3.0",

--- a/tools/generators/minisite/files/package.json__tmpl__
+++ b/tools/generators/minisite/files/package.json__tmpl__
@@ -41,7 +41,7 @@
     "eslint-plugin-flowtype": "8.0.3",
     "eslint-plugin-import": "2.26.0",
     "eslint-plugin-jsx-a11y": "6.6.1",
-    "eslint-plugin-react": "7.30.1",
+    "eslint-plugin-react": "7.31.10",
     "eslint-plugin-react-hooks": "4.6.0",
     "husky": "7.0.4",
     "prettier": "2.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9702,26 +9702,6 @@ eslint-plugin-react-hooks@4.6.0, eslint-plugin-react-hooks@4.x, eslint-plugin-re
   resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.6.0.tgz#4c3e697ad95b77e93f8646aaa1630c1ba607edd3"
   integrity sha512-oFc7Itz9Qxh2x4gNHStv3BqJq54ExXmfC+a1NjAta66IAN87Wu0R/QArgIS9qKzX3dXKPI9H5crl9QchNMY9+g==
 
-eslint-plugin-react@7.30.1:
-  version "7.30.1"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.30.1.tgz#2be4ab23ce09b5949c6631413ba64b2810fd3e22"
-  integrity sha512-NbEvI9jtqO46yJA3wcRF9Mo0lF9T/jhdHqhCHXiXtD+Zcb98812wvokjWpU7Q4QH5edo6dmqrukxVvWWXHlsUg==
-  dependencies:
-    array-includes "^3.1.5"
-    array.prototype.flatmap "^1.3.0"
-    doctrine "^2.1.0"
-    estraverse "^5.3.0"
-    jsx-ast-utils "^2.4.1 || ^3.0.0"
-    minimatch "^3.1.2"
-    object.entries "^1.1.5"
-    object.fromentries "^2.0.5"
-    object.hasown "^1.1.1"
-    object.values "^1.1.5"
-    prop-types "^15.8.1"
-    resolve "^2.0.0-next.3"
-    semver "^6.3.0"
-    string.prototype.matchall "^4.0.7"
-
 eslint-plugin-react@7.31.10, eslint-plugin-react@7.x, eslint-plugin-react@^7.27.1, eslint-plugin-react@^7.29.4, eslint-plugin-react@^7.31.7:
   version "7.31.10"
   resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.31.10.tgz#6782c2c7fe91c09e715d536067644bbb9491419a"


### PR DESCRIPTION
* Sync `eslint-plugin-react` versions to fix this error
```
> git -c user.useConfigOnly=true commit --quiet --allow-empty-message --file -
Executing ~/.huskyrc
yarn run v1.22.17
$ ./frontend/node_modules/.bin/lint-staged
[STARTED] Preparing lint-staged...
[SUCCESS] Preparing lint-staged...
[STARTED] Running tasks for staged files...
[STARTED] package.json — 141 files
[STARTED] *.{js,jsx,ts,tsx} — 72 files
[STARTED] *.{css, scss} — 3 files
[STARTED] eslint -c ./.eslintrc.js --fix
[STARTED] prettier --write
[SUCCESS] prettier --write
[STARTED] stylelint --fix
[SUCCESS] stylelint --fix
[SUCCESS] *.{css, scss} — 3 files
[FAILED] eslint -c ./.eslintrc.js --fix [FAILED]
[FAILED] eslint -c ./.eslintrc.js --fix [FAILED]
[SUCCESS] Running tasks for staged files...
[STARTED] Applying modifications from tasks...
[SKIPPED] Skipped because of errors from tasks.
[STARTED] Reverting to original state because of errors...
[SUCCESS] Reverting to original state because of errors...
[STARTED] Cleaning up temporary files...
[SUCCESS] Cleaning up temporary files...

✖ eslint -c ./.eslintrc.js --fix:

Oops! Something went wrong! :(

ESLint: 8.20.0

ESLint couldn't determine the plugin "react" uniquely.

- ./frontend/node_modules/eslint-plugin-react/index.js (loaded in "--config")
- ./frontend/apps/fishing-map/node_modules/eslint-plugin-react/index.js (loaded in "apps/fishing-map/.eslintrc.js")

Please remove the "plugins" setting from either config or remove either plugin installation.

If you still can't figure out the problem, please stop by https://eslint.org/chat/help to chat with the team.

error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
husky - pre-commit hook exited with code 1 (error)
```