### PR TITLE
support staging as WORKSPACE_ENV

### DIFF
--- a/apps/fishing-map/data/config.ts
+++ b/apps/fishing-map/data/config.ts
@@ -10,7 +10,9 @@ export const SUPPORT_EMAIL = 'support@globalfishingwatch.org'
 
 export const IS_PRODUCTION_BUILD = process.env.NODE_ENV === 'production'
 export const PUBLIC_WORKSPACE_ENV = process.env.NEXT_PUBLIC_WORKSPACE_ENV
-export const IS_PRODUCTION = PUBLIC_WORKSPACE_ENV === 'production' || IS_PRODUCTION_BUILD
+export const IS_PRODUCTION_WORKSPACE_ENV =
+  PUBLIC_WORKSPACE_ENV === 'production' || PUBLIC_WORKSPACE_ENV === 'staging'
+export const IS_PRODUCTION = IS_PRODUCTION_WORKSPACE_ENV || IS_PRODUCTION_BUILD
 
 export const REPORT_DAYS_LIMIT =
   typeof process.env.NEXT_PUBLIC_REPORT_DAYS_LIMIT !== 'undefined'

--- a/apps/fishing-map/data/default-workspaces/workspace.staging.ts
+++ b/apps/fishing-map/data/default-workspaces/workspace.staging.ts
@@ -1,0 +1,3 @@
+import workspace from './workspace.production'
+
+export default workspace

--- a/apps/fishing-map/features/workspace/highlight-panel/highlight-panel.content.ts
+++ b/apps/fishing-map/features/workspace/highlight-panel/highlight-panel.content.ts
@@ -1,4 +1,4 @@
-import { IS_PRODUCTION_BUILD, PUBLIC_WORKSPACE_ENV } from 'data/config'
+import { IS_PRODUCTION_BUILD, IS_PRODUCTION_WORKSPACE_ENV } from 'data/config'
 import { PATH_BASENAME } from 'routes/routes'
 import { Locale } from 'types'
 
@@ -105,7 +105,7 @@ const AVAILABLE_HIGHLIGHT_CONFIGS = HIGHLIGHT_CONFIGS
 const HIGHLIGHT_CONFIG_LATEST = AVAILABLE_HIGHLIGHT_CONFIGS.at(0) as HighlightPanelConfig
 const HIGHLIGHT_CONFIG_PREVIOUS = AVAILABLE_HIGHLIGHT_CONFIGS.at(1) as HighlightPanelConfig
 
-const IS_PRODUCTION_ENV = IS_PRODUCTION_BUILD && PUBLIC_WORKSPACE_ENV === 'production'
+const IS_PRODUCTION_ENV = IS_PRODUCTION_BUILD && IS_PRODUCTION_WORKSPACE_ENV
 
 const DISPLAY_LATEST_POPUP =
   // Non production environments always show the latest popup

--- a/apps/fishing-map/next.config.js
+++ b/apps/fishing-map/next.config.js
@@ -11,7 +11,9 @@ const basePath =
   process.env.NEXT_PUBLIC_URL || (process.env.NODE_ENV === 'production' ? '/map' : '')
 
 const IS_PRODUCTION =
-  process.env.NEXT_PUBLIC_WORKSPACE_ENV === 'production' || process.env.NODE_ENV === 'production'
+  process.env.NEXT_PUBLIC_WORKSPACE_ENV === 'production' ||
+  process.env.NEXT_PUBLIC_WORKSPACE_ENV === 'staging' ||
+  process.env.NODE_ENV === 'production'
 
 /**
  * @type {import('@nx/next/plugins/with-nx').WithNxOptions}


### PR DESCRIPTION
This avoids publishing [ui-libs-i18n-labels-stable](https://github.com/GlobalFishingWatch/frontend/blob/fishing-map/staging-env/apps/fishing-map/cloudbuild.yaml#L157) on every staging preview trigger
