### PR TITLE
Fishing map/download rate limits

### DIFF
--- a/apps/fishing-map/features/datasets/datasets.utils.ts
+++ b/apps/fishing-map/features/datasets/datasets.utils.ts
@@ -241,8 +241,16 @@ export const checkDatasetDownloadTrackPermission = (
   datasetId: string,
   permissions: UserPermission[]
 ) => {
-  const permission = { type: 'dataset', value: datasetId, action: 'download-track' }
-  return checkExistPermissionInList(permissions, permission)
+  // TODO make this number dynamic using wildcards like -*
+  const downloadPermissions = [
+    { type: 'dataset', value: datasetId, action: 'download-track' },
+    { type: 'dataset', value: datasetId, action: 'download-track-10' },
+    { type: 'dataset', value: datasetId, action: 'download-track-100' },
+    { type: 'dataset', value: datasetId, action: 'download-track-*' },
+  ]
+  return downloadPermissions.some((permission) =>
+    checkExistPermissionInList(permissions, permission)
+  )
 }
 
 export const getActivityDatasetsReportSupported = (

--- a/apps/fishing-map/features/download/downloadTrack.slice.ts
+++ b/apps/fishing-map/features/download/downloadTrack.slice.ts
@@ -7,6 +7,7 @@ import { GFWAPI, parseAPIError } from '@globalfishingwatch/api-client'
 import { AsyncError, AsyncReducerStatus } from 'utils/async-slice'
 import { DateRange } from 'features/download/downloadActivity.slice'
 import { getUTCDateTime } from 'utils/dates'
+import { logoutUserThunk } from 'features/user/user.slice'
 import { Format, FORMAT_EXTENSION } from './downloadTrack.config'
 
 type VesselParams = {
@@ -133,6 +134,10 @@ const downloadTrackSlice = createSlice({
           state.rateLimit = rateLimit
         }
       }
+    })
+    builder.addCase(logoutUserThunk.fulfilled, (state) => {
+      state.error = null
+      state.rateLimit = {} as DownloadRateLimit
     })
   },
 })

--- a/apps/fishing-map/features/workspace/vessels/VesselDownload.tsx
+++ b/apps/fishing-map/features/workspace/vessels/VesselDownload.tsx
@@ -1,0 +1,68 @@
+import { t } from 'i18next'
+import { useSelector } from 'react-redux'
+import { IconButton } from '@globalfishingwatch/ui-components'
+import { useAppDispatch } from 'features/app/app.hooks'
+import { getVesselDatasetsDownloadTrackSupported } from 'features/datasets/datasets.utils'
+import {
+  selectDownloadTrackError,
+  selectDownloadTrackRateLimit,
+  setDownloadTrackVessel,
+} from 'features/download/downloadTrack.slice'
+import { selectUserData } from 'features/user/user.slice'
+import { VesselLayerPanelProps } from 'features/workspace/vessels/VesselLayerPanel'
+
+type VessselDownloadProps = VesselLayerPanelProps & {
+  vesselId: string
+  vesselTitle: string
+  datasetId: string
+}
+
+function VesselDownload({ dataview, vesselId, vesselTitle, datasetId }: VessselDownloadProps) {
+  const dispatch = useAppDispatch()
+  const userData = useSelector(selectUserData)
+  const downloadError = useSelector(selectDownloadTrackError)
+  const rateLimit = useSelector(selectDownloadTrackRateLimit)
+  const downloadDatasetsSupported = getVesselDatasetsDownloadTrackSupported(
+    dataview,
+    userData?.permissions
+  )
+  const downloadSupported = downloadDatasetsSupported.length > 0
+  const hasDownloadError =
+    downloadError !== null && (downloadError.status === 429 || rateLimit?.remaining === 0)
+
+  const onDownloadClick = () => {
+    dispatch(
+      setDownloadTrackVessel({
+        id: vesselId,
+        name: vesselTitle,
+        datasets: datasetId,
+      })
+    )
+  }
+
+  let tooltip = t('download.trackAction', 'Download vessel track')
+  if (hasDownloadError) {
+    tooltip = t('download.trackLimitExceeded', {
+      defaultValue: 'You have excede the limit of tracks you can download per day ({{limit}})',
+      limit: rateLimit?.limit,
+    })
+  } else if (!downloadSupported) {
+    tooltip = t(
+      'download.trackNotAllowed',
+      "You don't have permissions to download tracks from this source"
+    )
+  }
+
+  return (
+    <IconButton
+      icon="download"
+      disabled={!downloadSupported || hasDownloadError}
+      tooltip={tooltip}
+      tooltipPlacement="top"
+      onClick={onDownloadClick}
+      size="small"
+    />
+  )
+}
+
+export default VesselDownload

