### PR TITLE
Fishing map/more buffer params cleanup

### DIFF
--- a/apps/fishing-map/features/reports/title/ReportTitle.tsx
+++ b/apps/fishing-map/features/reports/title/ReportTitle.tsx
@@ -20,14 +20,14 @@ import {
 import { selectReportAreaDataview } from 'features/reports/reports.selectors'
 import ReportTitlePlaceholder from 'features/reports/placeholders/ReportTitlePlaceholder'
 import { TrackCategory, trackEvent } from 'features/app/analytics.hooks'
-import { selectCurrentReport } from 'features/app/app.selectors'
+import {
+  selectCurrentReport,
+  selectReportBufferOperation,
+  selectReportBufferUnit,
+  selectReportBufferValue,
+} from 'features/app/app.selectors'
 import { useLocationConnect } from 'routes/routes.hook'
 import { BufferOperation, BufferUnit } from 'types'
-import {
-  selectUrlBufferUnitQuery,
-  selectUrlBufferValueQuery,
-  selectUrlBufferOperationQuery,
-} from 'routes/routes.selectors'
 import useMapInstance from 'features/map/map-context.hooks'
 import { cleanCurrentWorkspaceStateBufferParams } from 'features/workspace/workspace.slice'
 import { BufferButtonTooltip } from './BufferButonTooltip'
@@ -46,9 +46,9 @@ export default function ReportTitle({ area }: ReportTitleProps) {
   const areaDataview = useSelector(selectReportAreaDataview)
   const report = useSelector(selectCurrentReport)
   const previewBuffer = useSelector(selectReportPreviewBuffer)
-  const urlBufferValue = useSelector(selectUrlBufferValueQuery)
-  const urlBufferUnit = useSelector(selectUrlBufferUnitQuery)
-  const urlBufferOperation = useSelector(selectUrlBufferOperationQuery)
+  const urlBufferValue = useSelector(selectReportBufferValue)
+  const urlBufferUnit = useSelector(selectReportBufferUnit)
+  const urlBufferOperation = useSelector(selectReportBufferOperation)
   const { cleanFeatureState } = useFeatureState(useMapInstance())
 
   const [tooltipInstance, setTooltipInstance] = useState<any>(null)

--- a/apps/fishing-map/features/reports/title/ReportTitle.tsx
+++ b/apps/fishing-map/features/reports/title/ReportTitle.tsx
@@ -29,6 +29,7 @@ import {
   selectUrlBufferOperationQuery,
 } from 'routes/routes.selectors'
 import useMapInstance from 'features/map/map-context.hooks'
+import { cleanCurrentWorkspaceStateBufferParams } from 'features/workspace/workspace.slice'
 import { BufferButtonTooltip } from './BufferButonTooltip'
 import styles from './ReportTitle.module.css'
 
@@ -149,6 +150,7 @@ export default function ReportTitle({ area }: ReportTitleProps) {
       reportBufferOperation: undefined,
     })
     dispatch(resetReportData())
+    dispatch(cleanCurrentWorkspaceStateBufferParams())
   }, [dispatch, dispatchQueryParams, tooltipInstance])
 
   const reportTitle = useMemo(() => {


### PR DESCRIPTION
This PR fixes a couple of issues related to buffer state:
- When you open the buffer area tooltip (coming from a saved report) the default values doesn't match the buffer selection
- The area is not clean if you remove it.

Some thinking might be needed on the title creation logic (when the buffer is removed on a saved report with buffer the name of the reports remains the same but the report area is the original one, letting the name kind of out of sync) 
c.c: @satellitestudiodesign 