### PR TITLE
recalculate timebar graph on mode change

### DIFF
--- a/apps/fishing-map/features/map/map-sources.hooks.ts
+++ b/apps/fishing-map/features/map/map-sources.hooks.ts
@@ -172,23 +172,31 @@ type DataviewMetadata = {
 }
 
 // Key used to refresh activity graph only when active chunk changes and we can safely ignore the rest of the metadata
-function getGeneratorsMetadataChangeKey(generatorsMetadata: Record<string, HeatmapLayerMeta> = {}) {
-  if (!generatorsMetadata) return ''
+function getGeneratorsMetadataChangeKey(
+  style: ExtendedStyle,
+  dataviews: UrlDataviewInstance | UrlDataviewInstance[]
+) {
+  const generatorsMetadata = style?.metadata?.generatorsMetadata
+  const dataviewIds = toArray(dataviews || []).map(({ id }) => id)
+  if (!generatorsMetadata || !dataviewIds?.length) return ''
   return Object.keys(generatorsMetadata)
-    .map((key) => {
+    .flatMap((key) => {
       const metadata = generatorsMetadata[key]
-      const timeChunks = [
-        metadata.timeChunks.activeSourceId,
-        (metadata.timeChunks.chunks || [])
-          .map(({ active, sourceId, quantizeOffset }) => [
-            active,
-            sourceId,
-            quantizeOffset,
-            (metadata.sublayers || []).map((s) => s.id).join(','),
-          ])
-          .join('|'),
-      ].join('-')
-      return [metadata.sourceLayer, timeChunks, metadata.visibleSublayers].join('_')
+      if (metadata.sublayers.some((s) => dataviewIds.includes(s.id))) {
+        const timeChunks = [
+          metadata.timeChunks.activeSourceId,
+          (metadata.timeChunks.chunks || [])
+            .map(({ active, sourceId, quantizeOffset }) => [
+              active,
+              sourceId,
+              quantizeOffset,
+              (metadata.sublayers || []).map((s) => s.id).join(','),
+            ])
+            .join('|'),
+        ].join('-')
+        return [metadata.sourceLayer, timeChunks, metadata.visibleSublayers].join('_')
+      }
+      return []
     })
     .join('+')
 }
@@ -207,7 +215,7 @@ export const useMapDataviewFeatures = (
 
   // Memoized to avoid re-runs on style changes like hovers
   const memoizedDataviews = useMemoCompare(dataviews)
-  const metadataKey = getGeneratorsMetadataChangeKey(style?.metadata?.generatorsMetadata)
+  const metadataKey = getGeneratorsMetadataChangeKey(style, memoizedDataviews)
 
   const dataviewsMetadata = useMemo(() => {
     const dataviewsArray = toArray(memoizedDataviews || [])

--- a/apps/fishing-map/features/timebar/TimebarActivityGraph.hooks.ts
+++ b/apps/fishing-map/features/timebar/TimebarActivityGraph.hooks.ts
@@ -24,6 +24,7 @@ export const useStackedActivity = (dataviews: UrlDataviewInstance[]) => {
   const dataviewFeatures = useMapDataviewFeatures(dataviews)
   const error = hasDataviewsFeatureError(dataviewFeatures)
   const boundsChanged = !checkEqualBounds(bounds, debouncedBounds)
+  const layersSourceHash = dataviewFeatures.map(({ sourceId }) => sourceId).join(',')
   const layersFilterHash = dataviewFeatures
     .flatMap(({ metadata }) => `${metadata?.minVisibleValue}-${metadata?.maxVisibleValue}`)
     .join(',')
@@ -72,7 +73,7 @@ export const useStackedActivity = (dataviews: UrlDataviewInstance[]) => {
       debouncedSetStackedActivity(dataviewFeatures, debouncedBounds)
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [dataviewFeaturesLoaded, debouncedBounds, isSmallScreen, layersFilterHash])
+  }, [dataviewFeaturesLoaded, debouncedBounds, isSmallScreen, layersSourceHash, layersFilterHash])
 
   return { loading, error, stackedActivity }
 }


### PR DESCRIPTION
Before:

https://github.com/GlobalFishingWatch/frontend/assets/10500650/5a4795c9-f817-40eb-935d-0cd7388bc159

After:

https://github.com/GlobalFishingWatch/frontend/assets/10500650/28185556-b1dd-41d4-9a06-c4f4c6dce3eb

Extra: the metadata hash is calculated only with the sublayers visible