### PR TITLE
save data status by type

### DIFF
--- a/apps/fishing-map/features/map/map-layers.hooks.ts
+++ b/apps/fishing-map/features/map/map-layers.hooks.ts
@@ -1,7 +1,6 @@
 import { useSelector } from 'react-redux'
 import { useMemo } from 'react'
-import { useDeckLayerComposer, useVesselLayers } from '@globalfishingwatch/deck-layers'
-import { UrlDataviewInstance } from '@globalfishingwatch/dataviews-client'
+import { useDeckLayerComposer } from '@globalfishingwatch/deck-layers'
 import { useGeneratorsConnect, useGeneratorsDictionaryConnect } from 'features/map/map.hooks'
 import { selectHighlightedTime } from 'features/timebar/timebar.slice'
 import { useHighlightedEventsConnect } from 'features/timebar/timebar.hooks'
@@ -25,11 +24,4 @@ export const useMapDeckLayers = () => {
   })
 
   return layers
-}
-
-export const useMapVesselLayer = (dataview: UrlDataviewInstance) => {
-  const vesselLayers = useVesselLayers()
-  return useMemo(() => {
-    return vesselLayers.find((d) => d.id === dataview.id)
-  }, [dataview, vesselLayers])
 }

--- a/apps/fishing-map/features/map/map-layers.hooks.ts
+++ b/apps/fishing-map/features/map/map-layers.hooks.ts
@@ -1,6 +1,7 @@
 import { useSelector } from 'react-redux'
 import { useMemo } from 'react'
-import { useDeckLayerComposer } from '@globalfishingwatch/deck-layers'
+import { useDeckLayerComposer, useVesselLayers } from '@globalfishingwatch/deck-layers'
+import { UrlDataviewInstance } from '@globalfishingwatch/dataviews-client'
 import { useGeneratorsConnect, useGeneratorsDictionaryConnect } from 'features/map/map.hooks'
 import { selectHighlightedTime } from 'features/timebar/timebar.slice'
 import { useHighlightedEventsConnect } from 'features/timebar/timebar.hooks'
@@ -24,4 +25,11 @@ export const useMapDeckLayers = () => {
   })
 
   return layers
+}
+
+export const useMapVesselLayer = (dataview: UrlDataviewInstance) => {
+  const vesselLayers = useVesselLayers()
+  return useMemo(() => {
+    return vesselLayers.find((d) => d.id === dataview.id)
+  }, [dataview, vesselLayers])
 }

