### PR TITLE
fetch only datasets defined in dataview

### DIFF
--- a/apps/fishing-map/features/workspace/workspace.slice.ts
+++ b/apps/fishing-map/features/workspace/workspace.slice.ts
@@ -166,7 +166,7 @@ export const fetchWorkspaceThunk = createAsyncThunk(
           ...(workspace.dataviewInstances || []),
           ...(urlDataviewInstances || []),
         ]
-        const datasetsIds = getDatasetsInDataviews([...dataviews, ...dataviewInstances], guestUser)
+        const datasetsIds = getDatasetsInDataviews(dataviews, dataviewInstances, guestUser)
         const fetchDatasetsAction: any = dispatch(fetchDatasetsByIdsThunk(datasetsIds))
         signal.addEventListener('abort', fetchDatasetsAction.abort)
         const { error, payload: datasets } = await fetchDatasetsAction


### PR DESCRIPTION
This fixes GFW Staff sharing workspaces with guests as they include gaps as a related dataset (even if it is not used in the map yet)