### PR TITLE
Fishing map/vessel groups no limit

### DIFF
--- a/apps/fishing-map/.env.sample
+++ b/apps/fishing-map/.env.sample
@@ -9,5 +9,4 @@ NEXT_PUBLIC_USE_LOCAL_DATASETS=true
 NEXT_PUBLIC_WORKSPACE_ENV=development
 NEXT_PUBLIC_API_GATEWAY=https://gateway.api.dev.globalfishingwatch.org
 NEXT_PUBLIC_LATEST_CARRIER_DATASET_ID=carriers:latest
-NEXT_PUBLIC_VESSEL_GROUPS_DAYS_LIMIT=365
 NEXT_PUBLIC_CARRIER_PORTAL_URL=https://carrier-portal.dev.globalfishingwatch.org

--- a/apps/fishing-map/data/config.ts
+++ b/apps/fishing-map/data/config.ts
@@ -17,11 +17,6 @@ export const REPORT_DAYS_LIMIT =
     ? parseInt(process.env.NEXT_PUBLIC_REPORT_DAYS_LIMIT)
     : 366 // 1 year
 
-export const VESSEL_GROUPS_DAYS_LIMIT =
-  typeof process.env.VESSEL_GROUPS_DAYS_LIMIT !== 'undefined'
-    ? parseInt(process.env.VESSEL_GROUPS_DAYS_LIMIT)
-    : 93 // 3 months
-
 // Never actually used?
 export const API_GATEWAY = process.env.API_GATEWAY || process.env.NEXT_PUBLIC_API_GATEWAY || ''
 export const CARRIER_PORTAL_API_URL =

--- a/apps/fishing-map/data/config.ts
+++ b/apps/fishing-map/data/config.ts
@@ -1,7 +1,7 @@
 import { DateTime } from 'luxon'
 import { DataviewCategory, ThinningConfig } from '@globalfishingwatch/api-types'
 import { ThinningLevels, THINNING_LEVELS } from '@globalfishingwatch/api-client'
-import { TimebarGraphs, TimebarVisualisations } from 'types'
+import { TimebarGraphs, TimebarVisualisations, UserTab } from 'types'
 import { getUTCDateTime } from 'utils/dates'
 
 export const ROOT_DOM_ELEMENT = '__next'
@@ -91,6 +91,7 @@ export const DEFAULT_WORKSPACE = {
   reportVesselGraph: REPORT_VESSELS_GRAPH_FLAG,
   reportVesselPage: 0,
   reportResultsPerPage: REPORT_VESSELS_PER_PAGE,
+  userTab: UserTab.Info,
 }
 
 export const EVENTS_COLORS: Record<string, string> = {

--- a/apps/fishing-map/features/datasets/datasets.utils.ts
+++ b/apps/fishing-map/features/datasets/datasets.utils.ts
@@ -58,6 +58,7 @@ export type SupportedContextDatasetSchema = 'removal_of'
 export type SupportedEventsDatasetSchema = 'duration'
 
 const CONTEXT_DATASETS_SCHEMAS: SupportedContextDatasetSchema[] = ['removal_of']
+const SINGLE_SELECTION_SCHEMAS: SupportedDatasetSchema[] = ['vessel-groups']
 
 export type SchemaFieldDataview =
   | UrlDataviewInstance
@@ -535,6 +536,10 @@ export const getSchemaOptionsSelectedInDataview = (
     ]
   }
 
+  if (SINGLE_SELECTION_SCHEMAS.includes(schema)) {
+    return options?.filter((option) => dataview.config?.filters?.[schema]?.id === option.id)
+  }
+
   return options?.filter((option) =>
     dataview.config?.filters?.[schema]?.map((o) => o.toString())?.includes(option.id)
   )
@@ -552,6 +557,10 @@ export const getSchemaFilterOperationInDataview = (
     return
   }
   return dataview.config?.filterOperators?.[schema] || INCLUDE_FILTER_ID
