### PR TITLE
Support workspaces with less delay than default of 3 days

### DIFF
--- a/apps/fishing-map/data/config.ts
+++ b/apps/fishing-map/data/config.ts
@@ -52,10 +52,7 @@ export const USER_SUFIX = 'user'
 export const PRIVATE_SUFIX = 'private'
 
 // used when no url data and no workspace data
-export const LAST_DATA_UPDATE = DateTime.fromObject(
-  { hour: 0, minute: 0, second: 0 },
-  { zone: 'utc' }
-)
+const LAST_DATA_UPDATE = DateTime.fromObject({ hour: 0, minute: 0, second: 0 }, { zone: 'utc' })
   .minus({ days: 3 })
   .toISO()
 

--- a/apps/fishing-map/features/app/app.selectors.ts
+++ b/apps/fishing-map/features/app/app.selectors.ts
@@ -67,6 +67,20 @@ export const selectTimeRange = createSelector(
   }
 )
 
+export function isWorkspaceWithLessDelayThanDefault(endAt: string): boolean {
+  if (!endAt) return false
+  return endAt > DEFAULT_TIME_RANGE.end
+}
+
+export const selectLatestAvailableDate = createSelector(
+  [selectWorkspaceTimeRange],
+  (workspaceTimerange) => {
+    return isWorkspaceWithLessDelayThanDefault(workspaceTimerange.end)
+      ? workspaceTimerange.end
+      : DEFAULT_TIME_RANGE.end
+  }
+)
+
 export const selectReportTimeComparison = createSelector(
   [selectWorkspaceStateProperty('reportTimeComparison')],
   (reportTimeComparison): ReportActivityTimeComparison => {

--- a/apps/fishing-map/features/reports/activity/ReportActivityPeriodComparisonGraph.tsx
+++ b/apps/fishing-map/features/reports/activity/ReportActivityPeriodComparisonGraph.tsx
@@ -13,12 +13,11 @@ import {
 import { Interval as TimeInterval } from 'luxon'
 import { useSelector } from 'react-redux'
 import { Interval } from '@globalfishingwatch/layer-composer'
-import { selectReportTimeComparison } from 'features/app/app.selectors'
+import { selectLatestAvailableDate, selectReportTimeComparison } from 'features/app/app.selectors'
 import i18n, { t } from 'features/i18n/i18n'
 import { COLOR_GRADIENT, COLOR_PRIMARY_BLUE } from 'features/app/App'
 import { getUTCDateTime } from 'utils/dates'
 import { formatDate, formatTooltipValue, tickFormatter } from 'features/reports/reports.utils'
-import { LAST_DATA_UPDATE } from 'data/config'
 import styles from './ReportActivityEvolution.module.css'
 
 const DIFFERENCE = 'difference'
@@ -126,17 +125,18 @@ const ReportActivityPeriodComparisonGraph: React.FC<{
   const { start, end } = props
   const { interval, timeseries, sublayers } = props.data
   const timeComparison = useSelector(selectReportTimeComparison)
+  const latestAvailableDate = useSelector(selectLatestAvailableDate)
 
   const unit = useMemo(() => {
     return sublayers?.[0]?.legend?.unit
   }, [sublayers])
 
   const dtLastDataUpdate = useMemo(() => {
-    return getUTCDateTime(LAST_DATA_UPDATE)
-  }, [])
+    return getUTCDateTime(latestAvailableDate)
+  }, [latestAvailableDate])
 
   const offsetedLastDataUpdate = useMemo(() => {
-    // Need to offset LAST_DATA_UPDATE because graph uses dates from start, not compareStart
+    // Need to offset latestAvailableDate because graph uses dates from start, not compareStart
     if (timeComparison) {
       const diff = getUTCDateTime(timeComparison.compareStart)
         .diff(getUTCDateTime(timeComparison.start))

--- a/apps/fishing-map/features/timebar/Timebar.tsx
+++ b/apps/fishing-map/features/timebar/Timebar.tsx
@@ -23,10 +23,14 @@ import {
   useDisableHighlightTimeConnect,
   useActivityMetadata,
 } from 'features/timebar/timebar.hooks'
-import { DEFAULT_WORKSPACE, LAST_DATA_UPDATE } from 'data/config'
+import { DEFAULT_WORKSPACE } from 'data/config'
 import { TimebarVisualisations } from 'types'
 import useViewport from 'features/map/map-viewport.hooks'
-import { selectTimebarGraph, selectTimebarVisualisation } from 'features/app/app.selectors'
+import {
+  selectLatestAvailableDate,
+  selectTimebarGraph,
+  selectTimebarVisualisation,
+} from 'features/app/app.selectors'
 import { getEventLabel } from 'utils/analytics'
 import { upperFirst } from 'utils/info'
 import { selectShowTimeComparison } from 'features/reports/reports.selectors'
@@ -140,6 +144,7 @@ const TimebarWrapper = () => {
   const showTimeComparison = useSelector(selectShowTimeComparison)
   const vesselGroupsFiltering = useSelector(selectIsVessselGroupsFiltering)
   const isReportLocation = useSelector(selectIsReportLocation)
+  const latestAvailableDate = useSelector(selectLatestAvailableDate)
   const dispatch = useAppDispatch()
 
   const [bookmark, setBookmark] = useState<{ start: string; end: string } | null>(null)
@@ -324,7 +329,7 @@ const TimebarWrapper = () => {
         end={internalRange ? internalRange.end : end}
         absoluteStart={DEFAULT_WORKSPACE.availableStart}
         absoluteEnd={DEFAULT_WORKSPACE.availableEnd}
-        latestAvailableDataDate={LAST_DATA_UPDATE}
+        latestAvailableDataDate={latestAvailableDate}
         onChange={onChange}
         showLastUpdate={false}
         onMouseMove={onMouseMove}

--- a/apps/fishing-map/features/workspace/workspace.slice.ts
+++ b/apps/fishing-map/features/workspace/workspace.slice.ts
@@ -27,7 +27,10 @@ import {
 } from 'routes/routes.selectors'
 import { HOME, REPORT, ROUTE_TYPES, WORKSPACE } from 'routes/routes'
 import { cleanQueryLocation, updateLocation, updateQueryParam } from 'routes/routes.actions'
-import { selectDaysFromLatest } from 'features/app/app.selectors'
+import {
+  isWorkspaceWithLessDelayThanDefault,
+  selectDaysFromLatest,
+} from 'features/app/app.selectors'
 import {
   DEFAULT_DATAVIEW_SLUGS,
   ONLY_GFW_STAFF_DATAVIEW_SLUGS,
@@ -130,9 +133,10 @@ export const fetchWorkspaceThunk = createAsyncThunk(
 
       const daysFromLatest =
         selectDaysFromLatest(state) || workspace.state?.daysFromLatest || undefined
+      const isWorkspaceWithLessDelay = isWorkspaceWithLessDelayThanDefault(workspace.endAt)
       const endAt =
         daysFromLatest !== undefined
-          ? getUTCDateTime(DEFAULT_TIME_RANGE.end)
+          ? getUTCDateTime(isWorkspaceWithLessDelay ? workspace.endAt : DEFAULT_TIME_RANGE.end)
           : getUTCDateTime(workspace.endAt || DEFAULT_TIME_RANGE.end)
       const startAt =
         daysFromLatest !== undefined


### PR DESCRIPTION
Now the app supports a workspace with an `endAt` bigger than the `LAST_DATA_UPDATE` to fix the `private_papua_new_guinea` workspace

![image](https://user-images.githubusercontent.com/10500650/233588191-dff155e9-71b9-45c7-bc97-3086b664ce93.png)
