### PR TITLE
send 'vessel-groups' queryParam differently for API v2 and v3 in 'lis…

### DIFF
--- a/libs/dataviews-client/src/resolve-endpoint.ts
+++ b/libs/dataviews-client/src/resolve-endpoint.ts
@@ -32,14 +32,19 @@ export const resolveEndpoint = (dataset: Dataset, datasetConfig: DataviewDataset
         const queryArray = Array.isArray(query.value)
           ? (query.value as string[])
           : [query.value as string]
+
         // TODO check if we can remove this once map only uses v3 in dev and pro
-        if (API_VERSION === 'v3') {
+        if (
+          endpoint.id === 'list-vessels' &&
+          endpointQuery.id === 'vessel-groups' &&
+          API_VERSION === 'v2'
+        ) {
+          resolvedQuery.set(query.id, queryArray.join(','))
+        } else {
           queryArray.forEach((queryArrItem, i) => {
             const queryArrId = `${query.id}[${i}]`
             resolvedQuery.set(queryArrId, queryArrItem)
           })
-        } else {
-          resolvedQuery.set(query.id, queryArray.join(','))
         }
       } else {
         resolvedQuery.set(query.id, query.value.toString())


### PR DESCRIPTION
…t-vessels' endpoint