### PR TITLE
read endpoint pathTemplate to retrieve context feature

### DIFF
--- a/apps/fishing-map/features/analysis/analysis.hooks.ts
+++ b/apps/fishing-map/features/analysis/analysis.hooks.ts
@@ -46,6 +46,7 @@ import {
 } from 'features/areas/areas.slice'
 import { useAppDispatch } from 'features/app/app.hooks'
 import { getUTCDateTime } from 'utils/dates'
+import { selectDatasetById } from 'features/datasets/datasets.slice'
 import { filterByPolygon } from './analysis-geo.utils'
 import { AnalysisGraphProps } from './AnalysisEvolutionGraph'
 import { selectAnalysisArea, selectShowTimeComparison } from './analysis.selectors'
@@ -107,6 +108,7 @@ export const useAnalysisArea = () => {
   const { updateFeatureState, cleanFeatureState } = useFeatureState(map)
   const contextDataviews = useSelector(selectContextAreasDataviews)
   const { areaId, sourceId, datasetId } = useSelector(selectAnalysisQuery)
+  const analysisDataset = useSelector(selectDatasetById(datasetId))
   const analysisArea = useSelector(selectAnalysisArea)
   const { status, data: { bounds } = {} } = analysisArea || ({} as DatasetAreaDetail)
 
@@ -155,10 +157,10 @@ export const useAnalysisArea = () => {
 
   const areaName = contextDataviews?.find(({ id }) => id === sourceId)?.datasets?.[0].name
   useEffect(() => {
-    if (areaId && datasetId) {
-      fetchAnalysisArea({ datasetId, areaId, areaName })
+    if (areaId && analysisDataset) {
+      fetchAnalysisArea({ dataset: analysisDataset, areaId, areaName })
     }
-  }, [areaId, datasetId, fetchAnalysisArea, areaName])
+  }, [areaId, analysisDataset, fetchAnalysisArea, areaName])
 
   useEffect(() => {
     if (status === AsyncReducerStatus.Finished) {

--- a/apps/fishing-map/features/dataviews/dataviews.utils.ts
+++ b/apps/fishing-map/features/dataviews/dataviews.utils.ts
@@ -131,7 +131,7 @@ export const getEnvironmentDataviewInstance = (
       {
         datasetId,
         params: [],
-        endpoint: EndpointId.UserContextTiles,
+        endpoint: EndpointId.ContextTiles,
       },
     ],
   }
@@ -149,7 +149,7 @@ export const getUserPointsDataviewInstance = (
     datasetsConfig: [
       {
         datasetId: datasetId,
-        endpoint: EndpointId.UserContextTiles,
+        endpoint: EndpointId.ContextTiles,
         params: [{ id: 'id', value: datasetId }],
       },
     ],
@@ -187,7 +187,7 @@ export const getContextDataviewInstance = (datasetId: string): DataviewInstance<
       {
         datasetId,
         params: [],
-        endpoint: EndpointId.UserContextTiles,
+        endpoint: EndpointId.ContextTiles,
       },
     ],
   }

--- a/apps/fishing-map/features/map/popups/ContextLayers.hooks.ts
+++ b/apps/fishing-map/features/map/popups/ContextLayers.hooks.ts
@@ -14,6 +14,8 @@ import { fetchAreaDetailThunk } from 'features/areas/areas.slice'
 import { useAppDispatch } from 'features/app/app.hooks'
 import { setDownloadActivityAreaKey } from 'features/download/downloadActivity.slice'
 import useMapInstance from 'features/map/map-context.hooks'
+import { Bbox } from 'types'
+import { selectAllDatasets } from 'features/datasets/datasets.slice'
 import { setClickedEvent } from '../map.slice'
 import { TooltipEventFeature } from '../map.hooks'
 import { useMapFitBounds } from '../map-viewport.hooks'
@@ -36,6 +38,7 @@ export const useContextInteractions = () => {
   const isSidebarOpen = useSelector(selectSidebarOpen)
   const { dispatchQueryParams } = useLocationConnect()
   const { areaId, sourceId } = useSelector(selectAnalysisQuery) || {}
+  const datasets = useSelector(selectAllDatasets)
   const { cleanFeatureState } = useFeatureState(useMapInstance())
   const fitMapBounds = useMapFitBounds()
 
@@ -48,16 +51,19 @@ export const useContextInteractions = () => {
       }
 
       const datasetId = feature.datasetId
-      const areaName = feature.value || feature.title
-      batch(() => {
-        dispatch(setDownloadActivityAreaKey({ datasetId, areaId }))
-        dispatch(setClickedEvent(null))
-      })
-      dispatch(fetchAreaDetailThunk({ datasetId, areaId, areaName }))
+      const dataset = datasets.find((d) => d.id === datasetId)
+      if (dataset) {
+        const areaName = feature.value || feature.title
+        batch(() => {
+          dispatch(setDownloadActivityAreaKey({ datasetId, areaId }))
+          dispatch(setClickedEvent(null))
+        })
+        dispatch(fetchAreaDetailThunk({ dataset, areaId, areaName }))
+      }
 
       cleanFeatureState('highlight')
     },
-    [cleanFeatureState, dispatch]
+    [cleanFeatureState, dispatch, datasets]
   )
 
   const setAnalysisArea = useCallback(

--- a/libs/api-types/src/datasets.ts
+++ b/libs/api-types/src/datasets.ts
@@ -27,6 +27,7 @@ export interface EndpointParam {
 
 export enum EndpointId {
   ContextTiles = 'context-tiles',
+  ContextFeature = 'context-feature',
   ClusterTiles = 'events-cluster-tiles',
   ContextGeojson = 'temporal-context-geojson',
   Events = 'events',
@@ -36,7 +37,6 @@ export enum EndpointId {
   FourwingsLegend = '4wings-legend',
   FourwingsTiles = '4wings-tiles',
   Tracks = 'tracks',
-  UserContextTiles = 'user-context-tiles',
   UserTracks = 'user-tracks-data',
   Vessel = 'vessel',
   VesselAdvancedSearch = 'advanced-search-vessels',


### PR DESCRIPTION
Fixes [missing area names](https://globalfishingwatch.atlassian.net/browse/MAP-1089) resolving the proper url to fetch area details.
Blocked by https://github.com/GlobalFishingWatch/api-datasets/pull/88