+}
+
+const getSchemaFilterSingleSelection = (schema: SupportedDatasetSchema) => {
+  return SINGLE_SELECTION_SCHEMAS.includes(schema)
 }
 
 export const getSchemaFilterUnitInDataview = (
@@ -580,6 +589,7 @@ export type SchemaFilter = {
   optionsSelected: ReturnType<typeof getCommonSchemaFieldsInDataview>
   filterOperator: FilterOperator
   unit?: string
+  singleSelection?: boolean
 }
 export const getFiltersBySchema = (
   dataview: SchemaFieldDataview,
@@ -588,6 +598,7 @@ export const getFiltersBySchema = (
 ): SchemaFilter => {
   const options = getCommonSchemaFieldsInDataview(dataview, schema, vesselGroups)
   const type = getCommonSchemaTypeInDataview(dataview, schema) as DatasetSchemaType
+  const singleSelection = getSchemaFilterSingleSelection(schema)
   const filterOperator = getSchemaFilterOperationInDataview(dataview, schema) as FilterOperator
   const optionsSelected = getSchemaOptionsSelectedInDataview(dataview, schema, options)
   const unit = getSchemaFilterUnitInDataview(dataview, schema)
@@ -599,10 +610,20 @@ export const getFiltersBySchema = (
     ? t(`datasets:${datasetId}.schema.${schema}.keyword`, schema.toString())
     : t(`vessel.${schema}`, { defaultValue: schema, count: 2 }) // We always want to show the plural for the multiselect
   if (schema === 'vessel-groups') {
-    label = t('vesselGroup.vesselGroups', 'Vessel Groups')
+    label = t('vesselGroup.vesselGroup', 'Vessel Group')
   }
 
-  return { id: schema, label, unit, disabled, options, optionsSelected, type, filterOperator }
+  return {
+    id: schema,
+    label,
+    unit,
+    disabled,
+    options,
+    optionsSelected,
+    type,
+    filterOperator,
+    singleSelection,
+  }
 }
 
 export const getSchemaFiltersInDataview = (

--- a/apps/fishing-map/features/datasets/datasets.utils.ts
+++ b/apps/fishing-map/features/datasets/datasets.utils.ts
@@ -536,10 +536,6 @@ export const getSchemaOptionsSelectedInDataview = (
     ]
   }
 
-  if (SINGLE_SELECTION_SCHEMAS.includes(schema)) {
-    return options?.filter((option) => dataview.config?.filters?.[schema]?.id === option.id)
-  }
-
   return options?.filter((option) =>
     dataview.config?.filters?.[schema]?.map((o) => o.toString())?.includes(option.id)
   )

--- a/apps/fishing-map/features/dataviews/dataviews.slice.ts
+++ b/apps/fishing-map/features/dataviews/dataviews.slice.ts
@@ -257,9 +257,9 @@ export const selectAllDataviewInstancesResolved = createSelector(
 )
 
 export const selectMarineManagerDataviewInstanceResolved = createSelector(
-  [selectAllDataviews, selectAllDatasets],
-  (dataviews, datasets): UrlDataviewInstance[] | undefined => {
-    if (!dataviews.length || !datasets.length) return []
+  [selectIsMarineManagerLocation, selectAllDataviews, selectAllDatasets],
+  (isMarineManagerLocation, dataviews, datasets): UrlDataviewInstance[] | undefined => {
+    if (!isMarineManagerLocation || !dataviews.length || !datasets.length) return []
     const dataviewInstancesResolved = resolveDataviews(
       MARINE_MANAGER_DATAVIEWS,
       dataviews,

--- a/apps/fishing-map/features/map/map.selectors.ts
+++ b/apps/fishing-map/features/map/map.selectors.ts
@@ -39,8 +39,6 @@ import { selectShowTimeComparison } from 'features/reports/reports.selectors'
 import { WorkspaceCategory } from 'data/workspaces'
 import { AsyncReducerStatus } from 'utils/async-slice'
 import { BivariateDataviews } from 'types'
-import { VESSEL_GROUPS_DAYS_LIMIT } from 'data/config'
-import { getTimeRangeDuration } from 'utils/dates'
 
 type GetGeneratorConfigParams = {
   dataviews: UrlDataviewInstance[] | undefined
@@ -64,27 +62,11 @@ const getGeneratorsConfig = ({
   bivariateDataviews,
   showTimeComparison,
 }: GetGeneratorConfigParams) => {
-  const duration = getTimeRangeDuration(timeRange, 'days')
-  const hasVesselGroupsSelected = dataviews.some(
-    (d) => d.config?.filters?.['vessel-groups']?.length > 0
-  )
-  // Removes the HeatmapAnimated dataviews that won't work with the current
-  // vessel-groups timerange limitation to avoid requesting known error tiles
-  const dataviewsFiltered =
-    VESSEL_GROUPS_DAYS_LIMIT > 0
-      ? dataviews.filter((dataview) => {
-          const isHeatmap = dataview.config?.type === GeneratorType.HeatmapAnimated
-          return isHeatmap && hasVesselGroupsSelected
-            ? duration!?.days <= VESSEL_GROUPS_DAYS_LIMIT
-            : true
-        })
-      : dataviews
-
-  const animatedHeatmapDataviews = dataviewsFiltered.filter((dataview) => {
+  const animatedHeatmapDataviews = dataviews.filter((dataview) => {
     return dataview.config?.type === GeneratorType.HeatmapAnimated
   })
 
-  const visibleDataviewIds = dataviewsFiltered.map(({ id }) => id)
+  const visibleDataviewIds = dataviews.map(({ id }) => id)
   const bivariateVisible =
     bivariateDataviews?.filter((dataviewId) => visibleDataviewIds.includes(dataviewId))?.length ===
     2
@@ -101,7 +83,7 @@ const getGeneratorsConfig = ({
     heatmapAnimatedMode = HeatmapAnimatedMode.TimeCompare
   }
 
-  const trackDataviews = dataviewsFiltered.filter((d) => d.config?.type === GeneratorType.Track)
+  const trackDataviews = dataviews.filter((d) => d.config?.type === GeneratorType.Track)
   const singleTrack = trackDataviews.length === 1
 
   const generatorOptions: DataviewsGeneratorConfigsParams = {
@@ -117,11 +99,7 @@ const getGeneratorsConfig = ({
   }
 
   try {
-    let generatorsConfig = getDataviewsGeneratorConfigs(
-      dataviewsFiltered,
-      generatorOptions,
-      resources
-    )
+    let generatorsConfig = getDataviewsGeneratorConfigs(dataviews, generatorOptions, resources)
     // In time comparison mode, exclude any heatmap layer that is not activity
     if (showTimeComparison) {
       generatorsConfig = generatorsConfig.filter((config) => {

--- a/apps/fishing-map/features/reports/reports.utils.ts
+++ b/apps/fishing-map/features/reports/reports.utils.ts
@@ -17,9 +17,9 @@ import {
   getSchemaFilterOperationInDataview,
   SupportedDatasetSchema,
 } from 'features/datasets/datasets.utils'
-import { ReportVesselWithDatasets } from 'features/reports/reports.selectors'
-import { EMPTY_FIELD_PLACEHOLDER } from 'utils/info'
 import { ReportCategory } from 'types'
+
+const ALWAYS_SHOWN_FILTERS = ['vessel-groups']
 
 const arrayToStringTransform = (array: string[]) =>
   `(${array?.map((v: string) => `'${v}'`).join(', ')})`
@@ -104,12 +104,13 @@ const getSerializedDatasets = (dataview: UrlDataviewInstance) => {
 }
 
 const getSerializedFilterFields = (dataview: UrlDataviewInstance, filterKey: string): string => {
-  return dataview.config?.filters?.[filterKey]?.slice().sort(sortStrings).join(', ')
+  const values = dataview.config?.filters?.[filterKey]
+  return Array.isArray(values) ? values?.slice().sort(sortStrings).join(', ') : values
 }
 
 export const FIELDS = [
   ['geartype', 'layer.gearType_other', 'Gear types'],
-  ['vessel-groups', 'vesselGroup.vesselGroups', 'Vessel Groups'],
+  ['vessel-groups', 'vesselGroup.vesselGroup', 'Vessel Group'],
   ['origin', 'vessel.origin', 'Origin'],
   ['vessel_type', 'vessel.vesselType_other', 'Vessel types'],
 ]
@@ -164,7 +165,8 @@ export const getCommonProperties = (dataviews: UrlDataviewInstance[]) => {
         dataviews?.every((dataview) => {
           const genericFilterFields = getSerializedFilterFields(dataview, filterKey)
           return genericFilterFields === firstDataviewGenericFilterFields
-        })
+        }) &&
+        !ALWAYS_SHOWN_FILTERS.includes(filterKey)
       ) {
         const keyLabelField = FIELDS.find((field) => field[0] === filterKey)
         const keyLabel = keyLabelField

--- a/apps/fishing-map/features/reports/summary/ReportSummaryTags.tsx
+++ b/apps/fishing-map/features/reports/summary/ReportSummaryTags.tsx
@@ -42,8 +42,8 @@ export default function ReportSummaryTags({
   const areAllPropertiesHidden =
     hiddenProperties?.includes('dataset') &&
     hiddenProperties?.includes('source') &&
-    hiddenProperties?.includes('flag')
-  // && availableFields.every((f) => hiddenProperties?.includes(f[0]))
+    hiddenProperties?.includes('flag') &&
+    availableFields.every((f) => hiddenProperties?.includes(f[0]))
 
   if (areAllPropertiesHidden) {
     // TODO I don't understand that logic

--- a/apps/fishing-map/features/sidebar/SidebarHeader.tsx
+++ b/apps/fishing-map/features/sidebar/SidebarHeader.tsx
@@ -269,6 +269,7 @@ function CloseReportButton() {
 }
 
 function SidebarHeader() {
+  const { dispatchQueryParams } = useLocationConnect()
   const readOnly = useSelector(selectReadOnly)
   const locationCategory = useSelector(selectLocationCategory)
   const workspaceLocation = useSelector(selectIsWorkspaceLocation)
@@ -282,6 +283,10 @@ function SidebarHeader() {
     return subBrand
   }, [locationCategory])
 
+  const onCloseClick = useCallback(() => {
+    dispatchQueryParams({ userTab: undefined })
+  }, [dispatchQueryParams])
+
   return (
     <Sticky scrollElement=".scrollContainer" stickyClassName={styles.sticky}>
       <div className={styles.sidebarHeader}>
@@ -293,7 +298,7 @@ function SidebarHeader() {
         {(workspaceLocation || reportLocation) && !readOnly && <ShareWorkspaceButton />}
         {reportLocation && !readOnly && <CloseReportButton />}
         {!reportLocation && !readOnly && showBackToWorkspaceButton && lastVisitedWorkspace && (
-          <Link className={styles.workspaceLink} to={lastVisitedWorkspace}>
+          <Link className={styles.workspaceLink} to={lastVisitedWorkspace} onClick={onCloseClick}>
             <IconButton type="border" icon="close" />
           </Link>
         )}

--- a/apps/fishing-map/features/user/User.tsx
+++ b/apps/fishing-map/features/user/User.tsx
@@ -7,7 +7,7 @@ import { redirectToLogin } from '@globalfishingwatch/react-hooks'
 import { GUEST_USER_TYPE } from '@globalfishingwatch/api-client'
 import EditDataset from 'features/datasets/EditDataset'
 import {
-  fetchDefaultWorkspaceThunk,
+  // fetchDefaultWorkspaceThunk,
   fetchWorkspacesThunk,
 } from 'features/workspaces-list/workspaces-list.slice'
 import { fetchAllDatasetsThunk } from 'features/datasets/datasets.slice'
@@ -17,6 +17,7 @@ import { fetchUserVesselGroupsThunk } from 'features/vessel-groups/vessel-groups
 import { UserTab } from 'types'
 import { useLocationConnect } from 'routes/routes.hook'
 import { selectUserTab } from 'routes/routes.selectors'
+import { fetchWorkspaceThunk } from 'features/workspace/workspace.slice'
 import styles from './User.module.css'
 import { selectUserData, isUserLogged } from './user.slice'
 import { selectUserGroupsPermissions } from './user.selectors'
@@ -94,7 +95,8 @@ function User() {
   }, [dispatch, userData?.id, userLogged])
 
   useEffect(() => {
-    dispatch(fetchDefaultWorkspaceThunk())
+    dispatch(fetchWorkspaceThunk(''))
+    // dispatch(fetchDefaultWorkspaceThunk())
     dispatch(fetchAllDatasetsThunk())
   }, [dispatch])
 

--- a/apps/fishing-map/features/vessel-groups/VesselGroupModal.tsx
+++ b/apps/fishing-map/features/vessel-groups/VesselGroupModal.tsx
@@ -106,7 +106,12 @@ function VesselGroupModal(): React.ReactElement {
 
   const dispatchSearchVesselsGroupsThunk = useCallback(
     async (vessels: VesselGroupVessel[], idField: IdField = 'vesselId') => {
-      return dispatch(searchVesselGroupsVesselsThunk({ vessels, idField }))
+      const action = await dispatch(searchVesselGroupsVesselsThunk({ vessels, idField }))
+      if (searchVesselGroupsVesselsThunk.fulfilled.match(action)) {
+        setError('')
+      } else {
+        setError((action.payload as any)?.message || '')
+      }
     },
     [dispatch]
   )
@@ -357,7 +362,7 @@ function VesselGroupModal(): React.ReactElement {
         <UserGuideLink section="vesselGroups" />
         <div className={styles.footerMsg}>
           {error && <span className={styles.errorMsg}>{error}</span>}
-          {vesselGroupAPIError && (
+          {vesselGroupAPIError && !error && (
             <span className={styles.errorMsg}>
               {t('errors.genericShort', 'Something went wrong')}
             </span>

--- a/apps/fishing-map/features/vessel-groups/VesselGroupModal.tsx
+++ b/apps/fishing-map/features/vessel-groups/VesselGroupModal.tsx
@@ -173,14 +173,12 @@ function VesselGroupModal(): React.ReactElement {
           const currentDataviewInstance = urlDataviewInstances?.find(
             (dvi) => dvi.id === currentDataviewId
           )
+
           if (currentDataviewInstance) {
             config = {
               filters: {
                 ...(currentDataviewInstance.config?.filters || {}),
-                'vessel-groups': [
-                  ...(currentDataviewInstance.config?.filters?.['vessel-groups'] || []),
-                  vesselGroupId,
-                ],
+                'vessel-groups': [vesselGroupId],
               },
             }
           }

--- a/apps/fishing-map/features/vessel-groups/vessel-groups.slice.ts
+++ b/apps/fishing-map/features/vessel-groups/vessel-groups.slice.ts
@@ -86,6 +86,7 @@ export const searchVesselGroupsVesselsThunk = createAsyncThunk(
       (d) =>
         d.status !== DatasetStatus.Deleted && d.alias?.some((alias) => alias.includes(':latest'))
     )
+
     const vesselDatasetsByType = idField === 'vesselId' ? allVesselDatasets : advancedSearchDatasets
     const searchDatasets = vesselGroupDatasets?.length
       ? vesselDatasetsByType.filter((dataset) => vesselGroupDatasets.includes(dataset.id))

--- a/apps/fishing-map/features/vessel-groups/vessel-groups.slice.ts
+++ b/apps/fishing-map/features/vessel-groups/vessel-groups.slice.ts
@@ -233,10 +233,10 @@ export const getVesselInVesselGroupThunk = createAsyncThunk(
 
 export const fetchWorkspaceVesselGroupsThunk = createAsyncThunk(
   'workspace-vessel-groups/fetch',
-  async (ids: string[] = [], { signal, rejectWithValue }) => {
+  async (groups: VesselGroup[] = [], { signal, rejectWithValue }) => {
     try {
       const vesselGroupsParams = {
-        ...(ids?.length && { ids }),
+        ...(groups?.length && { ids: groups.map((g) => g.id).join(',') }),
         cache: false,
         ...DEFAULT_PAGINATION_PARAMS,
       }

--- a/apps/fishing-map/features/workspace/Workspace.tsx
+++ b/apps/fishing-map/features/workspace/Workspace.tsx
@@ -65,11 +65,13 @@ function Workspace() {
     }
   }, [workspace])
 
+  const workspaceVesselGroupsIdsHash = workspaceVesselGroupsIds.join(',')
   useEffect(() => {
     if (workspaceVesselGroupsIds.length) {
       dispatch(fetchWorkspaceVesselGroupsThunk(workspaceVesselGroupsIds))
     }
-  }, [workspaceVesselGroupsIds, dispatch])
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [workspaceVesselGroupsIdsHash, dispatch])
 
   const handleDragEnd = useCallback(
     (event) => {

--- a/apps/fishing-map/features/workspace/activity/ActivityFilters.tsx
+++ b/apps/fishing-map/features/workspace/activity/ActivityFilters.tsx
@@ -329,7 +329,7 @@ function ActivityFilters({ dataview: baseDataview }: ActivityFiltersProps): Reac
       {showSourceFilter && (
         <MultiSelect
           testId="activity-filters"
-          label={t('layer.source_other', 'Sources')}
+          label={t('layer.source_other', 'Sources') as string}
           placeholder={getPlaceholderBySelections(sourcesSelected)}
           options={allSourceOptions}
           selectedOptions={sourcesSelected}

--- a/apps/fishing-map/features/workspace/activity/ActivityFilters.tsx
+++ b/apps/fishing-map/features/workspace/activity/ActivityFilters.tsx
@@ -218,11 +218,14 @@ function ActivityFilters({ dataview: baseDataview }: ActivityFiltersProps): Reac
       dispatch(setVesselGroupCurrentDataviewIds([dataview.id]))
       return
     }
-    const filterValues = Array.isArray(selection)
-      ? selection.map(({ id }) => id).sort((a, b) => a - b)
-      : singleValue
-      ? selection
-      : [...(dataview.config?.filters?.[filterKey] || []), selection.id]
+    let filterValues: string[]
+    if (Array.isArray(selection)) {
+      filterValues = selection.map(({ id }) => id).sort((a, b) => a - b)
+    } else if (singleValue) {
+      filterValues = [selection.id]
+    } else {
+      filterValues = [...(dataview.config?.filters?.[filterKey] || []), selection.id]
+    }
     const newDataviewConfig = {
       filters: {
         ...(dataview.config?.filters || {}),

--- a/apps/fishing-map/features/workspace/activity/ActivityLayerPanel.tsx
+++ b/apps/fishing-map/features/workspace/activity/ActivityLayerPanel.tsx
@@ -171,7 +171,7 @@ function ActivityLayerPanel({
       { field: 'target_species', label: t('vessel.target_species', 'Target species') },
       { field: 'license_category', label: t('vessel.license_category', 'License category') },
       { field: 'vessel_type', label: t('vessel.vesselType_other', 'Vessel types') },
-      { field: 'vessel-groups', label: t('vesselGroup.vesselGroups', 'Vessel Groups') },
+      { field: 'vessel-groups', label: t('vesselGroup.vesselGroup', 'Vessel Group') },
     ]
     return fields
   }, [t])

--- a/apps/fishing-map/features/workspace/activity/ActivitySchemaFilter.tsx
+++ b/apps/fishing-map/features/workspace/activity/ActivitySchemaFilter.tsx
@@ -83,7 +83,17 @@ function ActivitySchemaFilter({
   onIsOpenChange,
   onSelectOperation,
 }: ActivitySchemaFilterProps) {
-  const { id, label, type, disabled, options, optionsSelected, filterOperator, unit } = schemaFilter
+  const {
+    id,
+    label,
+    type,
+    disabled,
+    options,
+    optionsSelected,
+    filterOperator,
+    unit,
+    singleSelection,
+  } = schemaFilter
   // eslint-disable-next-line react-hooks/exhaustive-deps
   const onSliderChange = useCallback(
     (rangeSelected) => {
@@ -168,7 +178,7 @@ function ActivitySchemaFilter({
   }
 
   return (
-    <div className={styles.relative}>
+    <div className={cx(styles.relative, styles.multiSelect)}>
       {filterOperator && (
         <Choice
           size="tiny"
@@ -178,19 +188,31 @@ function ActivitySchemaFilter({
           onSelect={(option) => onSelectOperation(id, option.id as FilterOperator)}
         />
       )}
-      <MultiSelect
-        key={id}
-        disabled={disabled}
-        label={label}
-        placeholder={getPlaceholderBySelections(optionsSelected, filterOperator)}
-        options={options}
-        selectedOptions={optionsSelected}
-        className={styles.multiSelect}
-        onSelect={(selection) => onSelect(id, selection)}
-        onRemove={(selection, rest) => onRemove(id, rest)}
-        onIsOpenChange={onIsOpenChange}
-        onCleanClick={() => onClean(id)}
-      />
+      {singleSelection ? (
+        <Select
+          key={id}
+          disabled={disabled}
+          label={label}
+          placeholder={getPlaceholderBySelections(optionsSelected, filterOperator)}
+          options={options}
+          selectedOption={optionsSelected[0]}
+          onSelect={(selection) => onSelect(id, selection, true)}
+          onCleanClick={() => onClean(id)}
+        />
+      ) : (
+        <MultiSelect
+          key={id}
+          disabled={disabled}
+          label={label}
+          placeholder={getPlaceholderBySelections(optionsSelected, filterOperator)}
+          options={options}
+          selectedOptions={optionsSelected}
+          onSelect={(selection) => onSelect(id, selection)}
+          onRemove={(selection, rest) => onRemove(id, rest)}
+          onIsOpenChange={onIsOpenChange}
+          onCleanClick={() => onClean(id)}
+        />
+      )}
     </div>
   )
 }

--- a/apps/fishing-map/features/workspace/shared/DatasetSchemaField.tsx
+++ b/apps/fishing-map/features/workspace/shared/DatasetSchemaField.tsx
@@ -30,7 +30,9 @@ function DatasetSchemaField({ dataview, field, label }: LayerPanelProps): React.
     vesselGroupsOptions
   )
 
-  let valuesSelected = schemaFieldSelected.sort((a, b) => a.label - b.label)
+  let valuesSelected = Array.isArray(schemaFieldSelected)
+    ? schemaFieldSelected.sort((a, b) => a.label - b.label)
+    : schemaFieldSelected
 
   const valuesAreRangeOfNumbers =
     valuesSelected.length > 1 &&

--- a/apps/fishing-map/features/workspace/shared/DatasetSchemaField.tsx
+++ b/apps/fishing-map/features/workspace/shared/DatasetSchemaField.tsx
@@ -1,6 +1,4 @@
 import { Fragment } from 'react'
-import cx from 'classnames'
-import { useSelector } from 'react-redux'
 import { useTranslation } from 'react-i18next'
 import { formatSliderNumber, TagList } from '@globalfishingwatch/ui-components'
 import { UrlDataviewInstance } from '@globalfishingwatch/dataviews-client'
@@ -13,9 +11,6 @@ import {
   SupportedDatasetSchema,
 } from 'features/datasets/datasets.utils'
 import { useVesselGroupsOptions } from 'features/vessel-groups/vessel-groups.hooks'
-import { selectTimeRange } from 'features/app/app.selectors'
-import { getTimeRangeDuration } from 'utils/dates'
-import { VESSEL_GROUPS_DAYS_LIMIT } from 'data/config'
 import { VALUE_TRANSFORMATIONS_BY_UNIT } from 'features/workspace/activity/ActivitySchemaFilter'
 
 type LayerPanelProps = {
@@ -26,8 +21,6 @@ type LayerPanelProps = {
 
 function DatasetSchemaField({ dataview, field, label }: LayerPanelProps): React.ReactElement {
   const { t } = useTranslation()
-  const timeRange = useSelector(selectTimeRange)
-  const duration = getTimeRangeDuration(timeRange, 'days')
   const vesselGroupsOptions = useVesselGroupsOptions()
   const filterOperation = getSchemaFilterOperationInDataview(dataview, field)
   const filterUnit = getSchemaFilterUnitInDataview(dataview, field)
@@ -82,17 +75,6 @@ function DatasetSchemaField({ dataview, field, label }: LayerPanelProps): React.
           <label>
             {label}
             {filterOperation === EXCLUDE_FILTER_ID && ` (${t('common.excluded', 'Excluded')})`}
-            {VESSEL_GROUPS_DAYS_LIMIT > 0 &&
-              field === 'vessel-groups' &&
-              duration!?.days > VESSEL_GROUPS_DAYS_LIMIT && (
-                <span className={cx(styles.dataWarning, styles.error)}>
-                  {' '}
-                  {t(
-                    'vesselGroup.timeRangeLimit',
-                    'Supported only for time ranges shorter than 3 months'
-                  )}
-                </span>
-              )}
           </label>
           <TagList
             tags={valuesSelected}

--- a/apps/fishing-map/public/locales/source/translations.json
+++ b/apps/fishing-map/public/locales/source/translations.json
@@ -622,7 +622,6 @@
     "saveAndFilter": "Save and filter workspace",
     "saveForLater": "Save for later",
     "saveForLaterTooltip": "You'll find the group in the activity layers filters or your user panel button",
-    "timeRangeLimit": "Supported only for time ranges shorter than 3 months",
     "tooManyVessels_one": "Maximum number of vessels is {{count}}",
     "tooManyVessels_other": "Maximum number of vessels is {{count}}",
     "uploadPublic": "Allow other users to see this vessel group when you share a workspace",

--- a/apps/fishing-map/routes/routes.selectors.ts
+++ b/apps/fishing-map/routes/routes.selectors.ts
@@ -3,7 +3,7 @@ import { memoize } from 'lodash'
 import { Query, RouteObject } from 'redux-first-router'
 import { RootState } from 'reducers'
 import { UrlDataviewInstance } from '@globalfishingwatch/dataviews-client'
-import { WorkspaceParam } from 'types'
+import { UserTab, WorkspaceParam } from 'types'
 import { WorkspaceCategory } from 'data/workspaces'
 import { REPORT, WORKSPACE_REPORT, ROUTE_TYPES, WORKSPACE_ROUTES } from './routes'
 
@@ -81,6 +81,7 @@ export const selectIsMarineManagerLocation = createSelector(
   }
 )
 
+export const selectUserTab = selectQueryParam<UserTab>('userTab')
 export const selectUrlMapZoomQuery = selectQueryParam<number>('zoom')
 export const selectUrlMapLatitudeQuery = selectQueryParam<number>('latitude')
 export const selectUrlMapLongitudeQuery = selectQueryParam<number>('longitude')

--- a/apps/fishing-map/types/index.ts
+++ b/apps/fishing-map/types/index.ts
@@ -39,6 +39,7 @@ export type WorkspaceStateProperty =
   | 'bivariateDataviews'
   | 'activityCategory'
   | ReportStateProperty
+  | keyof AppParams
 
 export type WorkspaceParam =
   | WorkspaceViewportParam
@@ -99,9 +100,22 @@ export type RedirectParam = {
   'access-token'?: string
 }
 
+export enum UserTab {
+  Info = 'info',
+  Workspaces = 'workspaces',
+  Datasets = 'datasets',
+  Reports = 'reports',
+  VesselGroups = 'vesselGroups',
+}
+
+export type AppParams = {
+  userTab?: UserTab
+}
+
 export type QueryParams = Partial<WorkspaceViewport> &
   Partial<WorkspaceTimeRange> &
   WorkspaceState &
+  AppParams &
   RedirectParam
 
 export type MapCoordinates = {

--- a/libs/api-types/src/datasets.ts
+++ b/libs/api-types/src/datasets.ts
@@ -128,6 +128,7 @@ export type DatasetSchema = {
   max: number
   stats?: boolean
   unit?: string
+  singleSelection?: boolean
 }
 
 export enum DatasetCategory {

--- a/libs/dataviews-client/src/resolve-dataviews.ts
+++ b/libs/dataviews-client/src/resolve-dataviews.ts
@@ -337,7 +337,7 @@ export function resolveDataviews(
       const { filters, filterOperators } = dataviewInstance.config
       if (filters) {
         if (filters['vessel-groups']) {
-          dataviewInstance.config['vessel-groups'] = filters['vessel-groups'].join(',')
+          dataviewInstance.config['vessel-groups'] = filters['vessel-groups'].id
         }
         const sqlFilters = Object.keys(filters)
           .filter((key) => key !== 'vessel-groups')

--- a/libs/dataviews-client/src/resolve-dataviews.ts
+++ b/libs/dataviews-client/src/resolve-dataviews.ts
@@ -337,7 +337,7 @@ export function resolveDataviews(
       const { filters, filterOperators } = dataviewInstance.config
       if (filters) {
         if (filters['vessel-groups']) {
-          dataviewInstance.config['vessel-groups'] = filters['vessel-groups'].id
+          dataviewInstance.config['vessel-groups'] = filters['vessel-groups'].join(',')
         }
         const sqlFilters = Object.keys(filters)
           .filter((key) => key !== 'vessel-groups')

--- a/libs/layer-composer/src/generators/user-points/user-points.ts
+++ b/libs/layer-composer/src/generators/user-points/user-points.ts
@@ -36,7 +36,7 @@ class UserPointsGenerator {
       ...baseLayer,
       type: 'circle',
       paint: {
-        'circle-radius': ['interpolate', ['linear'], ['zoom'], 2, 4, 5, 8],
+        'circle-radius': ['interpolate', ['linear'], ['zoom'], 2, 2, 5, 4],
         'circle-stroke-color': DEFAULT_BACKGROUND_COLOR,
         'circle-stroke-width': ['interpolate', ['linear'], ['zoom'], 3, 0.1, 5, 0.5],
         'circle-stroke-opacity': 0.5,


### PR DESCRIPTION
Cherry-picking https://github.com/GlobalFishingWatch/frontend/pull/2164 to clean unnecessary `as string` validations and fixes:
- [x] add vessel to a existing group crashes
- [x] vessel-group modal from search doesn't close after creation
- [x] vessel-group edit not working (no search datasets available)