### PR TITLE
add cloudbuildTaskStagingId to gfw-bot

### DIFF
--- a/.github/gfw-bot.json
+++ b/.github/gfw-bot.json
@@ -1,6 +1,7 @@
 {
   "fishing-map": {
     "cloudbuildTaskDevId": "ui-fishing-map-autodeploy",
+    "cloudbuildTaskStagingId": "ui-fishing-map-autodeploy-staging",
     "cloudbuildTaskProId": "ui-fishing-map-autodeploy-pro",
     "auto": false,
     "watch": ["apps/fishing-map/**/*", "yarn.lock"]


### PR DESCRIPTION
`ui-fishing-map-autodeploy-staging`trigger ready in cloud build but this depends on https://github.com/GlobalFishingWatch/gfw-github-bot/pull/5 to support `deploy-staging` github tag
