### PR TITLE
fix resolve dataviews with legacy ids

### DIFF
--- a/libs/dataviews-client/src/resolve-dataviews.ts
+++ b/libs/dataviews-client/src/resolve-dataviews.ts
@@ -256,12 +256,13 @@ export function resolveDataviews(
       if (dataviewInstance?.deleted) {
         return []
       }
-
-      const dataview = dataviews?.find((dataview) =>
-        ([dataview.id, dataview.slug] as Dataview['slug'][]).includes(
-          dataviewInstance.dataviewId as Dataview['slug']
+      const dataview = dataviews?.find((dataview) => {
+        return (
+          dataview.slug === dataviewInstance.dataviewId ||
+          // We need to parse the dataviewId as a string because now it is always a string to support slugs
+          dataview.id === parseInt(dataviewInstance.dataviewId as string, 10)
         )
-      )
+      })
       if (!dataview) {
         console.warn(
           `DataviewInstance id: ${dataviewInstance.id} doesn't have a valid dataview (${dataviewInstance.dataviewId})`


### PR DESCRIPTION
Fixes `DataviewInstance id: [xxxx] doesn't have a valid dataview ([number])` as the dataviewId now is a string and needs to be parsed