### PR TITLE
Deck playground/layers order

### DIFF
--- a/apps/deck-playground/features/map/Map.tsx
+++ b/apps/deck-playground/features/map/Map.tsx
@@ -4,18 +4,13 @@ import { BitmapLayer } from '@deck.gl/layers'
 import { TileLayer } from '@deck.gl/geo-layers'
 import { MapView } from '@deck.gl/core/typed'
 import { useVesselsLayer } from 'layers/vessel/vessels.hooks'
-import { useTimerange } from 'features/timebar/timebar.hooks'
-import { MapLayer, MapLayerType, useMapLayers } from 'features/map/layers.hooks'
+import { VesselEventsLayer } from 'layers/vessel/VesselEventsLayer'
+import { VesselTrackLayer } from 'layers/vessel/VesselTrackLayer'
+import { VesselsLayer } from 'layers/vessel/VesselsLayer'
+import { useFourwingsLayer } from 'layers/fourwings/fourwings.hooks'
 import { useURLViewport, useViewport } from 'features/map/map-viewport.hooks'
-import { useFourwingsLayer } from '../../layers/fourwings/fourwings.hooks'
+import { layersZIndexSort } from 'utils/layers'
 
-const INITIAL_VIEW_STATE = {
-  // longitude: -2,
-  // latitude: 40,
-  latitude: 44.00079038236199,
-  longitude: -8.153310241289587,
-  zoom: 9,
-}
 
 const basemap = new TileLayer({
   id: 'basemap',
@@ -40,30 +35,15 @@ const mapView = new MapView({ repeat: true })
 
 const MapWrapper = (): React.ReactElement => {
   useURLViewport()
-  const [timerange] = useTimerange()
-  const [mapLayers, setMapLayers] = useMapLayers()
   const { viewState, onViewportStateChange } = useViewport()
 
-  const setMapLayerProperty = useCallback(
-    (id: MapLayerType, property: keyof MapLayer, value) => {
-      setMapLayers((layers) =>
-        layers.map((l) => {
-          if (l.id === id) {
-            return { ...l, [property]: value }
-          }
-          return l
-        })
-      )
-    },
-    [setMapLayers]
-  )
-
-
   const fourwingsLayer = useFourwingsLayer()
-  const vesselsLayer = useVesselsLayer()
+  const VesselsLayerInstance: VesselsLayer = useVesselsLayer()
+  
   const layers = useMemo(() => {
-    return [basemap, fourwingsLayer, vesselsLayer]
-  }, [fourwingsLayer, vesselsLayer])
+    const vesselsLayers: (VesselEventsLayer | VesselTrackLayer)[] = VesselsLayerInstance?.getLayers() || []
+    return layersZIndexSort([basemap, fourwingsLayer, ...vesselsLayers])
+  }, [fourwingsLayer, VesselsLayerInstance])
 
   const getTooltip = (tooltip) => {
     // Heatmap

--- a/apps/deck-playground/features/sidebar/Sidebar.tsx
+++ b/apps/deck-playground/features/sidebar/Sidebar.tsx
@@ -22,10 +22,9 @@ function Sidebar() {
   const removeVesselId = useRemoveVesselInLayer()
 
   const getVesselsEventsData = () => {
-    const vesselsEvents = vesselsLayerInstance
-      .getVesselsLayers()
-      .reduce((acc, l) => [...acc, l.getVesselEventsData()], [])
-    console.log(vesselsEvents)
+    if (vesselIds.length) {
+      vesselIds.map(id => console.log(id, vesselsLayerInstance.getVesselEventsDataById(id)))
+    }
   }
 
   const getFourwingsData = () => {

--- a/apps/deck-playground/features/timebar/TimebarVesselsEvents.tsx
+++ b/apps/deck-playground/features/timebar/TimebarVesselsEvents.tsx
@@ -15,12 +15,11 @@ const TimebarVesselsEvents = () => {
 
   const eventsData = useMemo(() => {
     if (vesselsLayerLoaded) {
-      return vesselsLayerInstance
-        .getVesselsLayers()
-        .filter((l) => ids.includes(l.id))
-        .reduce((acc, l) => {
-          return [...acc, { chunks: l.getVesselEventsData(), color: '#f00' }]
-        }, [])
+      return ids.map(
+        id => ({
+          chunks: vesselsLayerInstance.getVesselEventsDataById(id),
+          color: '#f00' 
+      }))
     }
     return []
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/apps/deck-playground/features/timebar/TimebarVesselsTracks.tsx
+++ b/apps/deck-playground/features/timebar/TimebarVesselsTracks.tsx
@@ -6,13 +6,14 @@ import {
 } from 'layers/vessel/vessels.hooks'
 import { TimebarTracks, TimebarChartChunk, TimebarChartValue } from '@globalfishingwatch/timebar'
 import { ResourceStatus } from '@globalfishingwatch/api-types'
+import { VesselLayerTrack } from 'types'
 
 const TimebarVesselsEvents = () => {
   const vesselsLayerInstance = useVesselsLayerInstance()
   const vesselsLayerLoaded = useVesselsLayerLoaded()
   const ids = useVesselsLayerIds()
 
-  const getTrackChunk = (segment): TimebarChartChunk => {
+  const getTrackChunk = (segment: VesselLayerTrack): TimebarChartChunk => {
     const { waypoints } = segment
     return {
       start: waypoints[0].timestamp || Number.POSITIVE_INFINITY,
@@ -23,19 +24,13 @@ const TimebarVesselsEvents = () => {
 
   const tracksData = useMemo(() => {
     if (vesselsLayerLoaded) {
-      return vesselsLayerInstance
-        .getVesselsLayers()
-        .filter((l) => ids.includes(l.id))
-        .reduce((acc, l) => {
-          return [
-            ...acc,
-            {
-              status: ResourceStatus.Finished,
-              chunks: l.getVesselTrackData().map((segment) => getTrackChunk(segment)),
-              color: '#f00',
-            },
-          ]
-        }, [])
+      return ids.map( id => ({
+        status: ResourceStatus.Finished,
+        chunks: vesselsLayerInstance.getVesselTrackDataById(id).map(
+          segment => getTrackChunk(segment)
+        ),
+        color: '#f00',
+      }))
     }
     return []
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/apps/deck-playground/layers/vessel/VesselEventsLayer.ts
+++ b/apps/deck-playground/layers/vessel/VesselEventsLayer.ts
@@ -1,9 +1,15 @@
 import { AccessorFunction, DefaultProps } from '@deck.gl/core/typed'
 import { ScatterplotLayer, ScatterplotLayerProps } from '@deck.gl/layers/typed'
+import { Group, GROUP_ORDER } from '@globalfishingwatch/layer-composer'
 
 export type _VesselEventsLayerProps<DataT = any> = {
   eventType?: string
   filterRange: Array<number>
+  /**
+  * The layer z ordering index
+  * Default values come from layer-composer sorting for Point layers
+  */
+  layerZIndex?: number
   getShape?: AccessorFunction<DataT, number>
   getPosition?: AccessorFunction<DataT, number>
   getFilterValue?: AccessorFunction<DataT, number>
@@ -28,6 +34,7 @@ const defaultProps: DefaultProps<VesselEventsLayerProps> = {
   getFilterValue: { type: 'accessor', value: (d) => d.start },
   getPosition: { type: 'accessor', value: (d) => d.coordinates },
   getPickingInfo: { type: 'accessor', value: ({ info }) => info },
+  layerZIndex: { type: 'accessor', value: GROUP_ORDER.indexOf(Group.Point) }
 }
 
 export class VesselEventsLayer<DataT = any, ExtraProps = {}> extends ScatterplotLayer<

--- a/apps/deck-playground/layers/vessel/VesselTrackLayer.ts
+++ b/apps/deck-playground/layers/vessel/VesselTrackLayer.ts
@@ -3,6 +3,7 @@ import { AccessorFunction, DefaultProps } from '@deck.gl/core/typed'
 import { PathLayer, PathLayerProps } from '@deck.gl/layers/typed'
 import { getPathDefaultAccessor, getTimestampsDefaultAccessor } from 'layers/vessel/vessels.utils'
 import { Segment } from '@globalfishingwatch/api-types'
+import { Group, GROUP_ORDER } from '@globalfishingwatch/layer-composer'
 
 /** Properties added by VesselTrackLayer. */
 export type _VesselTrackLayerProps<DataT = any> = {
@@ -27,6 +28,11 @@ export type _VesselTrackLayerProps<DataT = any> = {
    */
   highlightEndTime?: number
   /**
+   * The layer z ordering index
+   * Default values come from layer-composer sorting for Track layers
+   */
+  layerZIndex?: number
+  /**
    * Path accessor.
    */
   getPath?: AccessorFunction<DataT, NumericArray>
@@ -42,6 +48,7 @@ const defaultProps: DefaultProps<VesselTrackLayerProps> = {
   getPath: { type: 'accessor', value: getPathDefaultAccessor },
   getColor: { type: 'accessor', value: () => [255, 255, 255, 100] },
   getTimestamps: { type: 'accessor', value: getTimestampsDefaultAccessor },
+  layerZIndex: { type: 'accessor', value: GROUP_ORDER.indexOf(Group.Track) }
 }
 
 /** All properties supported by VesselTrackLayer. */

--- a/apps/deck-playground/layers/vessel/VesselsLayer.ts
+++ b/apps/deck-playground/layers/vessel/VesselsLayer.ts
@@ -1,27 +1,134 @@
-import { CompositeLayer } from '@deck.gl/core/typed'
-import { VesselLayer, VesselLayerProps } from 'layers/vessel/VesselLayer'
+import { CompositeLayer, Layer, LayerProps } from '@deck.gl/core/typed'
+import { DataFilterExtension } from '@deck.gl/extensions'
+// Layers
+import { VesselEventsLayer, _VesselEventsLayerProps } from 'layers/vessel/VesselEventsLayer'
+import { VesselTrackLayer, _VesselTrackLayerProps } from 'layers/vessel/VesselTrackLayer'
+// Loaders
+import { trackLoader } from 'loaders/vessels/trackLoader'
+import { vesselEventsLoader } from 'loaders/vessels/eventsLoader'
+import { Segment } from '@globalfishingwatch/api-types'
+import { Group, GROUP_ORDER } from '@globalfishingwatch/layer-composer'
+import { VesselLayerEvent } from 'types'
+
+export type VesselLayerProps = _VesselTrackLayerProps & _VesselEventsLayerProps
+
+export const TRACK_LAYER_PREFIX = 'track'
+export const EVENTS_LAYER_PREFIX = 'events'
 
 export type VesselsLayerProps = { ids: string[] } & VesselLayerProps
 
 export class VesselsLayer extends CompositeLayer<VesselsLayerProps> {
-  vesselLayers = this.props.ids.map(
-    (id) =>
-      new VesselLayer({
-        id,
+  layersLoaded: Layer[] = []
+
+  onDataLoad: LayerProps['onDataLoad'] = (data, context) => {
+    this.layersLoaded = [...this.layersLoaded, context.layer]
+    if (this.layersLoaded.length === this.vesselLayers.length/this.props.ids.length) {
+      this.props.onDataLoad(data, context)
+    }
+  }
+
+  vesselLayers: (VesselTrackLayer | VesselEventsLayer)[] = this.props.ids.flatMap((id) => [
+    new VesselTrackLayer<Segment[]>(
+      this.getSubLayerProps({
+        id: `${TRACK_LAYER_PREFIX}-vessel-layer-${id}`,
+        data: `https://gateway.api.dev.globalfishingwatch.org/v2/vessels/${id}/tracks?binary=true&fields=lonlat%2Ctimestamp&format=valueArray&distance-fishing=500&bearing-val-fishing=1&change-speed-fishing=200&min-accuracy-fishing=30&distance-transit=500&bearing-val-transit=1&change-speed-transit=200&min-accuracy-transit=30&datasets=public-global-fishing-tracks%3Av20201001`,
+        loaders: [trackLoader],
+        widthUnits: 'pixels',
+        widthScale: 1,
+        wrapLongitude: true,
+        jointRounded: true,
+        capRounded: true,
+        layerZIndex: GROUP_ORDER.indexOf(Group.Track),
+        onDataLoad: this.onDataLoad,
+        getColor: (d) => {
+          return d.waypoints.map((p) => {
+            if (
+              p.timestamp >= this.props.highlightStartTime &&
+              p.timestamp <= this.props.highlightEndTime
+            ) {
+              return [255, 0, 0, 100]
+            }
+            return [255, 255, 255, 100]
+          })
+        },
+        getWidth: 3,
+        updateTriggers: {
+          getColor: [this.props.highlightStartTime, this.props.highlightEndTime],
+        },
         startTime: this.props.startTime,
         endTime: this.props.endTime,
-        highlightStartTime: this.props.highlightStartTime,
-        highlightEndTime: this.props.highlightEndTime,
-        onDataLoad: this.props.onDataLoad,
       })
-  )
-  renderLayers(): VesselLayer[] {
+    ),
+    new VesselEventsLayer(
+      this.getSubLayerProps({
+        id: `${EVENTS_LAYER_PREFIX}-fishing-${id}`,
+        data: `https://gateway.api.dev.globalfishingwatch.org/v2/events?limit=99999&offset=0&vessels=${id}&summary=true&datasets=public-global-fishing-events%3Av20201001`,
+        loaders: [vesselEventsLoader],
+        eventType: 'fishing',
+        pickable: true,
+        startTime: this.props.startTime,
+        endTime: this.props.endTime,
+        onDataLoad: this.onDataLoad,
+        layerZIndex: GROUP_ORDER.indexOf(Group.Point),
+        filterRange: [this.props.startTime, this.props.endTime],
+        extensions: [new DataFilterExtension({ filterSize: 1 })],
+      })
+    ),
+    new VesselEventsLayer(
+      this.getSubLayerProps({
+        id: `${EVENTS_LAYER_PREFIX}-port-visits-${id}`,
+        data: `https://gateway.api.dev.globalfishingwatch.org/v2/events?limit=99999&offset=0&vessels=${id}&summary=true&confidences=4&datasets=public-global-port-visits-c2-events%3Av20201001`,
+        loaders: [vesselEventsLoader],
+        eventType: 'port-visit',
+        pickable: true,
+        startTime: this.props.startTime,
+        endTime: this.props.endTime,
+        onDataLoad: this.onDataLoad,
+        layerZIndex: GROUP_ORDER.indexOf(Group.Point),
+        filterRange: [this.props.startTime, this.props.endTime],
+        extensions: [new DataFilterExtension({ filterSize: 1 })],
+      })
+    ),
+    new VesselEventsLayer(
+      this.getSubLayerProps({
+        id: `${EVENTS_LAYER_PREFIX}-encounters-${id}`,
+        data: `https://gateway.api.dev.globalfishingwatch.org/v2/events?limit=99999&offset=0&vessels=${id}&summary=true&datasets=public-global-encounters-events%3Av20201001`,
+        loaders: [vesselEventsLoader],
+        eventType: 'encounters',
+        pickable: true,
+        startTime: this.props.startTime,
+        endTime: this.props.endTime,
+        onDataLoad: this.onDataLoad,
+        layerZIndex: GROUP_ORDER.indexOf(Group.Point),
+        filterRange: [this.props.startTime, this.props.endTime],
+        extensions: [new DataFilterExtension({ filterSize: 1 })],
+      })
+    )
+  ])
+
+  renderLayers(): (VesselEventsLayer | VesselTrackLayer)[] {
     return this.vesselLayers
   }
-  getVesselsLayers() {
+
+  getLayers(): (VesselEventsLayer | VesselTrackLayer)[] {
     return this.vesselLayers
   }
-  getVesselLayer(id: string) {
-    return this.vesselLayers.find((l) => l.id === id)
+
+  getVesselLayersById(id: string): (VesselEventsLayer | VesselTrackLayer)[] {
+    return this.vesselLayers.filter((l) => l.id === id)
+  }
+
+  getVesselEventsDataById(id: string) {
+    return this.vesselLayers
+      .filter((l) => l.id.includes(EVENTS_LAYER_PREFIX))
+      .filter((l) => l.id.includes(id))
+      .reduce((acc, l: VesselEventsLayer) => [...acc, ...l.props.data as VesselLayerEvent[]], [])
+  }
+
+  getVesselTrackDataById(id: string) {
+    return this.vesselLayers
+      .filter((l) => l.id.includes(TRACK_LAYER_PREFIX))
+      .filter((l) => l.id.includes(id))
+      .flatMap((l: VesselTrackLayer) => l.props.data) 
   }
 }

--- a/apps/deck-playground/loaders/vessels/eventsLoader.ts
+++ b/apps/deck-playground/loaders/vessels/eventsLoader.ts
@@ -1,4 +1,6 @@
 import { LoaderWithParser } from '@loaders.gl/loader-utils'
+import { ApiEvent } from "@globalfishingwatch/api-types"
+import { VesselLayerEvent } from 'types'
 
 export const vesselEventsLoader: LoaderWithParser = {
   name: 'Events',
@@ -18,13 +20,13 @@ async function parse(arrayBuffer: ArrayBuffer) {
   return parseEvents(data.entries)
 }
 
-function parseEvents(events) {
+function parseEvents(events: ApiEvent[]) {
   const shapeIndex = {
     port_visit: 0,
     encounter: 1,
     fishing: 2,
   }
-  return events?.map((event) => {
+  return events?.map((event: ApiEvent): VesselLayerEvent => {
     const { position, start, end, type, ...attributes } = event
     return {
       ...attributes,

--- a/apps/deck-playground/types/index.ts
+++ b/apps/deck-playground/types/index.ts
@@ -1,3 +1,4 @@
+import { EncounterEvent, EventType, GapEvent, LoiteringEvent, PortVisitEvent } from "@globalfishingwatch/api-types"
 export type WorkspaceParam = 'zoom' | 'latitude' | 'longitude' | 'start' | 'end' | 'sidebarOpen'
 
 export type QueryParams = {
@@ -8,4 +9,27 @@ export type MapCoordinates = {
   latitude: number
   longitude: number
   zoom: number
+}
+
+export type VesselLayerEvent = {
+  coordinates: [number, number]
+  start: number
+  endTime: number
+  id: string
+  type: EventType
+  shapeIndex: number // Used on the shader to define the shape of the point
+  port_visit?: PortVisitEvent
+  encounter?: EncounterEvent
+  loitering?: LoiteringEvent
+  gap?: GapEvent
+  fishing?: Record<string,string>
+}
+
+export type VesselLayerTrack = {
+  waypoints: Waypoint[]
+}
+
+export type Waypoint = {
+  coordinates: [number, number]
+  timestamp: number
 }

--- a/apps/deck-playground/utils/layers.ts
+++ b/apps/deck-playground/utils/layers.ts
@@ -1,0 +1,9 @@
+
+import { VesselEventsLayer } from 'layers/vessel/VesselEventsLayer'
+import { VesselTrackLayer } from 'layers/vessel/VesselTrackLayer'
+
+type Layers = VesselEventsLayer | VesselTrackLayer
+
+export function layersZIndexSort(layersArray: Layers[]): Layers[] {
+    return layersArray.sort((a, b) => a.props?.layerZIndex && b.props?.layerZIndex ? a.props?.layerZIndex - b.props?.layerZIndex : 0)
+}

--- a/libs/layer-composer/src/transforms/sort/sort.ts
+++ b/libs/layer-composer/src/transforms/sort/sort.ts
@@ -1,6 +1,6 @@
 import { Group, Dictionary, ExtendedStyle, ExtendedLayer, StyleTransformation } from '../../types'
 
-const GROUP_ORDER = [
+export const GROUP_ORDER = [
   Group.Background,
   Group.Basemap,
   Group.OutlinePolygonsBackground,


### PR DESCRIPTION
Updating layers structure to return a flat array and sort it before passing it to Deck (events should be always on top of tracks)

![image](https://user-images.githubusercontent.com/6906348/211660103-f30a6468-d590-4fb5-b36f-5ce4a0ab18af.png)