--- a/apps/fishing-map/features/workspace/vessels/VesselDownload.tsx
+++ b/apps/fishing-map/features/workspace/vessels/VesselDownload.tsx
@@ -1,6 +1,8 @@
 import { t } from 'i18next'
 import { useSelector } from 'react-redux'
+import { useState } from 'react'
 import { IconButton } from '@globalfishingwatch/ui-components'
+import LocalStorageLoginLink from 'routes/LoginLink'
 import { useAppDispatch } from 'features/app/app.hooks'
 import { getVesselDatasetsDownloadTrackSupported } from 'features/datasets/datasets.utils'
 import {
@@ -8,7 +10,7 @@ import {
   selectDownloadTrackRateLimit,
   setDownloadTrackVessel,
 } from 'features/download/downloadTrack.slice'
-import { selectUserData } from 'features/user/user.slice'
+import { isGuestUser, selectUserData } from 'features/user/user.slice'
 import { VesselLayerPanelProps } from 'features/workspace/vessels/VesselLayerPanel'
 
 type VessselDownloadProps = VesselLayerPanelProps & {
@@ -20,7 +22,9 @@ type VessselDownloadProps = VesselLayerPanelProps & {
 function VesselDownload({ dataview, vesselId, vesselTitle, datasetId }: VessselDownloadProps) {
   const dispatch = useAppDispatch()
   const userData = useSelector(selectUserData)
+  const [isHover, setIsHover] = useState(false)
   const downloadError = useSelector(selectDownloadTrackError)
+  const guestUser = useSelector(isGuestUser)
   const rateLimit = useSelector(selectDownloadTrackRateLimit)
   const downloadDatasetsSupported = getVesselDatasetsDownloadTrackSupported(
     dataview,
@@ -37,6 +41,25 @@ function VesselDownload({ dataview, vesselId, vesselTitle, datasetId }: VessselD
         name: vesselTitle,
         datasets: datasetId,
       })
+    )
+  }
+  if (guestUser) {
+    return (
+      <LocalStorageLoginLink>
+        <IconButton
+          icon={isHover ? 'user' : 'download'}
+          tooltip={
+            t(
+              'download.trackLogin',
+              'Register and login to download vessel tracks (free, 2 minutes)'
+            ) as string
+          }
+          tooltipPlacement="top"
+          onMouseEnter={() => setIsHover(true)}
+          onMouseLeave={() => setIsHover(false)}
+          size="small"
+        />
+      </LocalStorageLoginLink>
     )
   }
 

--- a/apps/fishing-map/features/workspace/vessels/VesselLayerPanel.tsx
+++ b/apps/fishing-map/features/workspace/vessels/VesselLayerPanel.tsx
@@ -23,21 +23,15 @@ import { useDataviewInstancesConnect } from 'features/workspace/workspace.hook'
 import { selectResourceByUrl } from 'features/resources/resources.slice'
 import { VESSEL_DATAVIEW_INSTANCE_PREFIX } from 'features/dataviews/dataviews.utils'
 import ExpandedContainer from 'features/workspace/shared/ExpandedContainer'
-import { isGuestUser, isGFWUser, selectUserData } from 'features/user/user.slice'
+import { isGuestUser, isGFWUser } from 'features/user/user.slice'
 import I18nDate from 'features/i18n/i18nDate'
 import I18nFlag from 'features/i18n/i18nFlag'
-import {
-  getVesselDatasetsDownloadTrackSupported,
-  isGFWOnlyDataset,
-  isPrivateDataset,
-} from 'features/datasets/datasets.utils'
-import { setDownloadTrackVessel } from 'features/download/downloadTrack.slice'
+import { isGFWOnlyDataset, isPrivateDataset } from 'features/datasets/datasets.utils'
 import LocalStorageLoginLink from 'routes/LoginLink'
-import { useAppDispatch } from 'features/app/app.hooks'
-import { selectPrivateUserGroups } from 'features/user/user.selectors'
 import { useLayerPanelDataviewSort } from 'features/workspace/shared/layer-panel-sort.hook'
 import GFWOnly from 'features/user/GFWOnly'
 import DatasetLabel from 'features/datasets/DatasetLabel'
+import VesselDownload from 'features/workspace/vessels/VesselDownload'
 import Color from '../common/Color'
 import LayerSwitch from '../common/LayerSwitch'
 import Remove from '../common/Remove'
@@ -45,13 +39,12 @@ import Title from '../common/Title'
 import FitBounds from '../common/FitBounds'
 import InfoModal from '../common/InfoModal'
 
-type LayerPanelProps = {
+export type VesselLayerPanelProps = {
   dataview: UrlDataviewInstance
 }
 
-function LayerPanel({ dataview }: LayerPanelProps): React.ReactElement {
+function VesselLayerPanel({ dataview }: VesselLayerPanelProps): React.ReactElement {
   const { t } = useTranslation()
-  const dispatch = useAppDispatch()
   const { upsertDataviewInstance } = useDataviewInstancesConnect()
   const { url: infoUrl } = resolveDataviewDatasetResource(dataview, DatasetTypes.Vessels)
   const resources = useSelector(selectResources)
@@ -61,17 +54,10 @@ function LayerPanel({ dataview }: LayerPanelProps): React.ReactElement {
     useLayerPanelDataviewSort(dataview.id)
 
   const guestUser = useSelector(isGuestUser)
-  const userData = useSelector(selectUserData)
   const [colorOpen, setColorOpen] = useState(false)
   const [infoOpen, setInfoOpen] = useState(false)
   const [datasetModalOpen, setDatasetModalOpen] = useState(false)
   const gfwUser = useSelector(isGFWUser)
-  const userPrivateGroups = useSelector(selectPrivateUserGroups)
-  const downloadDatasetsSupported = getVesselDatasetsDownloadTrackSupported(
-    dataview,
-    userData?.permissions
-  )
-  const downloadSupported = downloadDatasetsSupported.length > 0
 
   const layerActive = dataview?.config?.visible ?? true
 
@@ -280,16 +266,6 @@ function LayerPanel({ dataview }: LayerPanelProps): React.ReactElement {
     </ExpandedContainer>
   )
 
-  const onDownloadClick = () => {
-    dispatch(
-      setDownloadTrackVessel({
-        id: vesselId,
-        name: vesselTitle,
-        datasets: trackResource?.dataset!?.id,
-      })
-    )
-  }
-
   return (
     <div
       className={cx(styles.LayerPanel, { [styles.expandedContainerOpen]: colorOpen || infoOpen })}
@@ -310,24 +286,12 @@ function LayerPanel({ dataview }: LayerPanelProps): React.ReactElement {
           })}
         >
           <Fragment>
-            {(gfwUser || userPrivateGroups?.length > 0) && (
-              <IconButton
-                icon="download"
-                disabled={!downloadSupported}
-                tooltip={
-                  downloadSupported
-                    ? t('download.trackAction', 'Download vessel track')
-                    : t(
-                        'download.trackNotAllowed',
-                        "You don't have permissions to download tracks from this source"
-                      )
-                }
-                tooltipPlacement="top"
-                onClick={onDownloadClick}
-                size="small"
-              />
-            )}
-
+            <VesselDownload
+              dataview={dataview}
+              vesselId={vesselId}
+              vesselTitle={vesselTitle}
+              datasetId={trackResource?.dataset!?.id}
+            />
             <Color
               dataview={dataview}
               open={colorOpen}
@@ -360,4 +324,4 @@ function LayerPanel({ dataview }: LayerPanelProps): React.ReactElement {
   )
 }
 
-export default LayerPanel
+export default VesselLayerPanel

--- a/apps/fishing-map/public/locales/source/translations.json
+++ b/apps/fishing-map/public/locales/source/translations.json
@@ -253,6 +253,7 @@
     "descriptionReport": "You can download a list of the activity or a heat map bitmap for this area in different formats",
     "downloadOptions": "Download options",
     "doYouNeedAnAPI": "Does your application need continuous data?",
+    "quotaReset": "The quota will be reset on {{reset}}",
     "format": "Format",
     "fullDataset": "Do you need the full dataset?",
     "fullTimeRange": "Full time range",
@@ -270,6 +271,7 @@
     "title": "Download",
     "track": "Vessel Track",
     "trackAction": "Download vessel track",
+    "trackLimitExceeded": "You have exceeded the limit of tracks you can download per day ({{limit}})",
     "trackNotAllowed": "You don't have permissions to download tracks from this source",
     "yearly": "Year",
     "yearlyNotAvailable": "Your time range is shorter than 1 year"

--- a/apps/fishing-map/public/locales/source/translations.json
+++ b/apps/fishing-map/public/locales/source/translations.json
@@ -272,6 +272,7 @@
     "track": "Vessel Track",
     "trackAction": "Download vessel track",
     "trackLimitExceeded": "You have exceeded the limit of tracks you can download per day ({{limit}})",
+    "trackLogin": "Register and login to download vessel tracks (free, 2 minutes)",
     "trackNotAllowed": "You don't have permissions to download tracks from this source",
     "yearly": "Year",
     "yearlyNotAvailable": "Your time range is shorter than 1 year"

--- a/libs/api-client/src/api-client.ts
+++ b/libs/api-client/src/api-client.ts
@@ -58,12 +58,19 @@ interface LibConfig {
   baseUrl?: string
 }
 
-const processStatus = (response: Response): Promise<Response> => {
+const processStatus = (
+  response: Response,
+  requestStatus?: ResourceResponseType
+): Promise<Response> => {
   return new Promise(async (resolve, reject) => {
     const { status, statusText } = response
     try {
       if (response.status >= 200 && response.status < 400) {
         return resolve(response)
+      }
+
+      if (requestStatus === 'default') {
+        return reject(response)
       }
       // Compatibility with v1 and v2 errors format
       const errors = {
@@ -303,6 +310,15 @@ export class GFW_API_CLASS {
     refreshRetries = 0,
     waitLogin = true
   ): Promise<T> {
+    const {
+      method = 'GET',
+      body = null,
+      headers = {},
+      responseType = 'json',
+      requestType = 'json',
+      signal,
+      local = false,
+    } = options
     try {
       if (this.logging && waitLogin) {
         // Don't do any request until the login is completed
@@ -317,15 +333,6 @@ export class GFW_API_CLASS {
       }
 
       try {
-        const {
-          method = 'GET',
-          body = null,
-          headers = {},
-          responseType = 'json',
-          requestType = 'json',
-          signal,
-          local = false,
-        } = options
         if (this.debug) {
           console.log(`GFWAPI: Fetching URL: ${url}`)
         }
@@ -349,7 +356,7 @@ export class GFW_API_CLASS {
           ...(body && { body: requestType === 'json' ? JSON.stringify(body) : body }),
           headers: finalHeaders,
         })
-          .then(processStatus)
+          .then((res) => processStatus(res, responseType))
           .then((res) => {
             switch (responseType) {
               case 'default':
@@ -423,12 +430,19 @@ export class GFW_API_CLASS {
             }
             console.warn(`GFWAPI: Error fetching ${url}`, e)
           }
+          if (responseType === 'default') {
+            throw e
+          }
+
           throw parseAPIError(e)
         }
       }
     } catch (e: any) {
       if (this.debug) {
         console.warn(`GFWAPI: Error fetching ${url}`, e)
+      }
+      if (responseType === 'default') {
+        throw e
       }
       throw parseAPIError(e)
     }

--- a/libs/api-types/src/vessel.ts
+++ b/libs/api-types/src/vessel.ts
@@ -1,3 +1,10 @@
+export type DownloadRateLimit = {
+  remaining: number | null
+  limit: number | null
+  reset: string | null
+  retryAfter: number | null
+}
+
 export interface Authorization {
   source: string
   startDate: string


### PR DESCRIPTION
Make the [download vessel track](https://globalfishingwatch.atlassian.net/browse/MAP-1167) option available for logged users with its rate limit

<img width="424" alt="image" src="https://github.com/GlobalFishingWatch/frontend/assets/10500650/32472389-b68a-423c-9bcd-a1d157ccff73">

<img width="775" alt="image" src="https://github.com/GlobalFishingWatch/frontend/assets/10500650/0f1b6c12-5c35-4a76-afb3-d95c8a670c18">

TODO:
- Enable request headers read from server