### PR TITLE
make vessel instances shorter in url

### DIFF
--- a/apps/fishing-map/features/dataviews/dataviews.utils.ts
+++ b/apps/fishing-map/features/dataviews/dataviews.utils.ts
@@ -36,33 +36,34 @@ export const ENVIRONMENTAL_LAYER_PREFIX = 'environment-'
 export const CONTEXT_LAYER_PREFIX = 'context-'
 export const VESSEL_DATAVIEW_INSTANCE_PREFIX = 'vessel-'
 
-type VesselInstanceDatasets = {
-  trackDatasetId?: string
-  infoDatasetId?: string
-  eventsDatasetsId?: string[]
+// Datasets ids for vessel instances
+export type VesselInstanceDatasets = {
+  info?: string
+  track?: string
+  events?: string[]
 }
 
 export const getVesselDataviewInstanceDatasetConfig = (
   vesselId: string,
-  { trackDatasetId, infoDatasetId, eventsDatasetsId }: VesselInstanceDatasets
+  { track, info, events }: VesselInstanceDatasets
 ) => {
   const datasetsConfig: DataviewDatasetConfig[] = []
-  if (infoDatasetId) {
+  if (info) {
     datasetsConfig.push({
-      datasetId: infoDatasetId,
+      datasetId: info,
       params: [{ id: 'vesselId', value: vesselId }],
       endpoint: EndpointId.Vessel,
     })
   }
-  if (trackDatasetId) {
+  if (track) {
     datasetsConfig.push({
-      datasetId: trackDatasetId,
+      datasetId: track,
       params: [{ id: 'vesselId', value: vesselId }],
       endpoint: EndpointId.Tracks,
     })
   }
-  if (eventsDatasetsId) {
-    eventsDatasetsId.forEach((eventDatasetId) => {
+  if (events) {
+    events.forEach((eventDatasetId) => {
       datasetsConfig.push({
         datasetId: eventDatasetId,
         query: [{ id: 'vessels', value: vesselId }],
@@ -74,13 +75,17 @@ export const getVesselDataviewInstanceDatasetConfig = (
   return datasetsConfig
 }
 
-const vesselDataviewInstanceTemplate = (dataviewSlug: Dataview['slug']) => {
+const vesselDataviewInstanceTemplate = (
+  dataviewSlug: Dataview['slug'],
+  datasets: VesselInstanceDatasets
+) => {
   return {
     // TODO find the way to use different vessel dataviews, for example
     // panama and peru doesn't show events and needed a workaround to work with this
     dataviewId: dataviewSlug,
     config: {
       colorCyclingType: 'line' as ColorCyclingType,
+      ...datasets,
     },
   }
 }
@@ -91,8 +96,7 @@ export const getVesselDataviewInstance = (
 ): DataviewInstance<GeneratorType> => {
   const vesselDataviewInstance = {
     id: `${VESSEL_DATAVIEW_INSTANCE_PREFIX}${vessel.id}`,
-    ...vesselDataviewInstanceTemplate(TEMPLATE_VESSEL_DATAVIEW_SLUG),
-    datasetsConfig: getVesselDataviewInstanceDatasetConfig(vessel.id, datasets),
+    ...vesselDataviewInstanceTemplate(TEMPLATE_VESSEL_DATAVIEW_SLUG, datasets),
   }
   return vesselDataviewInstance
 }
@@ -103,8 +107,7 @@ export const getPresenceVesselDataviewInstance = (
 ): DataviewInstance<GeneratorType> => {
   const vesselDataviewInstance = {
     id: `${VESSEL_DATAVIEW_INSTANCE_PREFIX}${vessel.id}`,
-    ...vesselDataviewInstanceTemplate(VESSEL_PRESENCE_DATAVIEW_SLUG),
-    datasetsConfig: getVesselDataviewInstanceDatasetConfig(vessel.id, datasets),
+    ...vesselDataviewInstanceTemplate(VESSEL_PRESENCE_DATAVIEW_SLUG, datasets),
   }
   return vesselDataviewInstance
 }

--- a/apps/fishing-map/features/map/popups/TileClusterLayers.tsx
+++ b/apps/fishing-map/features/map/popups/TileClusterLayers.tsx
@@ -83,9 +83,9 @@ function EncounterTooltipRow({ feature, showFeaturesDetails }: EncountersLayerPr
       const vesselDataviewInstance = getVesselDataviewInstance(
         { id: vessel.id },
         {
-          trackDatasetId: trackDataset?.id,
-          infoDatasetId: infoDataset?.id,
-          ...(eventsDatasetsId.length > 0 && { eventsDatasetsId }),
+          info: infoDataset?.id,
+          track: trackDataset?.id,
+          ...(eventsDatasetsId.length > 0 && { events: eventsDatasetsId }),
         }
       )
       upsertDataviewInstance(vesselDataviewInstance)

--- a/apps/fishing-map/features/map/popups/VesselsTable.tsx
+++ b/apps/fishing-map/features/map/popups/VesselsTable.tsx
@@ -131,8 +131,8 @@ function VesselsTable({
       vessel.trackDataset?.id.includes(PRESENCE_TRACKS_DATASET_ID)
     ) {
       vesselDataviewInstance = getPresenceVesselDataviewInstance(vessel, {
-        trackDatasetId: vessel.trackDataset?.id,
-        infoDatasetId: vessel.infoDataset?.id,
+        info: vessel.infoDataset?.id,
+        track: vessel.trackDataset?.id,
       })
     } else {
       const vesselEventsDatasets = getRelatedDatasetsByType(
@@ -145,9 +145,9 @@ function VesselsTable({
           : []
 
       vesselDataviewInstance = getVesselDataviewInstance(vessel, {
-        trackDatasetId: vessel.trackDataset?.id,
-        infoDatasetId: vessel.infoDataset?.id,
-        ...(eventsDatasetsId.length > 0 && { eventsDatasetsId }),
+        info: vessel.infoDataset?.id,
+        track: vessel.trackDataset?.id,
+        ...(eventsDatasetsId.length > 0 && { events: eventsDatasetsId }),
       })
     }
 

--- a/apps/fishing-map/features/reports/vessels/ReportVesselsTable.tsx
+++ b/apps/fishing-map/features/reports/vessels/ReportVesselsTable.tsx
@@ -64,9 +64,9 @@ export default function ReportVesselsTable({ activityUnit, reportName }: ReportV
     const vesselDataviewInstance: DataviewInstance = getVesselDataviewInstance(
       { id: vessel.vesselId },
       {
-        trackDatasetId: vessel.trackDataset?.id,
-        infoDatasetId: vessel.infoDataset?.id,
-        ...(eventsDatasetsId.length > 0 && { eventsDatasetsId }),
+        info: vessel.infoDataset?.id,
+        track: vessel.trackDataset?.id,
+        ...(eventsDatasetsId.length > 0 && { events: eventsDatasetsId }),
       }
     )
     upsertDataviewInstance(vesselDataviewInstance)

--- a/apps/fishing-map/features/search/Search.tsx
+++ b/apps/fishing-map/features/search/Search.tsx
@@ -259,9 +259,9 @@ function Search() {
           ? eventsRelatedDatasets.map((d) => d.id)
           : []
       const vesselDataviewInstance = getVesselDataviewInstance(vessel, {
-        trackDatasetId: vessel.trackDatasetId as string,
-        infoDatasetId: vessel.dataset.id,
-        ...(eventsDatasetsId.length > 0 && { eventsDatasetsId }),
+        info: vessel.dataset.id,
+        track: vessel.trackDatasetId as string,
+        ...(eventsDatasetsId.length > 0 && { events: eventsDatasetsId }),
       })
       return vesselDataviewInstance
     })

--- a/libs/api-types/src/dataviews.ts
+++ b/libs/api-types/src/dataviews.ts
@@ -22,6 +22,11 @@ export interface DataviewConfig<Type = any> {
   dynamicBreaks?: boolean
   maxZoom?: number
   layers?: DataviewContexLayerConfig[]
+  /** Vessel datasets */
+  info?: string
+  track?: string
+  events?: string[]
+  /*****************/
   [key: string]: any
 }
 


### PR DESCRIPTION
As we started to have [http errors 431](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/431) due a too large URL this PR makes it shorter.
This happens by storing just the raw datasetIds instead of the entire dataviewDatasetConfig and adding them [just before resolving](https://github.com/GlobalFishingWatch/frontend/compare/fishing-map/shorter-vessel-urls?expand=1#diff-1a1503a4e347164a35746c4e098cb27ca8ae3bc8cfdfa12cb989f9c0acfaa3d5R228)

**Comparison with default workspace and same vessel added:**

Link length with the new approach: 754 characters
```
https://fishing-map.dev.globalfishingwatch.org/map/?latitude=19&longitude=26&zoom=1.5&start=2023-03-24T00%3A00%3A00.000Z&end=2023-06-24T00%3A00%3A00.000Z&dvIn[0][id]=4e0e1a6ad-d6ed-d833-4fb3-18c67b0f8f05&dvIn[0][dvId]=fishing-map-vessel-track&dvIn[0][cfg][info]=public-global-fishing-vessels%3Av20201001&dvIn[0][cfg][track]=public-global-fishing-tracks%3Av20201001&dvIn[0][cfg][events][0]=public-global-fishing-events%3Av20201001&dvIn[0][cfg][events][1]=public-global-port-visits-c2-events%3Av20201001&dvIn[0][cfg][events][2]=public-global-encounters-events%3Av20201001&dvIn[0][cfg][events][3]=proto-global-gaps-events%3Av20201001&dvIn[0][cfg][events][4]=public-global-loitering-events%3Av20201001&dvIn[0][cfg][clr]=%23F95E5E&timebarVisualisation=vessel
```

Link length with the legacy approach: 1429 characters
```
https://fishing-map.dev.globalfishingwatch.org/map/?latitude=19&longitude=26&zoom=1.5&start=2023-03-24T00%3A00%3A00.000Z&end=2023-06-24T00%3A00%3A00.000Z&dvIn[0][id]=vessel-~1&dvIn[0][dvId]=fishing-map-vessel-track&dvIn[0][cfg][clr]=%23F95E5E&dvIn[0][dsC][0][dsId]=public-global-fishing-vessels%3Av20201001&dvIn[0][dsC][0][pms][0][id]=~0&dvIn[0][dsC][0][pms][0][val]=~1&dvIn[0][dsC][0][ept]=~2&dvIn[0][dsC][1][dsId]=public-global-fishing-tracks%3Av20201001&dvIn[0][dsC][1][pms][0][id]=~0&dvIn[0][dsC][1][pms][0][val]=~1&dvIn[0][dsC][1][ept]=tracks&dvIn[0][dsC][2][dsId]=public-global-fishing-events%3Av20201001&dvIn[0][dsC][2][qry][0][id]=~3&dvIn[0][dsC][2][qry][0][val]=~1&dvIn[0][dsC][2][ept]=~4&dvIn[0][dsC][3][dsId]=public-global-port-visits-c2-events%3Av20201001&dvIn[0][dsC][3][qry][0][id]=~3&dvIn[0][dsC][3][qry][0][val]=~1&dvIn[0][dsC][3][ept]=~4&dvIn[0][dsC][4][dsId]=public-global-encounters-events%3Av20201001&dvIn[0][dsC][4][qry][0][id]=~3&dvIn[0][dsC][4][qry][0][val]=~1&dvIn[0][dsC][4][ept]=~4&dvIn[0][dsC][5][dsId]=proto-global-gaps-events%3Av20201001&dvIn[0][dsC][5][qry][0][id]=~3&dvIn[0][dsC][5][qry][0][val]=~1&dvIn[0][dsC][5][ept]=~4&dvIn[0][dsC][6][dsId]=public-global-loitering-events%3Av20201001&dvIn[0][dsC][6][qry][0][id]=~3&dvIn[0][dsC][6][qry][0][val]=~1&dvIn[0][dsC][6][ept]=~4&timebarVisualisation=~2&tk[0]=vesselId&tk[1]=4e0e1a6ad-d6ed-d833-4fb3-18c67b0f8f05&tk[2]=vessel&tk[3]=vessels&tk[4]=events
```