### PR TITLE
Update context layers with new datasets and endpoints

### DIFF
--- a/apps/fishing-map/features/datasets/NewDataset.tsx
+++ b/apps/fishing-map/features/datasets/NewDataset.tsx
@@ -237,7 +237,7 @@ function NewDataset(): React.ReactElement {
             ...metadata,
             public: true,
             name: metadataName,
-            type: DatasetTypes.Context,
+            type: DatasetTypes.UserContext,
             category: datasetCategory,
             configuration,
           }))

--- a/apps/fishing-map/features/datasets/datasets.utils.ts
+++ b/apps/fishing-map/features/datasets/datasets.utils.ts
@@ -92,7 +92,7 @@ export const getDatasetLabel = (dataset: { id: string; name?: string }): string 
 export const getDatasetIcon = (dataset: Dataset): IconType => {
   if (dataset.type === DatasetTypes.UserTracks) return 'track'
   if (dataset.configuration.geometryType === 'points') return 'dots'
-  if (dataset.type === DatasetTypes.Context) return 'polygons'
+  if (dataset.type === DatasetTypes.UserContext) return 'polygons'
   return null
 }
 

--- a/apps/fishing-map/features/map/map.draw.utils.ts
+++ b/apps/fishing-map/features/map/map.draw.utils.ts
@@ -14,7 +14,7 @@ export const getCoordinatePrecisionRounded = (coordinate: Position): Position =>
 export const getDrawDatasetDefinition = (name: string): Partial<Dataset> => {
   return {
     name,
-    type: DatasetTypes.Context,
+    type: DatasetTypes.UserContext,
     category: DatasetCategory.Context,
     subcategory: 'user',
     unit: 'NA',

--- a/apps/fishing-map/features/map/map.hooks.ts
+++ b/apps/fishing-map/features/map/map.hooks.ts
@@ -273,6 +273,7 @@ export type TooltipEventFeature = {
   sourceLayer: string
   layerId: string
   datasetId?: string
+  promoteId?: string
   generatorContextLayer?: ContextLayerType | null
   value: string // TODO Why not a number?
   properties: Record<string, string>

--- a/apps/fishing-map/features/map/popups/ContextLayers.hooks.ts
+++ b/apps/fishing-map/features/map/popups/ContextLayers.hooks.ts
@@ -41,13 +41,13 @@ export const useContextInteractions = () => {
 
   const onDownloadClick = useCallback(
     (ev: React.MouseEvent<Element, MouseEvent>, feature: TooltipEventFeature) => {
-      if (!feature.properties?.gfw_id) {
+      const areaId = feature.properties.gfw_id || feature.properties[feature.promoteId]
+      if (!areaId) {
         console.warn('No gfw_id available in the feature to analyze', feature)
         return
       }
 
       const datasetId = feature.datasetId
-      const areaId = feature.properties?.gfw_id
       const areaName = feature.value || feature.title
       batch(() => {
         dispatch(setDownloadActivityAreaKey({ datasetId, areaId }))
@@ -62,11 +62,11 @@ export const useContextInteractions = () => {
 
   const setAnalysisArea = useCallback(
     (feature: TooltipEventFeature) => {
-      const { source: sourceId, datasetId, properties = {}, title, value } = feature
-      const { gfw_id: areaId, bbox } = properties
+      const { source: sourceId, datasetId, properties = {}, title, value, promoteId } = feature
+      const areaId = feature.properties.gfw_id || feature.properties[promoteId]
       // Analysis already does it on page reload but to avoid waiting
       // this moves the map to the same position
-      const bounds = parsePropertiesBbox(bbox)
+      const bounds = parsePropertiesBbox(properties.bbox)
       if (bounds) {
         const boundsParams = {
           padding: FIT_BOUNDS_ANALYSIS_PADDING,
@@ -96,12 +96,13 @@ export const useContextInteractions = () => {
 
   const onAnalysisClick = useCallback(
     (ev: React.MouseEvent<Element, MouseEvent>, feature: TooltipEventFeature) => {
-      if (!feature.properties?.gfw_id) {
+      const gfw_id = feature.properties.gfw_id || feature.properties[feature.promoteId]
+      if (!gfw_id) {
         console.warn('No gfw_id available in the feature to report', feature)
         return
       }
 
-      if (areaId !== feature.properties?.gfw_id || sourceId !== feature.source) {
+      if (areaId !== gfw_id || sourceId !== feature.source) {
         setAnalysisArea(feature)
       }
     },

--- a/apps/fishing-map/features/map/popups/ContextLayers.tsx
+++ b/apps/fishing-map/features/map/popups/ContextLayers.tsx
@@ -51,8 +51,8 @@ function ContextTooltipSection({ features, showFeaturesDetails = false }: Contex
             )}
             {featureByType.map((feature, index) => {
               if (!feature.value) return null
-              const { generatorContextLayer } = feature
-              const { gfw_id } = feature.properties
+              const { generatorContextLayer, promoteId } = feature
+              const gfw_id = feature.properties.gfw_id || feature.properties[promoteId]
               const isGFWLayer =
                 generatorContextLayer === ContextLayerType.MPA ||
                 generatorContextLayer === ContextLayerType.MPARestricted ||

--- a/apps/fishing-map/features/timebar/TimebarSettings.tsx
+++ b/apps/fishing-map/features/timebar/TimebarSettings.tsx
@@ -239,7 +239,7 @@ const TimebarSettings = ({ loading = false }: { loading: boolean }) => {
             />
             {activeEnvironmentalDataviews.map((envDataview, i) => {
               const dataset = envDataview.datasets?.find(
-                (d) => d.type === DatasetTypes.Fourwings || d.type === DatasetTypes.Context
+                (d) => d.type === DatasetTypes.Fourwings || d.type === DatasetTypes.UserContext
               )
 
               const title = t(`datasets:${dataset?.id}.name` as any, dataset?.name || dataset?.id)

--- a/apps/fishing-map/features/workspace/context-areas/ContextAreaLayerPanel.tsx
+++ b/apps/fishing-map/features/workspace/context-areas/ContextAreaLayerPanel.tsx
@@ -88,7 +88,7 @@ function LayerPanel({ dataview, onToggle }: LayerPanelProps): React.ReactElement
     setColorOpen(false)
   }
 
-  const dataset = dataview.datasets?.find((d) => d.type === DatasetTypes.Context)
+  const dataset = dataview.datasets?.find((d) => d.type === DatasetTypes.UserContext)
   const isUserLayer = !guestUser && dataset?.ownerId === userId
 
   useAutoRefreshImportingDataset(dataset, 5000)

--- a/apps/fishing-map/features/workspace/context-areas/ContextAreaLayerPanel.tsx
+++ b/apps/fishing-map/features/workspace/context-areas/ContextAreaLayerPanel.tsx
@@ -88,7 +88,9 @@ function LayerPanel({ dataview, onToggle }: LayerPanelProps): React.ReactElement
     setColorOpen(false)
   }
 
-  const dataset = dataview.datasets?.find((d) => d.type === DatasetTypes.UserContext)
+  const dataset = dataview.datasets?.find(
+    (d) => d.type === DatasetTypes.Context || d.type === DatasetTypes.UserContext
+  )
   const isUserLayer = !guestUser && dataset?.ownerId === userId
 
   useAutoRefreshImportingDataset(dataset, 5000)

--- a/apps/fishing-map/features/workspace/context-areas/ContextAreaSection.tsx
+++ b/apps/fishing-map/features/workspace/context-areas/ContextAreaSection.tsx
@@ -52,7 +52,7 @@ function ContextAreaSection(): React.ReactElement {
   const onToggleLayer = useCallback(
     (dataview: UrlDataviewInstance) => () => {
       const isVisible = dataview?.config?.visible ?? false
-      const dataset = dataview.datasets?.find((d) => d.type === DatasetTypes.Context)
+      const dataset = dataview.datasets?.find((d) => d.type === DatasetTypes.UserContext)
       const layerTitle = dataset?.name ?? dataset?.id ?? 'Unknown layer'
       const action = isVisible ? 'disable' : 'enable'
       uaEvent({

--- a/apps/fishing-map/features/workspace/context-areas/ContextAreaSection.tsx
+++ b/apps/fishing-map/features/workspace/context-areas/ContextAreaSection.tsx
@@ -52,7 +52,9 @@ function ContextAreaSection(): React.ReactElement {
   const onToggleLayer = useCallback(
     (dataview: UrlDataviewInstance) => () => {
       const isVisible = dataview?.config?.visible ?? false
-      const dataset = dataview.datasets?.find((d) => d.type === DatasetTypes.UserContext)
+      const dataset = dataview.datasets?.find(
+        (d) => d.type === DatasetTypes.Context || d.type === DatasetTypes.UserContext
+      )
       const layerTitle = dataset?.name ?? dataset?.id ?? 'Unknown layer'
       const action = isVisible ? 'disable' : 'enable'
       uaEvent({

--- a/apps/fishing-map/features/workspace/environmental/EnvironmentalLayerPanel.tsx
+++ b/apps/fishing-map/features/workspace/environmental/EnvironmentalLayerPanel.tsx
@@ -89,7 +89,7 @@ function EnvironmentalLayerPanel({ dataview, onToggle }: LayerPanelProps): React
   }
 
   const dataset = dataview.datasets?.find(
-    (d) => d.type === DatasetTypes.Fourwings || d.type === DatasetTypes.Context
+    (d) => d.type === DatasetTypes.Fourwings || d.type === DatasetTypes.UserContext
   )
   useAutoRefreshImportingDataset(dataset)
   const isCustomUserLayer = !guestUser && dataset?.ownerId === userId

--- a/apps/fishing-map/features/workspace/environmental/histogram.hooks.ts
+++ b/apps/fishing-map/features/workspace/environmental/histogram.hooks.ts
@@ -20,7 +20,7 @@ export const useDataviewHistogram = (dataview: UrlDataviewInstance) => {
   const layerFeature = useMapDataviewFeatures(dataview)?.[0]
   const sourcesLoaded = areDataviewsFeatureLoaded(layerFeature)
   const dataset = dataview.datasets?.find(
-    (d) => d.type === DatasetTypes.Fourwings || d.type === DatasetTypes.Context
+    (d) => d.type === DatasetTypes.Fourwings || d.type === DatasetTypes.UserContext
   )
   const [histogram, setHistogram] = useState<any>()
 

--- a/libs/api-types/src/datasets.ts
+++ b/libs/api-types/src/datasets.ts
@@ -91,6 +91,8 @@ export interface DatasetConfiguration {
   format?: 'geojson'
   documentation?: DatasetDocumentation
   fields?: string[]
+  idProperty?: string
+  valueProperties?: string[]
   [key: string]: unknown
 }
 

--- a/libs/api-types/src/datasets.ts
+++ b/libs/api-types/src/datasets.ts
@@ -61,6 +61,7 @@ export enum DatasetTypes {
   Ports = 'ports:v1',
   Tracks = 'tracks:v1',
   Fourwings = '4wings:v1',
+  Context = 'context-layer:v1',
   UserContext = 'user-context-layer:v1',
   TemporalContext = 'temporal-context-layer:v1',
   Download = 'data-download:v1',

--- a/libs/api-types/src/datasets.ts
+++ b/libs/api-types/src/datasets.ts
@@ -26,6 +26,7 @@ export interface EndpointParam {
 }
 
 export enum EndpointId {
+  ContextTiles = 'context-tiles',
   ClusterTiles = 'events-cluster-tiles',
   ContextGeojson = 'temporal-context-geojson',
   Events = 'events',
@@ -60,10 +61,9 @@ export enum DatasetTypes {
   Ports = 'ports:v1',
   Tracks = 'tracks:v1',
   Fourwings = '4wings:v1',
-  Context = 'user-context-layer:v1',
+  UserContext = 'user-context-layer:v1',
   TemporalContext = 'temporal-context-layer:v1',
   Download = 'data-download:v1',
-  // TODO
   UserTracks = 'user-tracks:v1',
 }
 

--- a/libs/api-types/src/dataviews.ts
+++ b/libs/api-types/src/dataviews.ts
@@ -6,6 +6,11 @@ export const INCLUDE_FILTER_ID = 'include'
 export const EXCLUDE_FILTER_ID = 'exclude'
 export type FilterOperator = typeof INCLUDE_FILTER_ID | typeof EXCLUDE_FILTER_ID
 
+export interface DataviewContexLayerConfig {
+  id: string
+  dataset: string
+}
+
 export interface DataviewConfig<Type = any> {
   // TODO use any property from layer-composer here?
   type?: Type
@@ -16,6 +21,7 @@ export interface DataviewConfig<Type = any> {
   filterOperators?: Record<string, FilterOperator>
   dynamicBreaks?: boolean
   maxZoom?: number
+  layers?: DataviewContexLayerConfig[]
   [key: string]: any
 }
 

--- a/libs/dataviews-client/src/resolve-dataviews-generators.ts
+++ b/libs/dataviews-client/src/resolve-dataviews-generators.ts
@@ -357,7 +357,7 @@ export function getGeneratorConfig(
           ? `${dataview.id}${MULTILAYER_SEPARATOR}${dataview.config.layers}`
           : dataview.id
         generator.layer = dataview.config.layers
-        const { dataset, url } = resolveDataviewDatasetResource(dataview, DatasetTypes.Context)
+        const { dataset, url } = resolveDataviewDatasetResource(dataview, DatasetTypes.UserContext)
         if (dataset?.status !== DatasetStatus.Done) {
           return []
         }

--- a/libs/dataviews-client/src/resolve-dataviews-generators.ts
+++ b/libs/dataviews-client/src/resolve-dataviews-generators.ts
@@ -336,28 +336,38 @@ export function getGeneratorConfig(
             dataset
           )
           if (!url || resolvedDataset?.status !== DatasetStatus.Done) return []
+
           return {
             id,
             tilesUrl: url,
             attribution: getDatasetAttribution(resolvedDataset),
             datasetId: resolvedDataset.id,
+            promoteId: resolvedDataset?.configuration?.idProperty,
+            valueProperties: resolvedDataset?.configuration?.valueProperties,
           }
         })
         // Duplicated generators when context dataview have multiple layers
-        return tilesUrls.map(({ id, tilesUrl, attribution, datasetId }) => ({
-          ...generator,
-          id: `${dataview.id}${MULTILAYER_SEPARATOR}${id}`,
-          layer: id,
-          attribution,
-          tilesUrl,
-          datasetId,
-        }))
+        return tilesUrls.map(
+          ({ id, tilesUrl, attribution, datasetId, promoteId, valueProperties }) => ({
+            ...generator,
+            id: `${dataview.id}${MULTILAYER_SEPARATOR}${id}`,
+            layer: id,
+            attribution,
+            tilesUrl,
+            datasetId,
+            promoteId,
+            valueProperties,
+          })
+        )
       } else {
         generator.id = dataview.config.layers
           ? `${dataview.id}${MULTILAYER_SEPARATOR}${dataview.config.layers}`
           : dataview.id
         generator.layer = dataview.config.layers
-        const { dataset, url } = resolveDataviewDatasetResource(dataview, DatasetTypes.UserContext)
+        const { dataset, url } = resolveDataviewDatasetResource(dataview, [
+          DatasetTypes.Context,
+          DatasetTypes.UserContext,
+        ])
         if (dataset?.status !== DatasetStatus.Done) {
           return []
         }

--- a/libs/layer-composer/src/generators/context/config.ts
+++ b/libs/layer-composer/src/generators/context/config.ts
@@ -1,1 +1,2 @@
+export const DEFAULT_CONTEXT_PROMOTE_ID = 'gfw_id'
 export const DEFAULT_CONTEXT_SOURCE_LAYER = 'main'

--- a/libs/layer-composer/src/generators/context/context.ts
+++ b/libs/layer-composer/src/generators/context/context.ts
@@ -15,7 +15,7 @@ import {
   getFillPaintWithFeatureState,
   getLinePaintWithFeatureState,
 } from './context.utils'
-import { DEFAULT_CONTEXT_SOURCE_LAYER } from './config'
+import { DEFAULT_CONTEXT_PROMOTE_ID, DEFAULT_CONTEXT_SOURCE_LAYER } from './config'
 
 const getPaintPropertyByType = (layer: LayerSpecification, config: any) => {
   const opacity = config.opacity !== undefined ? config.opacity : 1
@@ -73,7 +73,7 @@ class ContextGenerator {
       {
         id: getContextSourceId(config),
         type: 'vector',
-        promoteId: 'gfw_id',
+        promoteId: config.promoteId || DEFAULT_CONTEXT_PROMOTE_ID,
         tiles: [tilesUrl.replace(/{{/g, '{').replace(/}}/g, '}')],
         ...(config.attribution && { attribution: config.attribution }),
       },
@@ -111,6 +111,8 @@ class ContextGenerator {
           layer: config.layer,
           generatorId: config.id,
           datasetId: config.datasetId,
+          promoteId: config.promoteId || DEFAULT_CONTEXT_PROMOTE_ID,
+          valueProperties: config.valueProperties,
         },
       }
     })

--- a/libs/layer-composer/src/generators/types.ts
+++ b/libs/layer-composer/src/generators/types.ts
@@ -159,6 +159,14 @@ export interface ContextGeneratorConfig extends GeneratorConfig {
    */
   datasetId?: string
   /**
+   * Property to use as id internally in mapbox
+   */
+  promoteId?: string
+  /**
+   * Properties to be used as value
+   */
+  valueProperties?: string[]
+  /**
    * Url to grab the tiles from, internally using https://docs.mapbox.com/mapbox-gl-js/style-spec/sources/#vector-tiles
    */
   tilesUrl: string

--- a/libs/layer-composer/src/types/index.ts
+++ b/libs/layer-composer/src/types/index.ts
@@ -98,6 +98,8 @@ export interface ExtendedLayerMeta {
   datasetId?: string
   generatorId?: string
   generatorType?: GeneratorType
+  promoteId?: string
+  valueProperties?: string[]
   interactive?: boolean
   uniqueFeatureInteraction?: boolean
   group?: Group

--- a/libs/react-hooks/src/use-map-interaction/use-map-interaction.ts
+++ b/libs/react-hooks/src/use-map-interaction/use-map-interaction.ts
@@ -57,6 +57,15 @@ const getExtendedFeatures = (
 
     const uniqueFeatureInteraction = feature.layer?.metadata?.uniqueFeatureInteraction ?? false
     const properties = feature.properties || {}
+    const promoteIdValue =
+      feature.layer.metadata?.promoteId && feature.properties[feature.layer.metadata?.promoteId]
+    let value = properties.value || properties.name || properties.id
+    if (feature.layer.metadata?.valueProperties?.length) {
+      value = feature.layer.metadata.valueProperties
+        .flatMap((prop) => properties[prop] || [])
+        .join(', ')
+    }
+
     const extendedFeature: ExtendedFeature | null = {
       properties,
       generatorType,
@@ -65,8 +74,8 @@ const getExtendedFeatures = (
       source: feature.source,
       sourceLayer: feature.sourceLayer,
       uniqueFeatureInteraction,
-      id: (feature.id as number) || feature.properties?.gfw_id || undefined,
-      value: properties.value || properties.name || properties.id,
+      id: (feature.id as number) || feature.properties?.gfw_id || promoteIdValue || undefined,
+      value,
       tile: {
         x: (feature as any)._vectorTileFeature._x,
         y: (feature as any)._vectorTileFeature._y,
@@ -143,14 +152,15 @@ const getExtendedFeatures = (
         })
       case GeneratorType.Context:
       case GeneratorType.UserPoints:
-      case GeneratorType.UserContext:
+      case GeneratorType.UserContext: {
         return {
           ...extendedFeature,
-          gfwId: feature.properties?.gfw_id,
           datasetId: feature.layer.metadata?.datasetId,
+          promoteId: feature.layer.metadata?.promoteId,
           generatorContextLayer: feature.layer.metadata?.layer,
           geometry: feature.geometry,
         }
+      }
       default:
         return extendedFeature
     }


### PR DESCRIPTION
⚠️ Blocked by https://github.com/GlobalFishingWatch/gfw-terraform-api/pull/60

Use the new DatasetType and dataset configuration to render static tiles with:
- `idProperty` as promoteId in mapbox to replace the missing gfw_id
- `valueProperties` as value in the tooltips
