### PR TITLE
request areas in parallel and fix dataset id in production

### DIFF
--- a/apps/vessel-history/features/regions/regions.slice.ts
+++ b/apps/vessel-history/features/regions/regions.slice.ts
@@ -7,7 +7,7 @@ import {
   createAsyncSlice,
 } from 'utils/async-slice'
 import { RootState } from 'store'
-import { API_VERSION } from 'data/config'
+import { IS_PRODUCTION } from 'data/config'
 
 export type RegionId = string | number
 export enum MarineRegionType {
@@ -50,22 +50,37 @@ export const fetchRegionsThunk = createAsyncThunk(
     try {
       const apiUrl = `/datasets`
       const options = {}
-      const eezs = await GFWAPI.fetch<Region[]>(
-        `${apiUrl}/public-eez-areas/user-context-layer-v1`,
-        options
-      )
-      const mpas = await GFWAPI.fetch<Region[]>(
-        `${apiUrl}/public-mpa-all/user-context-layer-v1`,
-        options
-      )
-      const rfmos = await GFWAPI.fetch<Region[]>(
-        `${apiUrl}/public-rfmo/user-context-layer-v1`,
-        options
-      )
+      const promises = [
+        GFWAPI.fetch<Region[]>(`${apiUrl}/public-eez-areas/user-context-layer-v1`, options),
+        GFWAPI.fetch<Region[]>(`${apiUrl}/public-mpa-all/user-context-layer-v1`, options),
+        GFWAPI.fetch<Region[]>(
+          `${apiUrl}/${IS_PRODUCTION ? 'public-tuna-rfmo' : 'public-rfmo'}/user-context-layer-v1`,
+          options
+        ),
+      ]
+      const regions = await Promise.allSettled(promises)
       const result: Regions[] = [
-        { id: MarineRegionType.eez, data: eezs.sort(sortRegionAlphabetically) },
-        { id: MarineRegionType.mpa, data: mpas.sort(sortRegionAlphabetically) },
-        { id: MarineRegionType.rfmo, data: rfmos.sort(sortRegionAlphabetically) },
+        {
+          id: MarineRegionType.eez,
+          data:
+            regions[0]?.status === 'fulfilled'
+              ? regions[0].value.sort(sortRegionAlphabetically)
+              : [],
+        },
+        {
+          id: MarineRegionType.mpa,
+          data:
+            regions[1]?.status === 'fulfilled'
+              ? regions[1].value.sort(sortRegionAlphabetically)
+              : [],
+        },
+        {
+          id: MarineRegionType.rfmo,
+          data:
+            regions[2]?.status === 'fulfilled'
+              ? regions[2].value.sort(sortRegionAlphabetically)
+              : [],
+        },
       ]
       return result
     } catch (e: any) {


### PR DESCRIPTION
Looks like the `public-rfmo` dataset is not ready for production yet, so this PR uses the legacy dataset until we have it ready.
Also took advantage of the change to make this faster requesting the 3 areas in parallel, please @rdgfuentes take a look at this later as I'm going to merge this to get the bug fixed asap.