### PR TITLE
fetch vessel groups by group id

### DIFF
--- a/apps/fishing-map/features/vessel-groups/VesselGroupModal.tsx
+++ b/apps/fishing-map/features/vessel-groups/VesselGroupModal.tsx
@@ -43,6 +43,7 @@ import {
   updateVesselGroupThunk,
   searchVesselGroupsVesselsThunk,
   MAX_VESSEL_GROUP_VESSELS,
+  getVesselInVesselGroupThunk,
 } from './vessel-groups.slice'
 import styles from './VesselGroupModal.module.css'
 
@@ -92,12 +93,11 @@ function VesselGroupModal(): React.ReactElement {
     },
     [dispatch]
   )
-  const editingVesselGroupVessels = editingVesselGroup?.vessels
   useEffect(() => {
-    if (editingVesselGroupVessels?.length > 0) {
-      dispatchSearchVesselsGroupsThunk(editingVesselGroupVessels)
+    if (editingVesselGroup?.vessels?.length > 0) {
+      dispatch(getVesselInVesselGroupThunk({ vesselGroup: editingVesselGroup }))
     }
-  }, [editingVesselGroupVessels, dispatchSearchVesselsGroupsThunk])
+  }, [dispatch, editingVesselGroup])
 
   const onGroupNameChange = useCallback((e) => {
     setGroupName(e.target.value)

--- a/apps/fishing-map/features/vessel-groups/VesselGroupModalVessels.tsx
+++ b/apps/fishing-map/features/vessel-groups/VesselGroupModalVessels.tsx
@@ -136,7 +136,7 @@ function VesselGroupVessels(): React.ReactElement {
           Object.keys(searchVesselsByMMSI).map((mmsi) => {
             const vessels = searchVesselsByMMSI[mmsi]
             return (
-              <Fragment>
+              <Fragment key={mmsi}>
                 {vessels.map((vessel, i) => (
                   <VesselGroupVesselRow
                     key={`${vessel.id}-${vessel.dataset}`}


### PR DESCRIPTION
To avoid errors with large urls when retrieving a lot of vessels included in a vessel group this PR uses the new vessel-groups param in search vessels endpoint to fetch all the vessels info.

