### PR TITLE
update maplibre version

### DIFF
--- a/apps/deck-playground/pages/styles.css
+++ b/apps/deck-playground/pages/styles.css
@@ -59,7 +59,7 @@
   stroke: var(--color-terthiary-blue);
 }
 
-.mapboxgl-control-container .mapboxgl-ctrl.mapboxgl-ctrl-attrib {
+.maplibregl-control-container .maplibregl-ctrl.maplibregl-ctrl-attrib {
   padding-right: var(--space-XS);
   padding-bottom: var(--space-XS);
   font: var(--font-XS);
@@ -68,33 +68,33 @@
   opacity: var(--opacity-secondary);
 }
 
-.mapboxgl-control-container .mapboxgl-ctrl.mapboxgl-ctrl-attrib a {
+.maplibregl-control-container .maplibregl-ctrl.maplibregl-ctrl-attrib a {
   color: var(--color-white);
   opacity: var(--opacity-secondary);
 }
 
-.mapboxgl-popup .mapboxgl-popup-content {
+.maplibregl-popup .maplibregl-popup-content {
   background: none;
   padding: 0;
   box-shadow: none;
   border: none;
 }
 
-.printing .mapboxgl-popup {
+.printing .maplibregl-popup {
   display: none !important;
 }
 
 @media print {
-  .mapboxgl-popup {
+  .maplibregl-popup {
     display: none !important;
   }
 }
 
-.hover.mapboxgl-popup .mapboxgl-popup-content {
+.hover.maplibregl-popup .maplibregl-popup-content {
   pointer-events: none;
 }
 
-.mapboxgl-popup .mapboxgl-popup-close-button {
+.maplibregl-popup .maplibregl-popup-close-button {
   width: var(--size-S);
   height: var(--size-S);
   border-radius: 50%;
@@ -111,42 +111,42 @@
   border: var(--border-white);
 }
 
-.mapboxgl-popup .mapboxgl-popup-close-button:hover {
+.maplibregl-popup .maplibregl-popup-close-button:hover {
   opacity: 1;
   color: rgba(var(--white-rgb), 1);
   background-color: var(--color-primary-blue);
 }
 
-.mapboxgl-popup.mapboxgl-popup-anchor-top .mapboxgl-popup-tip,
-.mapboxgl-popup.mapboxgl-popup-anchor-top-left .mapboxgl-popup-tip,
-.mapboxgl-popup.mapboxgl-popup-anchor-top-right .mapboxgl-popup-tip {
+.maplibregl-popup.maplibregl-popup-anchor-top .maplibregl-popup-tip,
+.maplibregl-popup.maplibregl-popup-anchor-top-left .maplibregl-popup-tip,
+.maplibregl-popup.maplibregl-popup-anchor-top-right .maplibregl-popup-tip {
   border-bottom-color: white;
   transform: translateY(1px);
 }
 
-.mapboxgl-popup.mapboxgl-popup-anchor-bottom .mapboxgl-popup-tip,
-.mapboxgl-popup.mapboxgl-popup-anchor-bottom-left .mapboxgl-popup-tip,
-.mapboxgl-popup.mapboxgl-popup-anchor-bottom-right .mapboxgl-popup-tip {
+.maplibregl-popup.maplibregl-popup-anchor-bottom .maplibregl-popup-tip,
+.maplibregl-popup.maplibregl-popup-anchor-bottom-left .maplibregl-popup-tip,
+.maplibregl-popup.maplibregl-popup-anchor-bottom-right .maplibregl-popup-tip {
   border-top-color: white;
   transform: translateY(-1px);
 }
 
-.mapboxgl-popup.mapboxgl-popup-anchor-left .mapboxgl-popup-tip {
+.maplibregl-popup.maplibregl-popup-anchor-left .maplibregl-popup-tip {
   border-right-color: white;
   transform: translateX(1px);
 }
 
-.mapboxgl-popup.mapboxgl-popup-anchor-right .mapboxgl-popup-tip {
+.maplibregl-popup.maplibregl-popup-anchor-right .maplibregl-popup-tip {
   border-left-color: white;
   transform: translateX(-1px);
 }
 
-.mapboxgl-ctrl-bottom-left .mapboxgl-ctrl,
+.maplibregl-ctrl-bottom-left .maplibregl-ctrl,
 .maplibregl-ctrl-bottom-left .maplibregl-ctrl {
   margin: 0 0 2.5rem 0.5rem !important;
 }
 
-.mapboxgl-control-container .mapboxgl-ctrl-scale {
+.maplibregl-control-container .maplibregl-ctrl-scale {
   min-height: 1.5rem;
   font: var(--font-XS);
   background: none;

--- a/apps/fishing-map/features/map/Map.module.css
+++ b/apps/fishing-map/features/map/Map.module.css
@@ -4,10 +4,7 @@
 
 .screenshot {
   position: absolute;
-  left: 0;
-  right: 0;
-  top: 0;
-  bottom: 0;
+  inset: 0;
   display: none;
   object-fit: contain;
   width: 100%;

--- a/apps/fishing-map/features/map/MapScreenshot.tsx
+++ b/apps/fishing-map/features/map/MapScreenshot.tsx
@@ -72,7 +72,7 @@ function MapScreenshot() {
   if (!screenshotImage) return null
 
   // insert the image just below the canvas
-  const canvasDomElement = document.querySelector('.mapboxgl-canvas-container')
+  const canvasDomElement = document.querySelector('.maplibregl-canvas-container')
   if (!canvasDomElement) return null
   const size = isPrintSupported
     ? `${printSize.current?.width.in} ${printSize.current?.height.in}`

--- a/apps/fishing-map/features/map/map-sources.hooks.ts
+++ b/apps/fishing-map/features/map/map-sources.hooks.ts
@@ -1,6 +1,11 @@
 import { useEffect, useMemo } from 'react'
 import { useRecoilValue, useSetRecoilState } from 'recoil'
-import { GeoJSONFeature, MapDataEvent, MapGeoJSONFeature } from '@globalfishingwatch/maplibre-gl'
+import {
+  FilterSpecification,
+  GeoJSONFeature,
+  MapDataEvent,
+  MapGeoJSONFeature,
+} from '@globalfishingwatch/maplibre-gl'
 import {
   ExtendedStyle,
   HeatmapLayerMeta,
@@ -168,7 +173,7 @@ type DataviewMetadata = {
   sourcesId: string[]
   generatorSourceId: string
   dataviewsId: string[]
-  filter?: string[]
+  filter?: FilterSpecification
 }
 
 // Key used to refresh activity graph only when active chunk changes and we can safely ignore the rest of the metadata
@@ -283,7 +288,7 @@ export const useMapDataviewFeatures = (
                 } else {
                   features = map.querySourceFeatures(sourceId, {
                     sourceLayer,
-                    filter: filter as string[],
+                    filter,
                   })
                 }
               }
@@ -314,7 +319,7 @@ export const useMapDataviewFeatures = (
           } else {
             features = map.querySourceFeatures(sourceId, {
               sourceLayer,
-              filter: filter as string[],
+              filter,
             })
           }
         }

--- a/apps/fishing-map/features/map/popups/Popup.module.css
+++ b/apps/fishing-map/features/map/popups/Popup.module.css
@@ -215,19 +215,19 @@
   flex-wrap: wrap;
 }
 
-.hover:global(.mapboxgl-popup .mapboxgl-popup-content) {
+.hover:global(.maplibregl-popup .maplibregl-popup-content) {
   background: none;
   pointer-events: none;
 }
 
-.hover:global(.mapboxgl-popup.mapboxgl-popup-anchor-top .mapboxgl-popup-tip),
-.hover:global(.mapboxgl-popup.mapboxgl-popup-anchor-bottom .mapboxgl-popup-tip),
-.hover:global(.mapboxgl-popup.mapboxgl-popup-anchor-left .mapboxgl-popup-tip),
-.hover:global(.mapboxgl-popup.mapboxgl-popup-anchor-right .mapboxgl-popup-tip),
-.hover:global(.mapboxgl-popup.mapboxgl-popup-anchor-top-left .mapboxgl-popup-tip),
-.hover:global(.mapboxgl-popup.mapboxgl-popup-anchor-top-right .mapboxgl-popup-tip),
-.hover:global(.mapboxgl-popup.mapboxgl-popup-anchor-bottom-left .mapboxgl-popup-tip),
-.hover:global(.mapboxgl-popup.mapboxgl-popup-anchor-bottom-right .mapboxgl-popup-tip) {
+.hover:global(.maplibregl-popup.maplibregl-popup-anchor-top .maplibregl-popup-tip),
+.hover:global(.maplibregl-popup.maplibregl-popup-anchor-bottom .maplibregl-popup-tip),
+.hover:global(.maplibregl-popup.maplibregl-popup-anchor-left .maplibregl-popup-tip),
+.hover:global(.maplibregl-popup.maplibregl-popup-anchor-right .maplibregl-popup-tip),
+.hover:global(.maplibregl-popup.maplibregl-popup-anchor-top-left .maplibregl-popup-tip),
+.hover:global(.maplibregl-popup.maplibregl-popup-anchor-top-right .maplibregl-popup-tip),
+.hover:global(.maplibregl-popup.maplibregl-popup-anchor-bottom-left .maplibregl-popup-tip),
+.hover:global(.maplibregl-popup.maplibregl-popup-anchor-bottom-right .maplibregl-popup-tip) {
   display: none;
   border-width: 0 !important;
   pointer-events: none;

--- a/apps/fishing-map/pages/styles.css
+++ b/apps/fishing-map/pages/styles.css
@@ -68,7 +68,7 @@
   stroke: var(--color-terthiary-blue);
 }
 
-.mapboxgl-control-container .mapboxgl-ctrl.mapboxgl-ctrl-attrib {
+.maplibregl-control-container .maplibregl-ctrl.maplibregl-ctrl-attrib {
   padding-right: var(--space-XS);
   padding-bottom: var(--space-XS);
   font: var(--font-XS);
@@ -77,33 +77,33 @@
   opacity: var(--opacity-secondary);
 }
 
-.mapboxgl-control-container .mapboxgl-ctrl.mapboxgl-ctrl-attrib a {
+.maplibregl-control-container .maplibregl-ctrl.maplibregl-ctrl-attrib a {
   color: var(--color-white);
   opacity: var(--opacity-secondary);
 }
 
-.mapboxgl-popup .mapboxgl-popup-content {
+.maplibregl-popup .maplibregl-popup-content {
   padding: 0;
   box-shadow: none;
   border: none;
   width: fit-content;
 }
 
-.printing .mapboxgl-popup {
+.printing .maplibregl-popup {
   display: none !important;
 }
 
 @media print {
-  .mapboxgl-popup {
+  .maplibregl-popup {
     display: none !important;
   }
 }
 
-.hover.mapboxgl-popup .mapboxgl-popup-content {
+.hover.maplibregl-popup .maplibregl-popup-content {
   pointer-events: none;
 }
 
-.mapboxgl-popup .mapboxgl-popup-close-button {
+.maplibregl-popup .maplibregl-popup-close-button {
   width: var(--size-S);
   height: var(--size-S);
   border-radius: 50%;
@@ -120,42 +120,42 @@
   border: var(--border-white);
 }
 
-.mapboxgl-popup .mapboxgl-popup-close-button:hover {
+.maplibregl-popup .maplibregl-popup-close-button:hover {
   opacity: 1;
   color: rgba(var(--white-rgb), 1);
   background-color: var(--color-primary-blue);
 }
 
-.mapboxgl-popup.mapboxgl-popup-anchor-top .mapboxgl-popup-tip,
-.mapboxgl-popup.mapboxgl-popup-anchor-top-left .mapboxgl-popup-tip,
-.mapboxgl-popup.mapboxgl-popup-anchor-top-right .mapboxgl-popup-tip {
+.maplibregl-popup.maplibregl-popup-anchor-top .maplibregl-popup-tip,
+.maplibregl-popup.maplibregl-popup-anchor-top-left .maplibregl-popup-tip,
+.maplibregl-popup.maplibregl-popup-anchor-top-right .maplibregl-popup-tip {
   border-bottom-color: white;
   transform: translateY(1px);
 }
 
-.mapboxgl-popup.mapboxgl-popup-anchor-bottom .mapboxgl-popup-tip,
-.mapboxgl-popup.mapboxgl-popup-anchor-bottom-left .mapboxgl-popup-tip,
-.mapboxgl-popup.mapboxgl-popup-anchor-bottom-right .mapboxgl-popup-tip {
+.maplibregl-popup.maplibregl-popup-anchor-bottom .maplibregl-popup-tip,
+.maplibregl-popup.maplibregl-popup-anchor-bottom-left .maplibregl-popup-tip,
+.maplibregl-popup.maplibregl-popup-anchor-bottom-right .maplibregl-popup-tip {
   border-top-color: white;
   transform: translateY(-1px);
 }
 
-.mapboxgl-popup.mapboxgl-popup-anchor-left .mapboxgl-popup-tip {
+.maplibregl-popup.maplibregl-popup-anchor-left .maplibregl-popup-tip {
   border-right-color: white;
   transform: translateX(1px);
 }
 
-.mapboxgl-popup.mapboxgl-popup-anchor-right .mapboxgl-popup-tip {
+.maplibregl-popup.maplibregl-popup-anchor-right .maplibregl-popup-tip {
   border-left-color: white;
   transform: translateX(-1px);
 }
 
-.mapboxgl-control-container .mapboxgl-ctrl-bottom-left {
+.maplibregl-control-container .maplibregl-ctrl-bottom-left {
   bottom: var(--space-M);
   left: 0;
 }
 
-.mapboxgl-control-container .mapboxgl-ctrl-scale {
+.maplibregl-control-container .maplibregl-ctrl-scale {
   min-height: 1.5rem;
   font: var(--font-XS);
   background: none;
@@ -166,44 +166,46 @@
   border-width: 1px;
 }
 
-.mapboxgl-map.mouse-pointer .mapboxgl-canvas-container.mapboxgl-interactive .mapboxgl-canvas {
+.maplibregl-map.mouse-pointer
+  .maplibregl-canvas-container.maplibregl-interactive
+  .maplibregl-canvas {
   cursor: pointer !important;
 }
 
-.mapboxgl-map.mouse-move .mapboxgl-canvas-container.mapboxgl-interactive .mapboxgl-canvas {
+.maplibregl-map.mouse-move .maplibregl-canvas-container.maplibregl-interactive .maplibregl-canvas {
   cursor: move !important;
 }
 
-.mapboxgl-map.mouse-add .mapboxgl-canvas-container.mapboxgl-interactive .mapboxgl-canvas {
+.maplibregl-map.mouse-add .maplibregl-canvas-container.maplibregl-interactive .maplibregl-canvas {
   cursor: crosshair !important;
 }
 
-.mapboxgl-map.mouse-move.mode-direct_select
-  .mapboxgl-canvas-container.mapboxgl-interactive
-  .mapboxgl-canvas {
+.maplibregl-map.mouse-move.mode-direct_select
+  .maplibregl-canvas-container.maplibregl-interactive
+  .maplibregl-canvas {
   cursor: grab !important;
 }
 
-.mapboxgl-map.mode-static.mouse-pointer
-  .mapboxgl-canvas-container.mapboxgl-interactive
-  .mapboxgl-canvas {
+.maplibregl-map.mode-static.mouse-pointer
+  .maplibregl-canvas-container.maplibregl-interactive
+  .maplibregl-canvas {
   cursor: grab !important;
 }
 
-.mapboxgl-map.mode-direct_select.feature-midpoint.mouse-pointer
-  .mapboxgl-canvas-container.mapboxgl-interactive
-  .mapboxgl-canvas {
+.maplibregl-map.mode-direct_select.feature-midpoint.mouse-pointer
+  .maplibregl-canvas-container.maplibregl-interactive
+  .maplibregl-canvas {
   cursor: cell !important;
 }
 
-.mapboxgl-map.mode-direct_select.feature-feature.mouse-move
-  .mapboxgl-canvas-container.mapboxgl-interactive
-  .mapboxgl-canvas {
+.maplibregl-map.mode-direct_select.feature-feature.mouse-move
+  .maplibregl-canvas-container.maplibregl-interactive
+  .maplibregl-canvas {
   cursor: move !important;
 }
 
-.mapboxgl-map.mode-direct_select.feature-vertex.mouse-move
-  .mapboxgl-canvas-container.mapboxgl-interactive
-  .mapboxgl-canvas {
+.maplibregl-map.mode-direct_select.feature-vertex.mouse-move
+  .maplibregl-canvas-container.maplibregl-interactive
+  .maplibregl-canvas {
   cursor: pointer !important;
 }

--- a/apps/fourwings-explorer/features/map/popups/Popup.module.css
+++ b/apps/fourwings-explorer/features/map/popups/Popup.module.css
@@ -97,19 +97,19 @@
   flex-wrap: wrap;
 }
 
-.hover:global(.mapboxgl-popup .mapboxgl-popup-content) {
+.hover:global(.maplibregl-popup .maplibregl-popup-content) {
   background: none;
   pointer-events: none;
 }
 
-.hover:global(.mapboxgl-popup.mapboxgl-popup-anchor-top .mapboxgl-popup-tip),
-.hover:global(.mapboxgl-popup.mapboxgl-popup-anchor-bottom .mapboxgl-popup-tip),
-.hover:global(.mapboxgl-popup.mapboxgl-popup-anchor-left .mapboxgl-popup-tip),
-.hover:global(.mapboxgl-popup.mapboxgl-popup-anchor-right .mapboxgl-popup-tip),
-.hover:global(.mapboxgl-popup.mapboxgl-popup-anchor-top-left .mapboxgl-popup-tip),
-.hover:global(.mapboxgl-popup.mapboxgl-popup-anchor-top-right .mapboxgl-popup-tip),
-.hover:global(.mapboxgl-popup.mapboxgl-popup-anchor-bottom-left .mapboxgl-popup-tip),
-.hover:global(.mapboxgl-popup.mapboxgl-popup-anchor-bottom-right .mapboxgl-popup-tip) {
+.hover:global(.maplibregl-popup.maplibregl-popup-anchor-top .maplibregl-popup-tip),
+.hover:global(.maplibregl-popup.maplibregl-popup-anchor-bottom .maplibregl-popup-tip),
+.hover:global(.maplibregl-popup.maplibregl-popup-anchor-left .maplibregl-popup-tip),
+.hover:global(.maplibregl-popup.maplibregl-popup-anchor-right .maplibregl-popup-tip),
+.hover:global(.maplibregl-popup.maplibregl-popup-anchor-top-left .maplibregl-popup-tip),
+.hover:global(.maplibregl-popup.maplibregl-popup-anchor-top-right .maplibregl-popup-tip),
+.hover:global(.maplibregl-popup.maplibregl-popup-anchor-bottom-left .maplibregl-popup-tip),
+.hover:global(.maplibregl-popup.maplibregl-popup-anchor-bottom-right .maplibregl-popup-tip) {
   display: none;
   border-width: 0 !important;
   pointer-events: none;

--- a/apps/fourwings-explorer/pages/styles.css
+++ b/apps/fourwings-explorer/pages/styles.css
@@ -59,7 +59,7 @@
   stroke: var(--color-terthiary-blue);
 }
 
-.mapboxgl-control-container .mapboxgl-ctrl.mapboxgl-ctrl-attrib {
+.maplibregl-control-container .maplibregl-ctrl.maplibregl-ctrl-attrib {
   padding-right: var(--space-XS);
   padding-bottom: var(--space-XS);
   font: var(--font-XS);
@@ -68,33 +68,33 @@
   opacity: var(--opacity-secondary);
 }
 
-.mapboxgl-control-container .mapboxgl-ctrl.mapboxgl-ctrl-attrib a {
+.maplibregl-control-container .maplibregl-ctrl.maplibregl-ctrl-attrib a {
   color: var(--color-white);
   opacity: var(--opacity-secondary);
 }
 
-.mapboxgl-popup .mapboxgl-popup-content {
+.maplibregl-popup .maplibregl-popup-content {
   background: none;
   padding: 0;
   box-shadow: none;
   border: none;
 }
 
-.printing .mapboxgl-popup {
+.printing .maplibregl-popup {
   display: none !important;
 }
 
 @media print {
-  .mapboxgl-popup {
+  .maplibregl-popup {
     display: none !important;
   }
 }
 
-.hover.mapboxgl-popup .mapboxgl-popup-content {
+.hover.maplibregl-popup .maplibregl-popup-content {
   pointer-events: none;
 }
 
-.mapboxgl-popup .mapboxgl-popup-close-button {
+.maplibregl-popup .maplibregl-popup-close-button {
   width: var(--size-S);
   height: var(--size-S);
   border-radius: 50%;
@@ -111,42 +111,42 @@
   border: var(--border-white);
 }
 
-.mapboxgl-popup .mapboxgl-popup-close-button:hover {
+.maplibregl-popup .maplibregl-popup-close-button:hover {
   opacity: 1;
   color: rgba(var(--white-rgb), 1);
   background-color: var(--color-primary-blue);
 }
 
-.mapboxgl-popup.mapboxgl-popup-anchor-top .mapboxgl-popup-tip,
-.mapboxgl-popup.mapboxgl-popup-anchor-top-left .mapboxgl-popup-tip,
-.mapboxgl-popup.mapboxgl-popup-anchor-top-right .mapboxgl-popup-tip {
+.maplibregl-popup.maplibregl-popup-anchor-top .maplibregl-popup-tip,
+.maplibregl-popup.maplibregl-popup-anchor-top-left .maplibregl-popup-tip,
+.maplibregl-popup.maplibregl-popup-anchor-top-right .maplibregl-popup-tip {
   border-bottom-color: white;
   transform: translateY(1px);
 }
 
-.mapboxgl-popup.mapboxgl-popup-anchor-bottom .mapboxgl-popup-tip,
-.mapboxgl-popup.mapboxgl-popup-anchor-bottom-left .mapboxgl-popup-tip,
-.mapboxgl-popup.mapboxgl-popup-anchor-bottom-right .mapboxgl-popup-tip {
+.maplibregl-popup.maplibregl-popup-anchor-bottom .maplibregl-popup-tip,
+.maplibregl-popup.maplibregl-popup-anchor-bottom-left .maplibregl-popup-tip,
+.maplibregl-popup.maplibregl-popup-anchor-bottom-right .maplibregl-popup-tip {
   border-top-color: white;
   transform: translateY(-1px);
 }
 
-.mapboxgl-popup.mapboxgl-popup-anchor-left .mapboxgl-popup-tip {
+.maplibregl-popup.maplibregl-popup-anchor-left .maplibregl-popup-tip {
   border-right-color: white;
   transform: translateX(1px);
 }
 
-.mapboxgl-popup.mapboxgl-popup-anchor-right .mapboxgl-popup-tip {
+.maplibregl-popup.maplibregl-popup-anchor-right .maplibregl-popup-tip {
   border-left-color: white;
   transform: translateX(-1px);
 }
 
-.mapboxgl-ctrl-bottom-left .mapboxgl-ctrl,
+.maplibregl-ctrl-bottom-left .maplibregl-ctrl,
 .maplibregl-ctrl-bottom-left .maplibregl-ctrl {
   margin: 0 0 2.5rem 0.5rem !important;
 }
 
-.mapboxgl-control-container .mapboxgl-ctrl-scale {
+.maplibregl-control-container .maplibregl-ctrl-scale {
   min-height: 1.5rem;
   font: var(--font-XS);
   background: none;

--- a/apps/port-labeler/pages/styles.css
+++ b/apps/port-labeler/pages/styles.css
@@ -59,7 +59,7 @@
   stroke: var(--color-terthiary-blue);
 }
 
-.mapboxgl-control-container .mapboxgl-ctrl.mapboxgl-ctrl-attrib {
+.maplibregl-control-container .maplibregl-ctrl.maplibregl-ctrl-attrib {
   padding-right: var(--space-XS);
   padding-bottom: var(--space-XS);
   font: var(--font-XS);
@@ -68,33 +68,33 @@
   opacity: var(--opacity-secondary);
 }
 
-.mapboxgl-control-container .mapboxgl-ctrl.mapboxgl-ctrl-attrib a {
+.maplibregl-control-container .maplibregl-ctrl.maplibregl-ctrl-attrib a {
   color: var(--color-white);
   opacity: var(--opacity-secondary);
 }
 
-.mapboxgl-popup .mapboxgl-popup-content {
+.maplibregl-popup .maplibregl-popup-content {
   background: none;
   padding: 0;
   box-shadow: none;
   border: none;
 }
 
-.printing .mapboxgl-popup {
+.printing .maplibregl-popup {
   display: none !important;
 }
 
 @media print {
-  .mapboxgl-popup {
+  .maplibregl-popup {
     display: none !important;
   }
 }
 
-.hover.mapboxgl-popup .mapboxgl-popup-content {
+.hover.maplibregl-popup .maplibregl-popup-content {
   /* pointer-events: none; */
 }
 
-.mapboxgl-popup .mapboxgl-popup-close-button {
+.maplibregl-popup .maplibregl-popup-close-button {
   width: var(--size-S);
   height: var(--size-S);
   border-radius: 50%;
@@ -111,32 +111,32 @@
   border: var(--border-white);
 }
 
-.mapboxgl-popup .mapboxgl-popup-close-button:hover {
+.maplibregl-popup .maplibregl-popup-close-button:hover {
   opacity: 1;
   color: rgba(var(--white-rgb), 1);
   background-color: var(--color-primary-blue);
 }
 
-.mapboxgl-popup.mapboxgl-popup-anchor-top .mapboxgl-popup-tip,
-.mapboxgl-popup.mapboxgl-popup-anchor-top-left .mapboxgl-popup-tip,
-.mapboxgl-popup.mapboxgl-popup-anchor-top-right .mapboxgl-popup-tip {
+.maplibregl-popup.maplibregl-popup-anchor-top .maplibregl-popup-tip,
+.maplibregl-popup.maplibregl-popup-anchor-top-left .maplibregl-popup-tip,
+.maplibregl-popup.maplibregl-popup-anchor-top-right .maplibregl-popup-tip {
   border-bottom-color: white;
   transform: translateY(1px);
 }
 
-.mapboxgl-popup.mapboxgl-popup-anchor-bottom .mapboxgl-popup-tip,
-.mapboxgl-popup.mapboxgl-popup-anchor-bottom-left .mapboxgl-popup-tip,
-.mapboxgl-popup.mapboxgl-popup-anchor-bottom-right .mapboxgl-popup-tip {
+.maplibregl-popup.maplibregl-popup-anchor-bottom .maplibregl-popup-tip,
+.maplibregl-popup.maplibregl-popup-anchor-bottom-left .maplibregl-popup-tip,
+.maplibregl-popup.maplibregl-popup-anchor-bottom-right .maplibregl-popup-tip {
   border-top-color: white;
   transform: translateY(-1px);
 }
 
-.mapboxgl-popup.mapboxgl-popup-anchor-left .mapboxgl-popup-tip {
+.maplibregl-popup.maplibregl-popup-anchor-left .maplibregl-popup-tip {
   border-right-color: white;
   transform: translateX(1px);
 }
 
-.mapboxgl-popup.mapboxgl-popup-anchor-right .mapboxgl-popup-tip {
+.maplibregl-popup.maplibregl-popup-anchor-right .maplibregl-popup-tip {
   border-left-color: white;
   transform: translateX(-1px);
 }

--- a/apps/real-time-prototype/pages/styles.css
+++ b/apps/real-time-prototype/pages/styles.css
@@ -59,7 +59,7 @@
   stroke: var(--color-terthiary-blue);
 }
 
-.mapboxgl-control-container .mapboxgl-ctrl.mapboxgl-ctrl-attrib {
+.maplibregl-control-container .maplibregl-ctrl.maplibregl-ctrl-attrib {
   padding-right: var(--space-XS);
   padding-bottom: var(--space-XS);
   font: var(--font-XS);
@@ -68,33 +68,33 @@
   opacity: var(--opacity-secondary);
 }
 
-.mapboxgl-control-container .mapboxgl-ctrl.mapboxgl-ctrl-attrib a {
+.maplibregl-control-container .maplibregl-ctrl.maplibregl-ctrl-attrib a {
   color: var(--color-white);
   opacity: var(--opacity-secondary);
 }
 
-.mapboxgl-popup .mapboxgl-popup-content {
+.maplibregl-popup .maplibregl-popup-content {
   background: none;
   padding: 0;
   box-shadow: none;
   border: none;
 }
 
-.printing .mapboxgl-popup {
+.printing .maplibregl-popup {
   display: none !important;
 }
 
 @media print {
-  .mapboxgl-popup {
+  .maplibregl-popup {
     display: none !important;
   }
 }
 
-.hover.mapboxgl-popup .mapboxgl-popup-content {
+.hover.maplibregl-popup .maplibregl-popup-content {
   pointer-events: none;
 }
 
-.mapboxgl-popup .mapboxgl-popup-close-button {
+.maplibregl-popup .maplibregl-popup-close-button {
   width: var(--size-S);
   height: var(--size-S);
   border-radius: 50%;
@@ -111,42 +111,42 @@
   border: var(--border-white);
 }
 
-.mapboxgl-popup .mapboxgl-popup-close-button:hover {
+.maplibregl-popup .maplibregl-popup-close-button:hover {
   opacity: 1;
   color: rgba(var(--white-rgb), 1);
   background-color: var(--color-primary-blue);
 }
 
-.mapboxgl-popup.mapboxgl-popup-anchor-top .mapboxgl-popup-tip,
-.mapboxgl-popup.mapboxgl-popup-anchor-top-left .mapboxgl-popup-tip,
-.mapboxgl-popup.mapboxgl-popup-anchor-top-right .mapboxgl-popup-tip {
+.maplibregl-popup.maplibregl-popup-anchor-top .maplibregl-popup-tip,
+.maplibregl-popup.maplibregl-popup-anchor-top-left .maplibregl-popup-tip,
+.maplibregl-popup.maplibregl-popup-anchor-top-right .maplibregl-popup-tip {
   border-bottom-color: white;
   transform: translateY(1px);
 }
 
-.mapboxgl-popup.mapboxgl-popup-anchor-bottom .mapboxgl-popup-tip,
-.mapboxgl-popup.mapboxgl-popup-anchor-bottom-left .mapboxgl-popup-tip,
-.mapboxgl-popup.mapboxgl-popup-anchor-bottom-right .mapboxgl-popup-tip {
+.maplibregl-popup.maplibregl-popup-anchor-bottom .maplibregl-popup-tip,
+.maplibregl-popup.maplibregl-popup-anchor-bottom-left .maplibregl-popup-tip,
+.maplibregl-popup.maplibregl-popup-anchor-bottom-right .maplibregl-popup-tip {
   border-top-color: white;
   transform: translateY(-1px);
 }
 
-.mapboxgl-popup.mapboxgl-popup-anchor-left .mapboxgl-popup-tip {
+.maplibregl-popup.maplibregl-popup-anchor-left .maplibregl-popup-tip {
   border-right-color: white;
   transform: translateX(1px);
 }
 
-.mapboxgl-popup.mapboxgl-popup-anchor-right .mapboxgl-popup-tip {
+.maplibregl-popup.maplibregl-popup-anchor-right .maplibregl-popup-tip {
   border-left-color: white;
   transform: translateX(-1px);
 }
 
-.mapboxgl-ctrl-bottom-left .mapboxgl-ctrl,
+.maplibregl-ctrl-bottom-left .maplibregl-ctrl,
 .maplibregl-ctrl-bottom-left .maplibregl-ctrl {
   margin: 0 0 2.5rem 0.5rem !important;
 }
 
-.mapboxgl-control-container .mapboxgl-ctrl-scale {
+.maplibregl-control-container .maplibregl-ctrl-scale {
   min-height: 1.5rem;
   font: var(--font-XS);
   background: none;

--- a/apps/vessel-history/features/map/popups/Popup.module.css
+++ b/apps/vessel-history/features/map/popups/Popup.module.css
@@ -55,19 +55,19 @@
   margin-bottom: 0;
 }
 
-.hover:global(.mapboxgl-popup .mapboxgl-popup-content) {
+.hover:global(.maplibregl-popup .maplibregl-popup-content) {
   background: none;
   pointer-events: none;
 }
 
-.hover:global(.mapboxgl-popup.mapboxgl-popup-anchor-top .mapboxgl-popup-tip),
-.hover:global(.mapboxgl-popup.mapboxgl-popup-anchor-bottom .mapboxgl-popup-tip),
-.hover:global(.mapboxgl-popup.mapboxgl-popup-anchor-left .mapboxgl-popup-tip),
-.hover:global(.mapboxgl-popup.mapboxgl-popup-anchor-right .mapboxgl-popup-tip),
-.hover:global(.mapboxgl-popup.mapboxgl-popup-anchor-top-left .mapboxgl-popup-tip),
-.hover:global(.mapboxgl-popup.mapboxgl-popup-anchor-top-right .mapboxgl-popup-tip),
-.hover:global(.mapboxgl-popup.mapboxgl-popup-anchor-bottom-left .mapboxgl-popup-tip),
-.hover:global(.mapboxgl-popup.mapboxgl-popup-anchor-bottom-right .mapboxgl-popup-tip) {
+.hover:global(.maplibregl-popup.maplibregl-popup-anchor-top .maplibregl-popup-tip),
+.hover:global(.maplibregl-popup.maplibregl-popup-anchor-bottom .maplibregl-popup-tip),
+.hover:global(.maplibregl-popup.maplibregl-popup-anchor-left .maplibregl-popup-tip),
+.hover:global(.maplibregl-popup.maplibregl-popup-anchor-right .maplibregl-popup-tip),
+.hover:global(.maplibregl-popup.maplibregl-popup-anchor-top-left .maplibregl-popup-tip),
+.hover:global(.maplibregl-popup.maplibregl-popup-anchor-top-right .maplibregl-popup-tip),
+.hover:global(.maplibregl-popup.maplibregl-popup-anchor-bottom-left .maplibregl-popup-tip),
+.hover:global(.maplibregl-popup.maplibregl-popup-anchor-bottom-right .maplibregl-popup-tip) {
   display: none;
   border-width: 0 !important;
   pointer-events: none;

--- a/libs/layer-composer/package.json
+++ b/libs/layer-composer/package.json
@@ -12,7 +12,7 @@
     "url": "git+https://github.com/GlobalFishingWatch/frontend.git"
   },
   "dependencies": {
-    "@globalfishingwatch/maplibre-gl": "^2.2.0-gfw.25",
+    "@globalfishingwatch/maplibre-gl": "^3.3.1-gfw.1",
     "@mapbox/tilebelt": "^1.0.2",
     "@mapbox/vector-tile": "^1.3.1",
     "@turf/great-circle": "^6.5.0",

--- a/libs/layer-composer/src/generators/heatmap/modes/gridded.ts
+++ b/libs/layer-composer/src/generators/heatmap/modes/gridded.ts
@@ -78,7 +78,7 @@ export default function gridded(
       getLayerId(config.id, timeChunk),
       getSourceId(config.id, timeChunk)
     )
-    chunkMainLayer.paint = paint
+    chunkMainLayer.paint = paint as any
     // only add legend metadata for first time chunk
     const chunkLayers: LayerSpecification[] = [chunkMainLayer]
 

--- a/libs/layer-composer/src/generators/heatmap/util/get-base-layers.ts
+++ b/libs/layer-composer/src/generators/heatmap/util/get-base-layers.ts
@@ -1,10 +1,12 @@
 import {
   SymbolLayerSpecification,
-  FilterSpecification,
   FillLayerSpecification,
   LineLayerSpecification,
   FillExtrusionLayerSpecification,
   HeatmapLayerSpecification,
+  DataDrivenPropertyValueSpecification,
+  FormattedSpecification,
+  ExpressionSpecification,
 } from '@globalfishingwatch/maplibre-gl'
 import { ExtendedLayerMeta, Group } from '../../../types'
 import { GeneratorType } from '../../types'
@@ -87,11 +89,16 @@ export function getBaseInteractionHoverLayer(
 }
 
 export function getBaseDebugLabelsLayer(
-  exprPick: FilterSpecification,
+  exprPick: ExpressionSpecification,
   id: string,
   source: string
 ): SymbolLayerSpecification {
-  const exprDebugText = ['case', ['>', exprPick, 0], ['to-string', exprPick], '']
+  const exprDebugText: DataDrivenPropertyValueSpecification<FormattedSpecification> = [
+    'case',
+    ['>', exprPick, 0],
+    ['to-string', exprPick],
+    '',
+  ]
   return {
     id,
     source,

--- a/libs/layer-composer/src/generators/user-context/user-context.ts
+++ b/libs/layer-composer/src/generators/user-context/user-context.ts
@@ -3,6 +3,9 @@ import type {
   LayerSpecification,
   FillLayerSpecification,
   LineLayerSpecification,
+  DataDrivenPropertyValueSpecification,
+  FormattedSpecification,
+  ExpressionSpecification,
 } from '@globalfishingwatch/maplibre-gl'
 import { DEFAULT_CONTEXT_SOURCE_LAYER } from '../context/config'
 import { GeneratorType, UserContextGeneratorConfig } from '../types'
@@ -45,8 +48,16 @@ class UserContextGenerator {
     if (config.steps?.length && config.colorRamp) {
       const originalColorRamp = HEATMAP_COLOR_RAMPS[config.colorRamp]
       const legendRamp = zip(config.steps, originalColorRamp)
-      const valueExpression = ['to-number', ['get', config.pickValueAt || 'value']]
-      const colorRamp = ['interpolate', ['linear'], valueExpression, ...flatten(legendRamp)]
+      const valueExpression: ExpressionSpecification = [
+        'to-number',
+        ['get', config.pickValueAt || 'value'],
+      ]
+      const colorRamp: DataDrivenPropertyValueSpecification<FormattedSpecification> = [
+        'interpolate',
+        ['linear'],
+        valueExpression,
+        ...(flatten(legendRamp) as any),
+      ]
       const stepsLayer: FillLayerSpecification = {
         ...baseLayer,
         type: 'fill' as const,

--- a/libs/layer-composer/src/generators/vessel-events/vessel-events.ts
+++ b/libs/layer-composer/src/generators/vessel-events/vessel-events.ts
@@ -2,6 +2,8 @@ import memoizeOne from 'memoize-one'
 import { FeatureCollection } from 'geojson'
 import type {
   CircleLayerSpecification,
+  ColorSpecification,
+  DataDrivenPropertyValueSpecification,
   LineLayerSpecification,
   SymbolLayerSpecification,
 } from '@globalfishingwatch/maplibre-gl'
@@ -124,12 +126,23 @@ class VesselsEventsGenerator {
             14,
             [...activeFilter, 2, 3],
           ],
-          'circle-stroke-color': [...activeFilter, activeStrokeColor, strokeColor],
-          'circle-radius': [...activeFilter, 8 * activeIconsSize, 4 * inactiveIconsSize],
-
+          'circle-stroke-color': [
+            ...activeFilter,
+            activeStrokeColor,
+            strokeColor,
+          ] as DataDrivenPropertyValueSpecification<ColorSpecification>,
+          'circle-radius': [
+            ...activeFilter,
+            8 * activeIconsSize,
+            4 * inactiveIconsSize,
+          ] as DataDrivenPropertyValueSpecification<number>,
         },
         layout: {
-          'circle-sort-key': [...activeFilter, 1000, 500]
+          'circle-sort-key': [
+            ...activeFilter,
+            1000,
+            500,
+          ] as DataDrivenPropertyValueSpecification<number>,
         },
         metadata: {
           group: Group.Point,
@@ -149,8 +162,16 @@ class VesselsEventsGenerator {
         layout: {
           'icon-allow-overlap': true,
           'icon-image': ['get', 'icon'],
-          'icon-size': [...activeFilter, 1 * iconsSize, 0],
-          'symbol-sort-key': [...activeFilter, 1000, 500]
+          'icon-size': [
+            ...activeFilter,
+            1 * iconsSize,
+            0,
+          ] as DataDrivenPropertyValueSpecification<number>,
+          'symbol-sort-key': [
+            ...activeFilter,
+            1000,
+            500,
+          ] as DataDrivenPropertyValueSpecification<number>,
         },
         metadata: {
           group: Group.Point,
@@ -175,7 +196,7 @@ class VesselsEventsGenerator {
         },
         paint: {
           'line-color': ['get', 'color'],
-          'line-width': [...activeFilter, 6, 1.5],
+          'line-width': [...activeFilter, 6, 1.5] as DataDrivenPropertyValueSpecification<number>,
           'line-opacity': 1,
         },
         metadata: {

--- a/libs/react-hooks/package.json
+++ b/libs/react-hooks/package.json
@@ -16,7 +16,7 @@
     "@globalfishingwatch/dataviews-client": "14.x",
     "@globalfishingwatch/fourwings-aggregate": "4.x",
     "@globalfishingwatch/layer-composer": "10.x",
-    "@globalfishingwatch/maplibre-gl": "^2.2.0-gfw.25",
+    "@globalfishingwatch/maplibre-gl": "^3.3.1-gfw.1",
     "lodash": "4.x"
   },
   "publishConfig": {

--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
     "@babel/plugin-transform-react-jsx": "^7.20.13",
     "@babel/preset-react": "^7.14.5",
     "@globalfishingwatch/linting": "2.0.2",
-    "@globalfishingwatch/maplibre-gl": "^2.2.0-gfw.25",
+    "@globalfishingwatch/maplibre-gl": "^3.3.1-gfw.1",
     "@jscutlery/semver": "^2.29.3",
     "@next/bundle-analyzer": "^13.1.6",
     "@next/eslint-plugin-next": "13.1.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2270,14 +2270,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@globalfishingwatch/fourwings-aggregate@npm:4.2.1":
-  version: 4.2.1
-  resolution: "@globalfishingwatch/fourwings-aggregate@npm:4.2.1"
-  checksum: a49d6294f0c422a772c614e008ec8316f1454ee9ca3b60deaca8c55c59cb48075f85eac5d2b6fe8a4e56de491cc4e5189dcb3894d4886c39fdca58f5a7c29e6f
-  languageName: node
-  linkType: hard
-
-"@globalfishingwatch/fourwings-aggregate@workspace:libs/fourwings-aggregate":
+"@globalfishingwatch/fourwings-aggregate@4.3.0, @globalfishingwatch/fourwings-aggregate@workspace:libs/fourwings-aggregate":
   version: 0.0.0-use.local
   resolution: "@globalfishingwatch/fourwings-aggregate@workspace:libs/fourwings-aggregate"
   languageName: unknown
@@ -2296,7 +2289,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@globalfishingwatch/layer-composer@workspace:libs/layer-composer"
   dependencies:
-    "@globalfishingwatch/maplibre-gl": ^2.2.0-gfw.25
+    "@globalfishingwatch/maplibre-gl": ^3.3.1-gfw.1
     "@mapbox/tilebelt": ^1.0.2
     "@mapbox/vector-tile": ^1.3.1
     "@turf/great-circle": ^6.5.0
@@ -2361,41 +2354,62 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@globalfishingwatch/maplibre-gl@npm:^2.2.0-gfw.25":
-  version: 2.2.0-gfw.25
-  resolution: "@globalfishingwatch/maplibre-gl@npm:2.2.0-gfw.25"
+"@globalfishingwatch/maplibre-gl-style-spec@npm:^19.3.1":
+  version: 19.3.1
+  resolution: "@globalfishingwatch/maplibre-gl-style-spec@npm:19.3.1"
   dependencies:
-    "@globalfishingwatch/fourwings-aggregate": 4.2.1
-    "@mapbox/geojson-rewind": ^0.5.1
+    "@mapbox/jsonlint-lines-primitives": ~2.0.2
+    "@mapbox/unitbezier": ^0.0.1
+    json-stringify-pretty-compact: ^3.0.0
+    minimist: ^1.2.8
+    rw: ^1.3.3
+    sort-object: ^3.0.3
+  bin:
+    gl-style-format: dist/gl-style-format.mjs
+    gl-style-migrate: dist/gl-style-migrate.mjs
+    gl-style-validate: dist/gl-style-validate.mjs
+  checksum: d6d7a1ecffa82edb8bef7425c48ea52e1487603f1c8da6c049525ecb411f3dd6d6bd91ee21e495ebb04d4fda05fa49e496e4eb2584c63a9d589ec40a8cd0c22b
+  languageName: node
+  linkType: hard
+
+"@globalfishingwatch/maplibre-gl@npm:^3.3.1-gfw.1":
+  version: 3.3.1-gfw.1
+  resolution: "@globalfishingwatch/maplibre-gl@npm:3.3.1-gfw.1"
+  dependencies:
+    "@globalfishingwatch/fourwings-aggregate": 4.3.0
+    "@globalfishingwatch/maplibre-gl-style-spec": ^19.3.1
+    "@mapbox/geojson-rewind": ^0.5.2
     "@mapbox/jsonlint-lines-primitives": ^2.0.2
-    "@mapbox/mapbox-gl-supported": ^2.0.1
     "@mapbox/point-geometry": ^0.1.0
     "@mapbox/tilebelt": ^1.0.2
-    "@mapbox/tiny-sdf": ^2.0.4
+    "@mapbox/tiny-sdf": ^2.0.6
     "@mapbox/unitbezier": ^0.0.1
     "@mapbox/vector-tile": ^1.3.1
     "@mapbox/whoots-js": ^3.1.0
+    "@maplibre/maplibre-gl-style-spec": ^19.3.0
     "@swc/core-linux-x64-gnu": ^1.2.192
-    "@types/geojson": ^7946.0.8
+    "@types/geojson": ^7946.0.10
     "@types/mapbox__point-geometry": ^0.1.2
     "@types/mapbox__vector-tile": ^1.3.0
     "@types/pbf": ^3.0.2
-    csscolorparser: ~1.0.3
-    earcut: ^2.2.3
+    "@types/supercluster": ^7.1.0
+    earcut: ^2.2.4
     geojson-vt: ^3.2.1
     gl-matrix: ^3.4.3
+    global-prefix: ^3.0.0
+    kdbush: ^4.0.2
     lodash: ^4.17.21
     murmurhash-js: ^1.0.0
     pbf: ^3.2.1
-    potpack: ^1.0.2
+    potpack: ^2.0.0
     quickselect: ^2.0.0
-    supercluster: ^7.1.4
+    supercluster: ^8.0.1
     tinyqueue: ^2.0.3
     vt-pbf: ^3.1.3
   dependenciesMeta:
     "@swc/core-linux-x64-gnu":
       optional: true
-  checksum: cf04b2721b7135a4bcb74f4af92f9e9f1b2b4f71412006e6813e6cc2c1be4655b6af59f45c21feb49ea53d89b97458f92ea35b7e5620b58582003d4c91d25bbf
+  checksum: ab4b26aea1e6dd9dc3eca60ee8470238d23c3b86172a16ddf31a7d105068f75752ca4232b141c144f13d31d2dcccdea0e196c076e78433e3d3531f038ed9a742
   languageName: node
   linkType: hard
 
@@ -2432,7 +2446,7 @@ __metadata:
     "@globalfishingwatch/dataviews-client": 14.x
     "@globalfishingwatch/fourwings-aggregate": 4.x
     "@globalfishingwatch/layer-composer": 10.x
-    "@globalfishingwatch/maplibre-gl": ^2.2.0-gfw.25
+    "@globalfishingwatch/maplibre-gl": ^3.3.1-gfw.1
     lodash: 4.x
   languageName: unknown
   linkType: soft
@@ -2453,7 +2467,7 @@ __metadata:
     "@deck.gl/react": ^8.9.19
     "@globalfishingwatch/linting": 2.0.2
     "@globalfishingwatch/map-convert": "github:GlobalFishingWatch/map-convert"
-    "@globalfishingwatch/maplibre-gl": ^2.2.0-gfw.25
+    "@globalfishingwatch/maplibre-gl": ^3.3.1-gfw.1
     "@jscutlery/semver": ^2.29.3
     "@loaders.gl/core": ^3.2.13
     "@loaders.gl/loader-utils": ^3.2.13
@@ -4053,7 +4067,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@mapbox/geojson-rewind@npm:^0.5.1":
+"@mapbox/geojson-rewind@npm:^0.5.2":
   version: 0.5.2
   resolution: "@mapbox/geojson-rewind@npm:0.5.2"
   dependencies:
@@ -4080,7 +4094,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@mapbox/jsonlint-lines-primitives@npm:^2.0.2":
+"@mapbox/jsonlint-lines-primitives@npm:^2.0.2, @mapbox/jsonlint-lines-primitives@npm:~2.0.2":
   version: 2.0.2
   resolution: "@mapbox/jsonlint-lines-primitives@npm:2.0.2"
   checksum: 4eb31edd3ccff530f7b687ddc6d813d6e24fc66e9a563460882e7861b49f9331c5ded6fd7e927b37affbbd98f83bff1f7b916119044f1931df03c6ffedba2cfb
@@ -4099,13 +4113,6 @@ __metadata:
     lodash.isequal: ^4.5.0
     xtend: ^4.0.2
   checksum: cd010c35b5cf9cc01b34874d0f9f7043ec472434e069cb7a9ed1af09e49651b2b19eac754b16d0b9c673a874171bff8f49fb746ca710a2fbc1b394cee6f2b91c
-  languageName: node
-  linkType: hard
-
-"@mapbox/mapbox-gl-supported@npm:^2.0.1":
-  version: 2.0.1
-  resolution: "@mapbox/mapbox-gl-supported@npm:2.0.1"
-  checksum: 1dffc96baacc56e34b09f2ae6ac4b2b8f10ad51a9d7c4946dc2057f456deeacd5d0729e340120857b3204a14d9961266f3218d26e101d46e81717954f1c129af
   languageName: node
   linkType: hard
 
@@ -4139,7 +4146,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@mapbox/tiny-sdf@npm:^2.0.4, @mapbox/tiny-sdf@npm:^2.0.5":
+"@mapbox/tiny-sdf@npm:^2.0.5, @mapbox/tiny-sdf@npm:^2.0.6":
   version: 2.0.6
   resolution: "@mapbox/tiny-sdf@npm:2.0.6"
   checksum: efff5b5a7599aaa995e3c2fd8f2acd071226096458eebb694ffd7258043c46c52b1d09bb3c7343d2126eb257b3cd7d34e6dc7ccaaad7619e6f3e7dd76229a3cd
@@ -4166,6 +4173,24 @@ __metadata:
   version: 3.1.0
   resolution: "@mapbox/whoots-js@npm:3.1.0"
   checksum: c1837c04effd205b207f441356d952eae7e8aad6c58f7c4900de50318c2147cf175936fc9434f20dfa409f9e6a78ec604d61e70c1c20572db0cc7655fbb65f50
+  languageName: node
+  linkType: hard
+
+"@maplibre/maplibre-gl-style-spec@npm:^19.3.0":
+  version: 19.3.0
+  resolution: "@maplibre/maplibre-gl-style-spec@npm:19.3.0"
+  dependencies:
+    "@mapbox/jsonlint-lines-primitives": ~2.0.2
+    "@mapbox/unitbezier": ^0.0.1
+    json-stringify-pretty-compact: ^3.0.0
+    minimist: ^1.2.8
+    rw: ^1.3.3
+    sort-object: ^3.0.3
+  bin:
+    gl-style-format: dist/gl-style-format.mjs
+    gl-style-migrate: dist/gl-style-migrate.mjs
+    gl-style-validate: dist/gl-style-validate.mjs
+  checksum: bec1e2da07cace76fe82f2377765655a734d9c1e165d67c65ab6a4bb06251db4920115efb224f6a6606e78a33975542b2c7055b99bc9bb40bfcb9b2cf283493d
   languageName: node
   linkType: hard
 
@@ -8934,6 +8959,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/supercluster@npm:^7.1.0":
+  version: 7.1.0
+  resolution: "@types/supercluster@npm:7.1.0"
+  dependencies:
+    "@types/geojson": "*"
+  checksum: 029aba15871ac16855c8813bde35ca773f20996448647567b62f103f58a5979d852fb79066d895cb642913d28cb72ebbed6149bcca8c7f4b8b162062998fd640
+  languageName: node
+  linkType: hard
+
 "@types/symlink-or-copy@npm:^1.2.0":
   version: 1.2.0
   resolution: "@types/symlink-or-copy@npm:1.2.0"
@@ -9971,6 +10005,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"arr-union@npm:^3.1.0":
+  version: 3.1.0
+  resolution: "arr-union@npm:3.1.0"
+  checksum: b5b0408c6eb7591143c394f3be082fee690ddd21f0fdde0a0a01106799e847f67fcae1b7e56b0a0c173290e29c6aca9562e82b300708a268bc8f88f3d6613cb9
+  languageName: node
+  linkType: hard
+
 "array-back@npm:^3.0.1, array-back@npm:^3.1.0":
   version: 3.1.0
   resolution: "array-back@npm:3.1.0"
@@ -10150,6 +10191,13 @@ __metadata:
   version: 1.0.0
   resolution: "assert-plus@npm:1.0.0"
   checksum: 19b4340cb8f0e6a981c07225eacac0e9d52c2644c080198765d63398f0075f83bbc0c8e95474d54224e297555ad0d631c1dcd058adb1ddc2437b41a6b424ac64
+  languageName: node
+  linkType: hard
+
+"assign-symbols@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "assign-symbols@npm:1.0.0"
+  checksum: c0eb895911d05b6b2d245154f70461c5e42c107457972e5ebba38d48967870dee53bcdf6c7047990586daa80fab8dab3cc6300800fbd47b454247fdedd859a2c
   languageName: node
   linkType: hard
 
@@ -11043,6 +11091,25 @@ __metadata:
   version: 3.1.2
   resolution: "bytes@npm:3.1.2"
   checksum: e4bcd3948d289c5127591fbedf10c0b639ccbf00243504e4e127374a15c3bc8eed0d28d4aaab08ff6f1cf2abc0cce6ba3085ed32f4f90e82a5683ce0014e1b6e
+  languageName: node
+  linkType: hard
+
+"bytewise-core@npm:^1.2.2":
+  version: 1.2.3
+  resolution: "bytewise-core@npm:1.2.3"
+  dependencies:
+    typewise-core: ^1.2
+  checksum: e0d28fb7ff5bb6fd9320eef31c6b37e98da3b9a24d9893e2c17e0ee544457e0c76c2d3fc642c99d82daa0f18dcd49e7dce8dcc338711200e9ced79107cb78e8e
+  languageName: node
+  linkType: hard
+
+"bytewise@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "bytewise@npm:1.1.0"
+  dependencies:
+    bytewise-core: ^1.2.2
+    typewise: ^1.0.3
+  checksum: 20d7387ecf8c29adc4740e626fb02eaa27f34ae4c5ca881657d403e792730c0625ba4fed824462b3ddb7d3ebe41b7abbfe24f1cd3bf07cecc5a631f154d2d8d2
   languageName: node
   linkType: hard
 
@@ -12577,13 +12644,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"csscolorparser@npm:~1.0.3":
-  version: 1.0.3
-  resolution: "csscolorparser@npm:1.0.3"
-  checksum: e40f3045ea15c7e7eaa78e110412fe8b820d47b698c1eb1d1e7ecb42703bf447406a24304b891ae9df61e85d947f33fc67bd0120c7f9e3a5183e6e0b9afff92c
-  languageName: node
-  linkType: hard
-
 "cssdb@npm:^7.1.0":
   version: 7.6.0
   resolution: "cssdb@npm:7.6.0"
@@ -14051,7 +14111,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"earcut@npm:^2.0.0, earcut@npm:^2.0.6, earcut@npm:^2.2.3, earcut@npm:^2.2.4":
+"earcut@npm:^2.0.0, earcut@npm:^2.0.6, earcut@npm:^2.2.4":
   version: 2.2.4
   resolution: "earcut@npm:2.2.4"
   checksum: aea0466cb2f24e0c3c57148d8d28ac9846f53c4f43ee66780826474303ac851b305ef988152d0bdeb31e8f7ca939dc0df737e7505cfb1c1bdf2ff9d7f9ea2faa
@@ -15150,6 +15210,25 @@ __metadata:
   languageName: node
   linkType: hard
 
+"extend-shallow@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "extend-shallow@npm:2.0.1"
+  dependencies:
+    is-extendable: ^0.1.0
+  checksum: 8fb58d9d7a511f4baf78d383e637bd7d2e80843bd9cd0853649108ea835208fb614da502a553acc30208e1325240bb7cc4a68473021612496bb89725483656d8
+  languageName: node
+  linkType: hard
+
+"extend-shallow@npm:^3.0.0":
+  version: 3.0.2
+  resolution: "extend-shallow@npm:3.0.2"
+  dependencies:
+    assign-symbols: ^1.0.0
+    is-extendable: ^1.0.1
+  checksum: a920b0cd5838a9995ace31dfd11ab5e79bf6e295aa566910ce53dff19f4b1c0fda2ef21f26b28586c7a2450ca2b42d97bd8c0f5cec9351a819222bf861e02461
+  languageName: node
+  linkType: hard
+
 "extend@npm:^3.0.0, extend@npm:^3.0.2, extend@npm:~3.0.2":
   version: 3.0.2
   resolution: "extend@npm:3.0.2"
@@ -16061,6 +16140,13 @@ __metadata:
   dependencies:
     resolve-pkg-maps: ^1.0.0
   checksum: e791e671a9b55e91efea3ca819ecd7a25beae679e31c83234bf3dd62ddd93df070c1b95ae7e29d206358ebb6408f6f79ac6d83a32a3bbd6a6d217babe23de077
+  languageName: node
+  linkType: hard
+
+"get-value@npm:^2.0.2, get-value@npm:^2.0.6":
+  version: 2.0.6
+  resolution: "get-value@npm:2.0.6"
+  checksum: 5c3b99cb5398ea8016bf46ff17afc5d1d286874d2ad38ca5edb6e87d75c0965b0094cb9a9dddef2c59c23d250702323539a7fbdd870620db38c7e7d7ec87c1eb
   languageName: node
   linkType: hard
 
@@ -17603,6 +17689,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"is-extendable@npm:^0.1.0, is-extendable@npm:^0.1.1":
+  version: 0.1.1
+  resolution: "is-extendable@npm:0.1.1"
+  checksum: 3875571d20a7563772ecc7a5f36cb03167e9be31ad259041b4a8f73f33f885441f778cee1f1fe0085eb4bc71679b9d8c923690003a36a6a5fdf8023e6e3f0672
+  languageName: node
+  linkType: hard
+
+"is-extendable@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "is-extendable@npm:1.0.1"
+  dependencies:
+    is-plain-object: ^2.0.4
+  checksum: db07bc1e9de6170de70eff7001943691f05b9d1547730b11be01c0ebfe67362912ba743cf4be6fd20a5e03b4180c685dad80b7c509fe717037e3eee30ad8e84f
+  languageName: node
+  linkType: hard
+
 "is-extglob@npm:^2.1.0, is-extglob@npm:^2.1.1":
   version: 2.1.1
   resolution: "is-extglob@npm:2.1.1"
@@ -17816,7 +17918,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"is-plain-object@npm:^2.0.4":
+"is-plain-object@npm:^2.0.3, is-plain-object@npm:^2.0.4":
   version: 2.0.4
   resolution: "is-plain-object@npm:2.0.4"
   dependencies:
@@ -19461,6 +19563,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"json-stringify-pretty-compact@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "json-stringify-pretty-compact@npm:3.0.0"
+  checksum: 01ab5c5c8260299414868d96db97f53aef93c290fe469edd9a1363818e795006e01c952fa2fd7b47cbbab506d5768998eccc25e1da4fa2ccfebd1788c6098791
+  languageName: node
+  linkType: hard
+
 "json-stringify-safe@npm:^5.0.1, json-stringify-safe@npm:~5.0.1":
   version: 5.0.1
   resolution: "json-stringify-safe@npm:5.0.1"
@@ -19628,10 +19737,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"kdbush@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "kdbush@npm:3.0.0"
-  checksum: bc5fa433958e42664a8a92457e4f0d1db55b3b8e36956aac0102964adb2eab043bdbff156570dc8d867144ceff588fb7a1c6e099ba9be068cd1767a73e1ace92
+"kdbush@npm:^4.0.2":
+  version: 4.0.2
+  resolution: "kdbush@npm:4.0.2"
+  checksum: 6782ef2cdaec9322376b9955a16b0163beda0cefa2f87da76e8970ade2572d8b63bec915347aaeac609484b0c6e84d7b591f229ef353b68b460238095bacde2d
   languageName: node
   linkType: hard
 
@@ -23074,10 +23183,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"potpack@npm:^1.0.2":
-  version: 1.0.2
-  resolution: "potpack@npm:1.0.2"
-  checksum: 9dfdbbce012ce80842249abcdd89e20222eb8ae96beba8d578b7e41e78feefc7e33b5c72d46fb8dd3a1e382cb4da9c34574764d88aa8849ab36f542fd2088b42
+"potpack@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "potpack@npm:2.0.0"
+  checksum: 6dd41692349936b436c29c28cf9ff1268c03ed6ec96c4384b2d9eb95e58e422fab75d428648f475507dd167934984d1002df2010b83e5747b5c358bea371e8f7
   languageName: node
   linkType: hard
 
@@ -25053,7 +25162,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"rw@npm:1":
+"rw@npm:1, rw@npm:^1.3.3":
   version: 1.3.3
   resolution: "rw@npm:1.3.3"
   checksum: c20d82421f5a71c86a13f76121b751553a99cd4a70ea27db86f9b23f33db941f3f06019c30f60d50c356d0bd674c8e74764ac146ea55e217c091bde6fba82aa3
@@ -25478,6 +25587,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"set-value@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "set-value@npm:2.0.1"
+  dependencies:
+    extend-shallow: ^2.0.1
+    is-extendable: ^0.1.1
+    is-plain-object: ^2.0.3
+    split-string: ^3.0.1
+  checksum: 09a4bc72c94641aeae950eb60dc2755943b863780fcc32e441eda964b64df5e3f50603d5ebdd33394ede722528bd55ed43aae26e9df469b4d32e2292b427b601
+  languageName: node
+  linkType: hard
+
 "setimmediate@npm:^1.0.5":
   version: 1.0.5
   resolution: "setimmediate@npm:1.0.5"
@@ -25703,12 +25824,40 @@ __metadata:
   languageName: node
   linkType: hard
 
+"sort-asc@npm:^0.2.0":
+  version: 0.2.0
+  resolution: "sort-asc@npm:0.2.0"
+  checksum: b3610ab695dc8b2cba1c3e6ead06ce97a41f013ed0a002ff7a0d2a39ca297fd2f58c92d3de67dda3a9313ecb1073de4eacc30da3a740ff8d57eb668c9bb151bd
+  languageName: node
+  linkType: hard
+
+"sort-desc@npm:^0.2.0":
+  version: 0.2.0
+  resolution: "sort-desc@npm:0.2.0"
+  checksum: fb2c02ea38815c79c0127d014f18926a473a1988c01f4c00de467584b99fc7e9f6e4f61c8386f4c2ac3501c60842931c5a499330b3086be6d8cff4d0b8602bed
+  languageName: node
+  linkType: hard
+
 "sort-keys@npm:^5.0.0":
   version: 5.0.0
   resolution: "sort-keys@npm:5.0.0"
   dependencies:
     is-plain-obj: ^4.0.0
   checksum: 9c0b7a468312075be03770b260b2cc0e5d55149025e564edaed41c9ff619199698aad6712a6fe4bbc75c541efb081276ac6bbd4cf2723d742f272f7a8fe354f5
+  languageName: node
+  linkType: hard
+
+"sort-object@npm:^3.0.3":
+  version: 3.0.3
+  resolution: "sort-object@npm:3.0.3"
+  dependencies:
+    bytewise: ^1.1.0
+    get-value: ^2.0.2
+    is-extendable: ^0.1.1
+    sort-asc: ^0.2.0
+    sort-desc: ^0.2.0
+    union-value: ^1.0.1
+  checksum: 381a6b6fe2309d400bd6ae3a8d0188b2b3b3855345d16d953b4bb5875d28fd5512501c85bd4eb951543056cd3095ff8e197ab3efc11389dcfa0e3334bf4a23a5
   languageName: node
   linkType: hard
 
@@ -25880,6 +26029,15 @@ __metadata:
   version: 3.1.2
   resolution: "splaytree@npm:3.1.2"
   checksum: 7b90a52e02036699b0c7228bb86c784aa674618909622da652c80a809694dafa068b73c97309ecb719783b7c1e1092ac6917acf2213defc0fa9027f92b2afa62
+  languageName: node
+  linkType: hard
+
+"split-string@npm:^3.0.1":
+  version: 3.1.0
+  resolution: "split-string@npm:3.1.0"
+  dependencies:
+    extend-shallow: ^3.0.0
+  checksum: ae5af5c91bdc3633628821bde92fdf9492fa0e8a63cf6a0376ed6afde93c701422a1610916f59be61972717070119e848d10dfbbd5024b7729d6a71972d2a84c
   languageName: node
   linkType: hard
 
@@ -26555,12 +26713,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"supercluster@npm:^7.1.4":
-  version: 7.1.5
-  resolution: "supercluster@npm:7.1.5"
+"supercluster@npm:^8.0.1":
+  version: 8.0.1
+  resolution: "supercluster@npm:8.0.1"
   dependencies:
-    kdbush: ^3.0.0
-  checksum: 69863238870093b96617135884721b6343746e14f396b2d67d6b55c52c362ec0516c5e386aa21815e75a9cef2054e831ac34023d0d8b600091d28cea0794f027
+    kdbush: ^4.0.2
+  checksum: 39d141f768a511efa53260252f9dab9a2ce0228b334e55482c8d3019e151932f05e1a9a0252d681737651b13c741c665542a6ddb40ec27de96159ea7ad41f7f4
   languageName: node
   linkType: hard
 
@@ -27630,6 +27788,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"typewise-core@npm:^1.2, typewise-core@npm:^1.2.0":
+  version: 1.2.0
+  resolution: "typewise-core@npm:1.2.0"
+  checksum: c21e83544546d1aba2f17377c25ae0eb571c2153b2e3705932515bef103dbe43e05d2286f238ad139341b1000da40583115a44cb5e69a2ef408572b13dab844b
+  languageName: node
+  linkType: hard
+
+"typewise@npm:^1.0.3":
+  version: 1.0.3
+  resolution: "typewise@npm:1.0.3"
+  dependencies:
+    typewise-core: ^1.2.0
+  checksum: eb3452b1387df8bf8e3b620720d240425a50ce402d7c064c21ac4b5d88c551ee4d1f26cd649b8a17a6d06f7a3675733de841723f8e06bb3edabfeacc4924af4a
+  languageName: node
+  linkType: hard
+
 "typical@npm:^4.0.0":
   version: 4.0.0
   resolution: "typical@npm:4.0.0"
@@ -27727,6 +27901,18 @@ __metadata:
   version: 2.1.0
   resolution: "unicode-property-aliases-ecmascript@npm:2.1.0"
   checksum: 243524431893649b62cc674d877bd64ef292d6071dd2fd01ab4d5ad26efbc104ffcd064f93f8a06b7e4ec54c172bf03f6417921a0d8c3a9994161fe1f88f815b
+  languageName: node
+  linkType: hard
+
+"union-value@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "union-value@npm:1.0.1"
+  dependencies:
+    arr-union: ^3.1.0
+    get-value: ^2.0.6
+    is-extendable: ^0.1.1
+    set-value: ^2.0.1
+  checksum: a3464097d3f27f6aa90cf103ed9387541bccfc006517559381a10e0dffa62f465a9d9a09c9b9c3d26d0f4cbe61d4d010e2fbd710fd4bf1267a768ba8a774b0ba
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Update [maplibre fork](https://github.com/GlobalFishingWatch/maplibre-gl-js/pull/8) to [latest version](https://github.com/maplibre/maplibre-gl-js/releases/tag/v3.3.1)

Improvements to test in [this preview url](https://fishing-map-chore-update-maplibre-version-jzzp2ui3wq-uc.a.run.app/map))
- Being on the latest version makes it easier to keep updated in case of bugs
- Better [expression typings](https://github.com/maplibre/maplibre-gl-js/pull/1510)
- Significant improvement in blocking time
Before:
![image](https://github.com/GlobalFishingWatch/frontend/assets/10500650/dff0183c-4a5a-47ba-b310-0702e3fcd59b)
After:
![image](https://github.com/GlobalFishingWatch/frontend/assets/10500650/fa72f5e9-0ae5-4d82-bcab-8f8318507d54)


