### PR TITLE
fix fallback option when omited datasets

### DIFF
--- a/libs/layer-composer/src/generators/heatmap/util/get-time-chunks-interval.ts
+++ b/libs/layer-composer/src/generators/heatmap/util/get-time-chunks-interval.ts
@@ -2,6 +2,8 @@ import { Interval } from '../types'
 import { HeatmapAnimatedMode, HeatmapAnimatedGeneratorConfig } from '../../types'
 import { getInterval } from './time-chunks'
 
+export const TIME_COMPARISON_NOT_SUPPORTED_INTERVALS: Interval[] = ['month', 'year']
+
 export const getTimeChunksInterval = (
   config: HeatmapAnimatedGeneratorConfig,
   start: string,
@@ -10,7 +12,9 @@ export const getTimeChunksInterval = (
   const availableIntervals = config.availableIntervals
     ? [config.availableIntervals]
     : (config.sublayers || []).map((s) => s.availableIntervals)
-  const omitIntervals: Interval[] = config.mode === HeatmapAnimatedMode.TimeCompare ? ['month'] : []
+  const omitIntervals: Interval[] =
+    config.mode === HeatmapAnimatedMode.TimeCompare ? TIME_COMPARISON_NOT_SUPPORTED_INTERVALS : []
+
   const interval = getInterval(start, end, availableIntervals as Interval[][], omitIntervals)
   return interval
 }

--- a/libs/layer-composer/src/generators/heatmap/util/time-chunks.ts
+++ b/libs/layer-composer/src/generators/heatmap/util/time-chunks.ts
@@ -171,10 +171,8 @@ export const getInterval = (
 
   // Get intervals that are common to all dataset (initial array provided to ensure order from smallest to largest)
   const commonIntervals = intersection(INTERVAL_ORDER, ...availableIntervals)
-  const fallbackOption = commonIntervals.length
-    ? commonIntervals[commonIntervals.length - 1]
-    : 'day'
   const intervals = commonIntervals.filter((interval) => !omitIntervals.includes(interval))
+  const fallbackOption = intervals.length ? intervals[intervals.length - 1] : 'day'
   if (!intervals.length) {
     console.warn(
       `no common interval found, using the largest available option (${fallbackOption})`,


### PR DESCRIPTION
Fix analysis crash as was using interval `year` when no supported
![image](https://user-images.githubusercontent.com/10500650/215848981-126bebd7-d7c4-4edf-a337-864f57d7cea0.png)
