### PR TITLE
resolve track dataset when available

### DIFF
--- a/apps/fishing-map/features/workspace/vessels/VesselLayerPanel.tsx
+++ b/apps/fishing-map/features/workspace/vessels/VesselLayerPanel.tsx
@@ -196,7 +196,7 @@ function LayerPanel({ dataview }: LayerPanelProps): React.ReactElement {
   }
 
   const infoFields = guestUser
-    ? dataview.infoConfig?.fields.filter((field) => field.guest)
+    ? dataview.infoConfig?.fields?.filter((field) => field.guest)
     : dataview.infoConfig?.fields
 
   const TrackIconComponent = trackLoading ? (


### PR DESCRIPTION
Fixes missing track when logged after pinning a vessel without login

<img width="329" alt="image" src="https://github.com/GlobalFishingWatch/frontend/assets/10500650/e360f360-313f-4953-949b-192027f029e2">