--- a/apps/fishing-map/features/timebar/timebar-vessel.hooks.ts
+++ b/apps/fishing-map/features/timebar/timebar-vessel.hooks.ts
@@ -21,26 +21,26 @@ export const useTimebarVesselTracks = () => {
   useEffect(() => {
     requestAnimationFrame(() => {
       if (vessels?.length) {
-        const vesselTracks = vessels.flatMap((vessel) => {
-          if (!vessel.props.visible) {
+        const vesselTracks = vessels.flatMap(({ instance }) => {
+          if (!instance.props.visible) {
             return []
           }
-          const segments = vessel.getVesselTrackSegments()
+          const segments = instance.getVesselTrackSegments()
           const chunks = segments?.map((t) => {
             const start = t[0]?.timestamp
             const end = t[t.length - 1]?.timestamp
             return {
               start,
               end,
-              props: { color: vessel.getVesselColor() },
+              props: { color: instance.getVesselColor() },
               values: t,
             }
           })
           return {
             status: ResourceStatus.Finished,
             chunks,
-            color: vessel.getVesselColor(),
-            defaultLabel: vessel.getVesselName() || '',
+            color: instance.getVesselColor(),
+            defaultLabel: instance.getVesselName() || '',
             getHighlighterLabel: getUserTrackHighlighterLabel,
             getHighlighterIcon: 'vessel',
           }
@@ -73,16 +73,16 @@ export const useTimebarVesselEvents = () => {
   useEffect(() => {
     requestAnimationFrame(() => {
       if (vessels.length) {
-        const vesselEvents: TimebarChartData<any> = vessels.flatMap((vessel) => {
-          if (!vessel.props.visible) {
+        const vesselEvents: TimebarChartData<any> = vessels.flatMap(({ instance, dataStatus }) => {
+          if (!instance.props.visible) {
             return []
           }
-          const chunks = vessel.getVesselEventsData(vessel.props.visibleEvents) as any
+          const chunks = instance.getVesselEventsData(instance.props.visibleEvents) as any
           return {
-            color: vessel.getVesselColor(),
+            color: instance.getVesselColor(),
             chunks,
-            status: ResourceStatus.Finished,
-            defaultLabel: vessel.getVesselName(),
+            status: dataStatus.find((s) => s.type === 'track')?.status,
+            defaultLabel: instance.getVesselName(),
             getHighlighterLabel: getTrackEventHighlighterLabel,
             getHighlighterIcon: 'vessel',
           }

--- a/apps/fishing-map/features/workspace/vessels/VesselLayerPanel.tsx
+++ b/apps/fishing-map/features/workspace/vessels/VesselLayerPanel.tsx
@@ -38,6 +38,7 @@ import { selectPrivateUserGroups } from 'features/user/user.selectors'
 import { useLayerPanelDataviewSort } from 'features/workspace/shared/layer-panel-sort.hook'
 import GFWOnly from 'features/user/GFWOnly'
 import DatasetLabel from 'features/datasets/DatasetLabel'
+import { useMapVesselLayer } from 'features/map/map-layers.hooks'
 import Color from '../common/Color'
 import LayerSwitch from '../common/LayerSwitch'
 import Remove from '../common/Remove'
@@ -55,6 +56,7 @@ function LayerPanel({ dataview }: LayerPanelProps): React.ReactElement {
   const { upsertDataviewInstance } = useDataviewInstancesConnect()
   const { url: infoUrl } = resolveDataviewDatasetResource(dataview, DatasetTypes.Vessels)
   const resources = useSelector(selectResources)
+  const vesselInstance = useMapVesselLayer(dataview)
   const trackResource = pickTrackResource(dataview, EndpointId.Tracks, resources)
   const infoResource: Resource<Vessel> = useSelector(selectResourceByUrl<Vessel>(infoUrl))
   const { items, attributes, listeners, setNodeRef, setActivatorNodeRef, style } =
@@ -99,12 +101,13 @@ function LayerPanel({ dataview }: LayerPanelProps): React.ReactElement {
     }
   }
 
-  const trackLoading = trackResource?.status === ResourceStatus.Loading
+  const vesselTrackData = vesselInstance?.dataStatus.find((l) => l.type === 'track')
+  const trackLoading = vesselTrackData?.status === ResourceStatus.Loading
   const infoLoading = infoResource?.status === ResourceStatus.Loading
   const loading = trackLoading || infoLoading
 
   const infoError = infoResource?.status === ResourceStatus.Error
-  const trackError = trackResource?.status === ResourceStatus.Error
+  const trackError = vesselTrackData?.status === ResourceStatus.Error
 
   const vesselLabel = infoResource?.data ? getVesselLabel(infoResource.data) : ''
   const vesselId =

--- a/apps/fishing-map/features/workspace/vessels/VesselLayerPanel.tsx
+++ b/apps/fishing-map/features/workspace/vessels/VesselLayerPanel.tsx
@@ -17,6 +17,7 @@ import {
   pickTrackResource,
   selectResources,
 } from '@globalfishingwatch/dataviews-client'
+import { useMapVesselLayer } from '@globalfishingwatch/deck-layers'
 import { EMPTY_FIELD_PLACEHOLDER, formatInfoField, getVesselLabel } from 'utils/info'
 import styles from 'features/workspace/shared/LayerPanel.module.css'
 import { useDataviewInstancesConnect } from 'features/workspace/workspace.hook'
@@ -38,7 +39,6 @@ import { selectPrivateUserGroups } from 'features/user/user.selectors'
 import { useLayerPanelDataviewSort } from 'features/workspace/shared/layer-panel-sort.hook'
 import GFWOnly from 'features/user/GFWOnly'
 import DatasetLabel from 'features/datasets/DatasetLabel'
-import { useMapVesselLayer } from 'features/map/map-layers.hooks'
 import Color from '../common/Color'
 import LayerSwitch from '../common/LayerSwitch'
 import Remove from '../common/Remove'
@@ -56,7 +56,7 @@ function LayerPanel({ dataview }: LayerPanelProps): React.ReactElement {
   const { upsertDataviewInstance } = useDataviewInstancesConnect()
   const { url: infoUrl } = resolveDataviewDatasetResource(dataview, DatasetTypes.Vessels)
   const resources = useSelector(selectResources)
-  const vesselInstance = useMapVesselLayer(dataview)
+  const vesselInstance = useMapVesselLayer(dataview.id)
   const trackResource = pickTrackResource(dataview, EndpointId.Tracks, resources)
   const infoResource: Resource<Vessel> = useSelector(selectResourceByUrl<Vessel>(infoUrl))
   const { items, attributes, listeners, setNodeRef, setActivatorNodeRef, style } =

--- a/libs/deck-layers/src/layers/vessel/VesselEventsLayer.ts
+++ b/libs/deck-layers/src/layers/vessel/VesselEventsLayer.ts
@@ -30,7 +30,6 @@ export type _VesselEventsLayerProps<DataT = any> = {
   getFilterValue: AccessorFunction<DataT, number>
   getPickingInfo?: AccessorFunction<DataT, string>
   onEventsDataLoad?: AccessorFunction<DataT, void>
-  getEventVisibility?: AccessorFunction<DataT, number>
 }
 
 export type VesselEventsLayerProps<DataT = any> = _VesselEventsLayerProps<DataT> &
@@ -55,7 +54,6 @@ const defaultProps: DefaultProps<VesselEventsLayerProps> = {
   getPickingInfo: { type: 'accessor', value: ({ info }) => info },
   zIndex: { type: 'accessor', value: GROUP_ORDER.indexOf(Group.Point) },
   visibleEvents: { type: 'accessor', value: [] },
-  getEventVisibility: { type: 'accessor', value: () => 1 },
 }
 
 export class VesselEventsLayer<DataT = any, ExtraProps = {}> extends ScatterplotLayer<
@@ -74,10 +72,6 @@ export class VesselEventsLayer<DataT = any, ExtraProps = {}> extends Scatterplot
           size: 1,
           accessor: 'getShape',
         },
-        instanceEventsVisibility: {
-          size: 1,
-          accessor: 'getEventVisibility',
-        },
       })
     }
   }
@@ -88,27 +82,21 @@ export class VesselEventsLayer<DataT = any, ExtraProps = {}> extends Scatterplot
       inject: {
         'vs:#decl': `
           attribute float instanceShapes;
-          attribute float instanceEventsVisibility;
           attribute float instanceId;
           varying float vShape;
-          varying float vVisibility;
         `,
         'vs:#main-end': `
           vShape = instanceShapes;
-          vVisibility = instanceEventsVisibility;
         `,
         'fs:#decl': `
           uniform mat3 hueTransform;
           varying float vShape;
-          varying float vVisibility;
           const int SHAPE_SQUARE = 0;
           const int SHAPE_DIAMOND = 1;
         `,
         'fs:DECKGL_FILTER_COLOR': `
           vec2 uv = abs(geometry.uv);
           int shape = int(vShape);
-          int visible = int(vVisibility);
-          if (visible == 0) discard;
           if (shape == SHAPE_SQUARE) {
             if (uv.x > 0.7 || uv.y > 0.7) discard;
           } else if (shape == SHAPE_DIAMOND) {

--- a/libs/deck-layers/src/layers/vessel/VesselLayer.ts
+++ b/libs/deck-layers/src/layers/vessel/VesselLayer.ts
@@ -1,7 +1,20 @@
 import { DataFilterExtension } from '@deck.gl/extensions'
-import { CompositeLayer, Layer, LayersList, LayerProps, Color } from '@deck.gl/core/typed'
+import {
+  CompositeLayer,
+  Layer,
+  LayersList,
+  LayerProps,
+  Color,
+  FilterContext,
+} from '@deck.gl/core/typed'
 // Layers
-import { ApiEvent, EventTypes, EventVessel, Segment } from '@globalfishingwatch/api-types'
+import {
+  ApiEvent,
+  EventTypes,
+  EventVessel,
+  ResourceStatus,
+  Segment,
+} from '@globalfishingwatch/api-types'
 import { parquetLoader } from '../../loaders/vessels/trackLoader'
 import { VesselDeckLayersEventData, vesselEventsLoader } from '../../loaders/vessels/eventsLoader'
 import { VesselDeckLayersEvent } from '../../layer-composer/types/vessel'
@@ -9,100 +22,137 @@ import { deckToHexColor } from '../../utils/colors'
 import { EVENTS_COLORS, VesselEventsLayer, _VesselEventsLayerProps } from './VesselEventsLayer'
 import { VesselTrackLayer, _VesselTrackLayerProps } from './VesselTrackLayer'
 
+export const TRACK_LAYER_TYPE = 'track'
+export type VesselDataStatus = {
+  type: typeof TRACK_LAYER_TYPE | EventTypes
+  status: ResourceStatus
+}
+export type _VesselLayerProps = {
+  name: string
+  color: Color
+  onVesselDataLoad: (layers: VesselDataStatus[]) => void
+}
 export type VesselEventsLayerProps = _VesselEventsLayerProps & { events: VesselDeckLayersEvent[] }
-export type VesselLayerProps = _VesselTrackLayerProps &
-  VesselEventsLayerProps & { name: string; color: Color; layersLoaded: string[] }
+export type VesselLayerProps = _VesselTrackLayerProps & VesselEventsLayerProps & _VesselLayerProps
 
-export const TRACK_LAYER_PREFIX = 'track'
-export const EVENTS_LAYER_PREFIX = 'events'
 export class VesselLayer extends CompositeLayer<VesselLayerProps & LayerProps> {
-  layersLoaded: string[] = []
   layers: Layer[] = []
-  data = []
+  dataStatus: VesselDataStatus[] = []
 
-  onSublayerLoad: LayerProps['onDataLoad'] = (data, context) => {
-    const vesselLayer = context.layer.parent as VesselLayer
-    vesselLayer?.layersLoaded?.push(context.layer.id)
-    const isLastLayer = vesselLayer?.layersLoaded?.length === vesselLayer?.layers.length - 1
-    if (isLastLayer) {
-      vesselLayer?.props.onDataLoad && vesselLayer?.props?.onDataLoad(data, context)
+  updateDataStatus = (dataType: VesselDataStatus['type'], status: ResourceStatus) => {
+    this.dataStatus = this.dataStatus.map((l) => ({
+      ...l,
+      status: l.type === dataType ? status : l.status,
+    }))
+    if (this?.props.onVesselDataLoad) {
+      this?.props?.onVesselDataLoad(this.dataStatus)
     }
   }
 
+  onSublayerLoad: LayerProps['onDataLoad'] = (data, context) => {
+    this.updateDataStatus(context.layer.props.type, ResourceStatus.Finished)
+  }
+
+  onSublayerError = (dataType: VesselDataStatus['type'], error: any) => {
+    console.warn(`Error loading ${dataType} in ${this.props.id} layer`, error)
+    this.updateDataStatus(dataType, ResourceStatus.Error)
+  }
+
   _getVesselTrackLayer() {
-    return new VesselTrackLayer<any>({
-      id: `${TRACK_LAYER_PREFIX}-vessel-layer-${this.props.id}`,
-      data: this.props.trackUrl,
-      loaders: [parquetLoader],
-      widthUnits: 'pixels',
-      onDataLoad: this.onSublayerLoad,
-      widthScale: 1,
-      wrapLongitude: true,
-      jointRounded: true,
-      capRounded: true,
-      highlightStartTime: this.props.highlightStartTime,
-      highlightEndTime: this.props.highlightEndTime,
-      startTime: this.props.startTime,
-      endTime: this.props.endTime,
-      _pathType: 'open',
-      getColor: this.props.color,
-      getWidth: 1,
-    })
+    return new VesselTrackLayer<any>(
+      this.getSubLayerProps({
+        id: TRACK_LAYER_TYPE,
+        data: this.props.trackUrl,
+        type: TRACK_LAYER_TYPE,
+        loaders: [parquetLoader],
+        widthUnits: 'pixels',
+        onDataLoad: this.onSublayerLoad,
+        // TODO debug when data loading throws an error this is not triggered
+        onError: (error: any) => this.updateDataStatus(TRACK_LAYER_TYPE, error),
+        widthScale: 1,
+        wrapLongitude: true,
+        jointRounded: true,
+        capRounded: true,
+        highlightStartTime: this.props.highlightStartTime,
+        highlightEndTime: this.props.highlightEndTime,
+        startTime: this.props.startTime,
+        endTime: this.props.endTime,
+        _pathType: 'open',
+        getColor: this.props.color,
+        getWidth: 1,
+      })
+    )
   }
 
   _getVesselEventsLayer(): VesselEventsLayer[] {
-    const { visible, id, visibleEvents, startTime, endTime, highlightEventIds } = this.props
+    const { visibleEvents, startTime, endTime, highlightEventIds } = this.props
     // return one layer with all events if we are consuming the data object from app resources
-    return this.props.events?.map(({ url, type, data }, index) => {
-      return new VesselEventsLayer<VesselDeckLayersEventData[]>({
-        id: `${EVENTS_LAYER_PREFIX}-${id}-${index}`,
-        data: url || data,
-        visible,
-        type,
-        onDataLoad: this.onSublayerLoad,
-        loaders: [vesselEventsLoader],
-        pickable: true,
-        // name,
-        // startTime: startTime,
-        // endTime: endTime,
-        visibleEvents: visibleEvents,
-        getFillColor: (d: any): Color => {
-          if (highlightEventIds?.includes(d.id)) {
-            return EVENTS_COLORS.highlight
-          }
-          return d.type === EventTypes.Fishing ? this.props.color : EVENTS_COLORS[d.type]
-        },
-        // TODO add line border to highlight event
-        // getLineColor: (d: any): Color =>
-        //   d.id === this.props.highlightEventId ? [255, 255, 255, 255] : [0, 0, 0, 0],
-        getEventVisibility: (d: VesselDeckLayersEventData) =>
-          visibleEvents?.includes(d.type) ? 1 : 0,
-        updateTriggers: {
-          getEventVisibility: [visibleEvents],
-          getFillColor: [this.props.highlightEventIds],
-        },
-        radiusMinPixels: 15,
-        getFilterValue: (d: VesselDeckLayersEventData) => [d.start, d.end] as any,
-        filterRange: [[startTime, endTime] as any, [startTime, endTime] as any],
-        extensions: [new DataFilterExtension({ filterSize: 2 }) as any],
-      })
+    return this.props.events?.map(({ url, type, data }) => {
+      return new VesselEventsLayer<VesselDeckLayersEventData[]>(
+        this.getSubLayerProps({
+          id: type,
+          data: url || data,
+          type,
+          onDataLoad: this.onSublayerLoad,
+          onError: (error: any) => this.onSublayerError(type, error),
+          loaders: [vesselEventsLoader],
+          pickable: true,
+          visibleEvents: visibleEvents,
+          getFillColor: (d: any): Color => {
+            if (highlightEventIds?.includes(d.id)) {
+              return EVENTS_COLORS.highlight
+            }
+            return d.type === EventTypes.Fishing ? this.props.color : EVENTS_COLORS[d.type]
+          },
+          // TODO add line border to highlight event
+          // getLineColor: (d: any): Color =>
+          //   d.id === this.props.highlightEventId ? [255, 255, 255, 255] : [0, 0, 0, 0],
+          getEventVisibility: (d: VesselDeckLayersEventData) =>
+            visibleEvents?.includes(d.type) ? 1 : 0,
+          updateTriggers: {
+            getEventVisibility: [visibleEvents],
+            getFillColor: [this.props.highlightEventIds],
+          },
+          radiusMinPixels: 15,
+          getFilterValue: (d: VesselDeckLayersEventData) => [d.start, d.end] as any,
+          filterRange: [[startTime, endTime] as any, [startTime, endTime] as any],
+          extensions: [new DataFilterExtension({ filterSize: 2 }) as any],
+        })
+      )
     })
   }
 
   renderLayers(): Layer<{}> | LayersList {
     this.layers = [this._getVesselTrackLayer(), ...this._getVesselEventsLayer()]
+    if (!this.dataStatus.length) {
+      this.dataStatus = this.layers.map((l) => ({
+        type: l.props.type,
+        status: ResourceStatus.Loading,
+      }))
+    }
     return this.layers
   }
 
+  filterSubLayer(context: FilterContext) {
+    const subLayerType = context.layer.props.type
+    if (subLayerType === TRACK_LAYER_TYPE) {
+      return this.props.visible
+    }
+    if (this.props.visibleEvents?.length) {
+      return this.props.visibleEvents.includes(subLayerType)
+    }
+    return false
+  }
+
   getTrackLayer() {
-    return this.getSubLayers().find((l) => l.id.includes(TRACK_LAYER_PREFIX)) as VesselTrackLayer<
+    return this.getSubLayers().find((l) => l.id.includes(TRACK_LAYER_TYPE)) as VesselTrackLayer<
       Segment[]
     >
   }
 
   getEventLayers() {
-    return this.getSubLayers().filter((l) =>
-      l.id.includes(EVENTS_LAYER_PREFIX)
+    return this.getSubLayers().filter(
+      (l) => !l.id.includes(TRACK_LAYER_TYPE)
     ) as VesselEventsLayer[]
   }
 

--- a/libs/deck-layers/src/layers/vessel/vessel.hooks.ts
+++ b/libs/deck-layers/src/layers/vessel/vessel.hooks.ts
@@ -125,3 +125,10 @@ export const useSetVesselLayers = (
   }, [start, end, highlightEndTime, highlightStartTime, vesselLayersGenerator])
   return useAtomValue(vesselLayersInstancesSelector)
 }
+
+export const useMapVesselLayer = (layerId: string) => {
+  const vesselLayers = useVesselLayers()
+  return useMemo(() => {
+    return vesselLayers.find((d) => d.id === layerId)
+  }, [layerId, vesselLayers])
+}


### PR DESCRIPTION
As we need granularity for the status of the data vessel resources this PRs replaces the atom `layersLoaded` property by a new `dataStatus` one. 
This stores an array of `{ type: 'track' | EventType , status: ResourceStatus }` with every layer loaded. [See example of how to get the status](https://github.com/GlobalFishingWatch/frontend/compare/deck-migration/layers-hooks-review...deck-migration/layers-hooks-data-status?expand=1#diff-b6ec3c581e2855592974c9e919dea4bdd64e083a4913c63492a8e13afda7518bR84)

Pending TODO:
- [ ] Handle data loading errors as I couldn't catch the loader error
- [ ] Reset status if data URL changes