### PR TITLE
Fishing map/v3 integration fixes

### DIFF
--- a/apps/fishing-map/features/download/downloadActivity.slice.ts
+++ b/apps/fishing-map/features/download/downloadActivity.slice.ts
@@ -88,9 +88,9 @@ export const downloadActivityThunk = createAsyncThunk<
         'region-id': areaId,
         'region-dataset': datasetId,
         'group-by': groupBy,
-        'buffer-unit': bufferUnit,
+        'buffer-unit': bufferUnit?.toUpperCase(),
         'buffer-value': bufferValue,
-        'buffer-operation': bufferOperation,
+        'buffer-operation': bufferOperation?.toUpperCase(),
       }
 
       const fileName = `${areaName} - ${downloadActivityParams['date-range']}.${

--- a/apps/fishing-map/features/reports/title/ReportTitle.tsx
+++ b/apps/fishing-map/features/reports/title/ReportTitle.tsx
@@ -73,9 +73,8 @@ export default function ReportTitle({ area }: ReportTitleProps) {
           value: previewBuffer.value || DEFAULT_BUFFER_VALUE,
         })
       )
-      cleanFeatureState('highlight')
     },
-    [dispatch, previewBuffer, cleanFeatureState]
+    [dispatch, previewBuffer]
   )
 
   const handleBufferValueChange = useCallback(


### PR DESCRIPTION
This PR fixes two small issues. 
-  The first one is related with API v3 updates. [`/v3/4wings/report` ](https://gateway.api.dev.globalfishingwatch.org/swagger?version=3#/4wings/get_v3_4wings_report) endpoint need params to be Uppercase (a `422` was being returned).
- Cleaning feature state on report buffer operation update was caussing the issue of leaving no area highlighted in case the buffer was removed before confirmation.