### PR TITLE
Avoid report category missmatch on stored workspaces

### DIFF
--- a/apps/fishing-map/features/app/app.selectors.ts
+++ b/apps/fishing-map/features/app/app.selectors.ts
@@ -1,5 +1,6 @@
 import { createSelector } from '@reduxjs/toolkit'
 import { RootState } from 'reducers'
+import { uniq } from 'lodash'
 import { DataviewCategory, DataviewInstance, Workspace } from '@globalfishingwatch/api-types'
 import { APP_NAME, DEFAULT_TIME_RANGE, DEFAULT_WORKSPACE } from 'data/config'
 import { createDeepEqualSelector } from 'utils/selectors'
@@ -157,29 +158,36 @@ export const selectReportAreaId = createSelector(
   (locationAreaId, report) => (locationAreaId || report?.areaId) as number
 )
 
-export const selectReportCategory = createSelector(
-  [
-    selectWorkspaceStateProperty('reportCategory'),
-    (state) => selectDataviewInstancesResolved(state),
-  ],
-  (reportCategory, dataviews): ReportCategory => {
-    if (reportCategory) {
-      return reportCategory
-    }
+export const selectActiveDataviewsCategories = createSelector(
+  [(state) => selectDataviewInstancesResolved(state)],
+  (dataviews): ReportCategory[] => {
+    return uniq(
+      dataviews.flatMap((d) => (d.config?.visible ? getReportCategoryFromDataview(d) : []))
+    )
+  }
+)
+
+export const selectReportActiveCategories = createSelector(
+  [selectActiveDataviewsCategories],
+  (activeCategories): ReportCategory[] => {
     const orderedCategories = [
       ReportCategory.Fishing,
       ReportCategory.Presence,
       ReportCategory.Detections,
       ReportCategory.Environment,
     ]
-    const categoriesWithActiveDataviews = orderedCategories.map((category) => {
-      return dataviews.some((dataview) => {
-        return dataview.config?.visible && getReportCategoryFromDataview(dataview) === category
-      })
-    })
-    const firstCategoryActive =
-      categoriesWithActiveDataviews.findIndex((active) => active === true) || 0
-    return orderedCategories[firstCategoryActive]
+    return orderedCategories.flatMap((category) =>
+      activeCategories.some((a) => a === category) ? category : []
+    )
+  }
+)
+
+export const selectReportCategory = createSelector(
+  [selectWorkspaceStateProperty('reportCategory'), selectReportActiveCategories],
+  (reportCategory, activeCategories): ReportCategory => {
+    return activeCategories.some((category) => category === reportCategory)
+      ? reportCategory
+      : activeCategories[0]
   }
 )
 


### PR DESCRIPTION
This PR fixes a bug that gets triggered os stored workspaces created with some `activity`, `detections` or `environment` layer activated. If you try to do a report on that workspace without any of those layers active the `reportCategory` is not coherent with the current categories, messing with map and report selection of the data to display.

#### Bug on `develop`/`master` branch 👇🏼 🐛 

[Screencast from 13-09-23 13:29:49.webm](https://github.com/GlobalFishingWatch/frontend/assets/6906348/61d5e72d-036e-46da-b706-d73b8e28789b)

#### Fix on this branch 🧹

[Screencast from 13-09-23 13:40:24.webm](https://github.com/GlobalFishingWatch/frontend/assets/6906348/e2a77068-7149-4203-9c64-0cd936209126)

