### PR TITLE
Fishing map/all identities data in workspace

### DIFF
--- a/apps/fishing-map/features/dataviews/dataviews.utils.ts
+++ b/apps/fishing-map/features/dataviews/dataviews.utils.ts
@@ -43,18 +43,33 @@ export type VesselInstanceDatasets = {
   relatedVesselIds?: string[]
 }
 
+export const getVesselInfoDataviewInstanceDatasetConfig = (
+  vesselId: string,
+  { info }: VesselInstanceDatasets
+) => {
+  return {
+    datasetId: info,
+    params: [{ id: 'vesselId', value: vesselId }],
+    query: [
+      { id: 'dataset', value: info },
+      {
+        id: 'includes',
+        value: ['POTENTIAL_RELATED_SELF_REPORTED_INFO'],
+      },
+    ],
+    endpoint: EndpointId.Vessel,
+  } as DataviewDatasetConfig
+}
+
 export const getVesselDataviewInstanceDatasetConfig = (
   vesselId: string,
   { track, info, events, relatedVesselIds = [] }: VesselInstanceDatasets
 ) => {
   const datasetsConfig: DataviewDatasetConfig[] = []
   if (info) {
-    datasetsConfig.push({
-      datasetId: info,
-      params: [{ id: 'vesselId', value: vesselId }],
-      query: [{ id: 'dataset', value: info }],
-      endpoint: EndpointId.Vessel,
-    })
+    datasetsConfig.push(
+      getVesselInfoDataviewInstanceDatasetConfig(vesselId, { info: info as string })
+    )
   }
   if (track) {
     const vesselIds = relatedVesselIds ? [vesselId, ...relatedVesselIds].join(',') : vesselId

--- a/apps/fishing-map/features/map/map.slice.ts
+++ b/apps/fishing-map/features/map/map.slice.ts
@@ -158,6 +158,10 @@ export const getVesselInfoEndpoint = (vesselDatasets: Dataset[], vesselIds: stri
         id: 'ids',
         value: vesselIds,
       },
+      {
+        id: 'includes',
+        value: ['POTENTIAL_RELATED_SELF_REPORTED_INFO'],
+      },
     ],
   }
   return resolveEndpoint(vesselDatasets[0], datasetConfig)

--- a/apps/fishing-map/features/map/popups/EncounterTooltipRow.tsx
+++ b/apps/fishing-map/features/map/popups/EncounterTooltipRow.tsx
@@ -1,26 +1,18 @@
 import { Fragment, useEffect } from 'react'
-import { useSelector } from 'react-redux'
 import { useTranslation } from 'react-i18next'
 import { stringify } from 'qs'
-import { Button, Icon, IconButton } from '@globalfishingwatch/ui-components'
-import { DatasetTypes, EventVessel } from '@globalfishingwatch/api-types'
+import { Button, Icon } from '@globalfishingwatch/ui-components'
+import { EventVessel } from '@globalfishingwatch/api-types'
 import { TooltipEventFeature } from 'features/map/map.hooks'
 import { AsyncReducerStatus } from 'utils/async-slice'
 import I18nDate from 'features/i18n/i18nDate'
-import {
-  ENCOUNTER_EVENTS_SOURCE_ID,
-  getVesselDataviewInstance,
-  getVesselInWorkspace,
-} from 'features/dataviews/dataviews.utils'
+import { ENCOUNTER_EVENTS_SOURCE_ID } from 'features/dataviews/dataviews.utils'
 import { formatInfoField } from 'utils/info'
-import { selectAllDatasets } from 'features/datasets/datasets.slice'
-import { useDataviewInstancesConnect } from 'features/workspace/workspace.hook'
 import { CARRIER_PORTAL_URL } from 'data/config'
 import { useCarrierLatestConnect } from 'features/datasets/datasets.hook'
 import { useTimerangeConnect } from 'features/timebar/timebar.hooks'
-import { selectActiveTrackDataviews } from 'features/dataviews/dataviews.slice'
-import { getRelatedDatasetByType, getRelatedDatasetsByType } from 'features/datasets/datasets.utils'
 import VesselLink from 'features/vessel/VesselLink'
+import VesselPin from 'features/vessel/VesselPin'
 import useViewport from '../map-viewport.hooks'
 import { ExtendedEventVessel, ExtendedFeatureEvent } from '../map.slice'
 import styles from './Popup.module.css'
@@ -50,48 +42,16 @@ type EncountersLayerProps = {
 
 function EncounterTooltipRow({ feature, showFeaturesDetails }: EncountersLayerProps) {
   const { t } = useTranslation()
-  const { upsertDataviewInstance, deleteDataviewInstance } = useDataviewInstancesConnect()
-  const datasets = useSelector(selectAllDatasets)
   const { start, end } = useTimerangeConnect()
   const { viewport } = useViewport()
   const { carrierLatest, carrierLatestStatus, dispatchFetchLatestCarrier } =
     useCarrierLatestConnect()
-  const vessels = useSelector(selectActiveTrackDataviews)
 
   useEffect(() => {
     if (!carrierLatest) {
       dispatchFetchLatestCarrier()
     }
   }, [carrierLatest, dispatchFetchLatestCarrier])
-
-  const onPinClick = (ev: React.MouseEvent<Element, MouseEvent>, vessel: ExtendedEventVessel) => {
-    const vesselInWorkspace = getVesselInWorkspace(vessels, vessel.id)
-    if (vesselInWorkspace) {
-      deleteDataviewInstance(vesselInWorkspace.id)
-      return
-    }
-
-    const infoDataset = datasets.find((dataset) => dataset.id === vessel.dataset)
-    const trackDataset = getRelatedDatasetByType(infoDataset, DatasetTypes.Tracks)
-    const eventsRelatedDatasets = getRelatedDatasetsByType(infoDataset, DatasetTypes.Events)
-
-    const eventsDatasetsId =
-      eventsRelatedDatasets && eventsRelatedDatasets?.length
-        ? eventsRelatedDatasets.map((d) => d.id)
-        : []
-
-    if (infoDataset || trackDataset) {
-      const vesselDataviewInstance = getVesselDataviewInstance(
-        { id: vessel.id },
-        {
-          info: infoDataset?.id,
-          track: trackDataset?.id,
-          ...(eventsDatasetsId.length > 0 && { events: eventsDatasetsId }),
-        }
-      )
-      upsertDataviewInstance(vesselDataviewInstance)
-    }
-  }
 
   const event = parseEvent(feature.event)
   const linkParams = {
@@ -123,9 +83,6 @@ function EncounterTooltipRow({ feature, showFeaturesDetails }: EncountersLayerPr
     )
   }
 
-  const carrierInWorkspace = getVesselInWorkspace(vessels, event!?.vessel!?.id)
-  const donorInWorkspace = getVesselInWorkspace(vessels, event!?.encounter!?.vessel!?.id)
-
   return (
     <div className={styles.popupSection}>
       <Icon icon="encounters" className={styles.layerIcon} style={{ color: feature.color }} />
@@ -149,22 +106,7 @@ function EncounterTooltipRow({ feature, showFeaturesDetails }: EncountersLayerPr
                           </VesselLink>
                         </span>
                         {(event.vessel as ExtendedEventVessel).dataset && (
-                          <IconButton
-                            icon={carrierInWorkspace ? 'pin-filled' : 'pin'}
-                            style={{
-                              color: carrierInWorkspace ? carrierInWorkspace.config?.color : '',
-                            }}
-                            size="small"
-                            tooltip={
-                              carrierInWorkspace
-                                ? t(
-                                    'search.vesselAlreadyInWorkspace',
-                                    'This vessel is already in your workspace'
-                                  )
-                                : t('vessel.addToWorkspace', 'Add vessel to view')
-                            }
-                            onClick={(e) => onPinClick(e, event.vessel as ExtendedEventVessel)}
-                          />
+                          <VesselPin vesselToResolve={event.vessel} />
                         )}
                       </div>
                     </div>
@@ -183,24 +125,7 @@ function EncounterTooltipRow({ feature, showFeaturesDetails }: EncountersLayerPr
                             </VesselLink>
                           </span>
                           {(event.encounter?.vessel as ExtendedEventVessel).dataset && (
-                            <IconButton
-                              icon={donorInWorkspace ? 'pin-filled' : 'pin'}
-                              style={{
-                                color: donorInWorkspace ? donorInWorkspace.config?.color : '',
-                              }}
-                              size="small"
-                              tooltip={
-                                donorInWorkspace
-                                  ? t(
-                                      'search.vesselAlreadyInWorkspace',
-                                      'This vessel is already in your workspace'
-                                    )
-                                  : t('vessel.addToWorkspace', 'Add vessel to view')
-                              }
-                              onClick={(e) =>
-                                onPinClick(e, event.encounter?.vessel as ExtendedEventVessel)
-                              }
-                            />
+                            <VesselPin vesselToResolve={event.encounter.vessel} />
                           )}
                         </div>
                       </div>

--- a/apps/fishing-map/features/map/popups/VesselsTable.tsx
+++ b/apps/fishing-map/features/map/popups/VesselsTable.tsx
@@ -21,9 +21,10 @@ import { TimeRangeDates } from 'features/map/controls/MapInfo'
 import DatasetLabel from 'features/datasets/DatasetLabel'
 import { getUTCDateTime } from 'utils/dates'
 import { GLOBAL_VESSELS_DATASET_ID } from 'data/workspaces'
-import { getVesselProperty } from 'features/vessel/vessel.utils'
+import { getOtherVesselNames, getVesselProperty } from 'features/vessel/vessel.utils'
 import VesselLink from 'features/vessel/VesselLink'
 import VesselPin from 'features/vessel/VesselPin'
+import { getVesselIdentityTooltipSummary } from 'features/workspace/vessels/VesselLayerPanel'
 import {
   SUBLAYER_INTERACTION_TYPES_WITH_VESSEL_INTERACTION,
   TooltipEventFeature,
@@ -142,6 +143,8 @@ function VesselsTable({
                 getVesselProperty(vessel, 'shipname', getVesselPropertyParams),
                 'name'
               )
+
+              const otherVesselsLabel = vessel ? getOtherVesselNames(vessel) : ''
               const vesselFlag = getVesselProperty(vessel, 'flag', getVesselPropertyParams)
 
               const vesselType = isPresenceActivity
@@ -160,6 +163,8 @@ function VesselsTable({
 
               const pinTrackDisabled = !interactionAllowed || !hasDatasets
               const detectionsTimestamps = getDetectionsTimestamps(vessel)
+
+              const identitiesSummary = vessel ? getVesselIdentityTooltipSummary(vessel) : ''
               return (
                 <tr key={i} data-test={`${testId}-item-${i}`}>
                   {!pinTrackDisabled && (
@@ -169,17 +174,23 @@ function VesselsTable({
                   )}
                   <td colSpan={hasPinColumn && pinTrackDisabled ? 2 : 1} data-test="vessel-name">
                     {vesselName !== EMPTY_FIELD_PLACEHOLDER ? (
-                      <VesselLink
-                        className={styles.link}
-                        vesselId={vessel.id}
-                        datasetId={vessel.infoDataset?.id}
-                        query={{
-                          vesselIdentitySource: VesselIdentitySourceEnum.SelfReported,
-                          vesselSelfReportedId: vessel.id,
-                        }}
-                      >
-                        {vesselName}
-                      </VesselLink>
+                      <Fragment>
+                        <VesselLink
+                          className={styles.link}
+                          vesselId={vessel.id}
+                          datasetId={vessel.infoDataset?.id}
+                          tooltip={identitiesSummary}
+                          query={{
+                            vesselIdentitySource: VesselIdentitySourceEnum.SelfReported,
+                            vesselSelfReportedId: vessel.id,
+                          }}
+                        >
+                          {vesselName}
+                        </VesselLink>
+                        {otherVesselsLabel && (
+                          <span className={styles.secondary}>{otherVesselsLabel}</span>
+                        )}
+                      </Fragment>
                     ) : (
                       vesselName
                     )}

--- a/apps/fishing-map/features/map/popups/VesselsTable.tsx
+++ b/apps/fishing-map/features/map/popups/VesselsTable.tsx
@@ -1,18 +1,9 @@
 import { Fragment } from 'react'
 import cx from 'classnames'
 import { useTranslation } from 'react-i18next'
-import { useSelector } from 'react-redux'
 import { DateTime } from 'luxon'
-import { IconButton, Tooltip } from '@globalfishingwatch/ui-components'
-import {
-  DatasetSubCategory,
-  DatasetTypes,
-  DataviewInstance,
-  Resource,
-  ResourceStatus,
-  VesselIdentitySourceEnum,
-} from '@globalfishingwatch/api-types'
-import { resolveEndpoint, setResource } from '@globalfishingwatch/dataviews-client'
+import { Tooltip } from '@globalfishingwatch/ui-components'
+import { DatasetSubCategory, VesselIdentitySourceEnum } from '@globalfishingwatch/api-types'
 import {
   EMPTY_FIELD_PLACEHOLDER,
   formatInfoField,
@@ -20,28 +11,19 @@ import {
   getVesselGearType,
   getVesselShipType,
 } from 'utils/info'
-import { useDataviewInstancesConnect } from 'features/workspace/workspace.hook'
-import {
-  getVesselDataviewInstance,
-  getVesselDataviewInstanceDatasetConfig,
-  getVesselInWorkspace,
-} from 'features/dataviews/dataviews.utils'
-import { getDatasetLabel, getRelatedDatasetsByType } from 'features/datasets/datasets.utils'
+import { getDatasetLabel } from 'features/datasets/datasets.utils'
 import I18nNumber from 'features/i18n/i18nNumber'
 import { ActivityProperty, ExtendedFeatureVessel, MAX_TOOLTIP_LIST } from 'features/map/map.slice'
-import { getEventLabel } from 'utils/analytics'
-import { selectActiveTrackDataviews } from 'features/dataviews/dataviews.slice'
 import { t } from 'features/i18n/i18n'
 import I18nDate from 'features/i18n/i18nDate'
 import { useTimerangeConnect } from 'features/timebar/timebar.hooks'
 import { TimeRangeDates } from 'features/map/controls/MapInfo'
 import DatasetLabel from 'features/datasets/DatasetLabel'
 import { getUTCDateTime } from 'utils/dates'
-import { TrackCategory, trackEvent } from 'features/app/analytics.hooks'
 import { GLOBAL_VESSELS_DATASET_ID } from 'data/workspaces'
-import { useAppDispatch } from 'features/app/app.hooks'
-import { getRelatedIdentityVesselIds, getVesselProperty } from 'features/vessel/vessel.utils'
+import { getVesselProperty } from 'features/vessel/vessel.utils'
 import VesselLink from 'features/vessel/VesselLink'
+import VesselPin from 'features/vessel/VesselPin'
 import {
   SUBLAYER_INTERACTION_TYPES_WITH_VESSEL_INTERACTION,
   TooltipEventFeature,
@@ -114,9 +96,6 @@ function VesselsTable({
   testId?: string
 }) {
   const { t } = useTranslation()
-  const dispatch = useAppDispatch()
-  const { upsertDataviewInstance, deleteDataviewInstance } = useDataviewInstancesConnect()
-  const vesselsInWorkspace = useSelector(selectActiveTrackDataviews)
 
   const interactionAllowed = [...SUBLAYER_INTERACTION_TYPES_WITH_VESSEL_INTERACTION].includes(
     feature.temporalgrid?.sublayerInteractionType || ''
@@ -131,66 +110,6 @@ function VesselsTable({
       return hasDatasets
     })
 
-  // This avoid requesting the vessel info again when we alredy requested it for the popup
-  const populateVesselInfoResource = (
-    vessel: ExtendedFeatureVessel,
-    vesselDataviewInstance: DataviewInstance
-  ) => {
-    const infoDatasetConfig = getVesselDataviewInstanceDatasetConfig(
-      vessel?.id,
-      vesselDataviewInstance.config || {}
-    )?.find((dc) => dc.datasetId === vessel.infoDataset?.id)
-    if (vessel.infoDataset && infoDatasetConfig) {
-      const url = resolveEndpoint(vessel.infoDataset, infoDatasetConfig)
-      if (url) {
-        const resource: Resource = {
-          url,
-          dataset: vessel.infoDataset,
-          datasetConfig: infoDatasetConfig,
-          dataviewId: vesselDataviewInstance.dataviewId as string,
-          data: vessel,
-          status: ResourceStatus.Finished,
-        }
-        dispatch(setResource(resource))
-      }
-    }
-  }
-  const onVesselClick = (
-    ev: React.MouseEvent<Element, MouseEvent>,
-    vessel: ExtendedFeatureVessel
-  ) => {
-    const vesselInWorkspace = getVesselInWorkspace(vesselsInWorkspace, vessel.id)
-    if (vesselInWorkspace) {
-      deleteDataviewInstance(vesselInWorkspace.id)
-      return
-    }
-
-    let vesselDataviewInstance: DataviewInstance | undefined
-    const vesselEventsDatasets = getRelatedDatasetsByType(
-      vessel.infoDataset || vessel.dataset,
-      DatasetTypes.Events
-    )
-    const eventsDatasetsId =
-      vesselEventsDatasets && vesselEventsDatasets?.length
-        ? vesselEventsDatasets.map((d) => d.id)
-        : []
-
-    vesselDataviewInstance = getVesselDataviewInstance(vessel, {
-      info: vessel.infoDataset?.id,
-      track: vessel.trackDataset?.id,
-      ...(eventsDatasetsId.length > 0 && { events: eventsDatasetsId }),
-      relatedVesselIds: getRelatedIdentityVesselIds(vessel),
-    })
-
-    upsertDataviewInstance(vesselDataviewInstance)
-    populateVesselInfoResource(vessel, vesselDataviewInstance)
-
-    trackEvent({
-      category: TrackCategory.Tracks,
-      action: 'Click in vessel from grid cell panel',
-      label: getEventLabel([vessel.dataset.id, vessel.id]),
-    })
-  }
   const isHoursProperty = vesselProperty !== 'detections'
   const isPresenceActivity = activityType === DatasetSubCategory.Presence
   return (
@@ -239,29 +158,13 @@ function VesselsTable({
                 ? vessel.infoDataset !== undefined && vessel.trackDataset !== undefined
                 : vessel.infoDataset !== undefined || vessel.trackDataset !== undefined
 
-              const vesselInWorkspace = getVesselInWorkspace(vesselsInWorkspace, vessel.id)
               const pinTrackDisabled = !interactionAllowed || !hasDatasets
               const detectionsTimestamps = getDetectionsTimestamps(vessel)
               return (
                 <tr key={i} data-test={`${testId}-item-${i}`}>
                   {!pinTrackDisabled && (
                     <td className={styles.icon}>
-                      <IconButton
-                        icon={vesselInWorkspace ? 'pin-filled' : 'pin'}
-                        style={{
-                          color: vesselInWorkspace ? vesselInWorkspace.config?.color : '',
-                        }}
-                        tooltip={
-                          vesselInWorkspace
-                            ? t(
-                                'search.vesselAlreadyInWorkspace',
-                                'This vessel is already in your workspace'
-                              )
-                            : t('search.seeVessel', 'See vessel')
-                        }
-                        onClick={(e) => onVesselClick(e, vessel)}
-                        size="small"
-                      />
+                      <VesselPin vessel={vessel} />
                     </td>
                   )}
                   <td colSpan={hasPinColumn && pinTrackDisabled ? 2 : 1} data-test="vessel-name">

--- a/apps/fishing-map/features/map/popups/VesselsTable.tsx
+++ b/apps/fishing-map/features/map/popups/VesselsTable.tsx
@@ -40,7 +40,7 @@ import { getUTCDateTime } from 'utils/dates'
 import { TrackCategory, trackEvent } from 'features/app/analytics.hooks'
 import { GLOBAL_VESSELS_DATASET_ID } from 'data/workspaces'
 import { useAppDispatch } from 'features/app/app.hooks'
-import { getVesselProperty } from 'features/vessel/vessel.utils'
+import { getRelatedIdentityVesselIds, getVesselProperty } from 'features/vessel/vessel.utils'
 import VesselLink from 'features/vessel/VesselLink'
 import {
   SUBLAYER_INTERACTION_TYPES_WITH_VESSEL_INTERACTION,
@@ -179,6 +179,7 @@ function VesselsTable({
       info: vessel.infoDataset?.id,
       track: vessel.trackDataset?.id,
       ...(eventsDatasetsId.length > 0 && { events: eventsDatasetsId }),
+      relatedVesselIds: getRelatedIdentityVesselIds(vessel),
     })
 
     upsertDataviewInstance(vesselDataviewInstance)

--- a/apps/fishing-map/features/reports/vessels/ReportVesselsTable.tsx
+++ b/apps/fishing-map/features/reports/vessels/ReportVesselsTable.tsx
@@ -91,6 +91,7 @@ export default function ReportVesselsTable({ activityUnit, reportName }: ReportV
                       id: vessel.id || vessel.vesselId,
                       datasetId: vessel.dataset,
                     }}
+                    tooltip={t('vessel.addToWorkspace', 'Add vessel to view')}
                   />
                 </div>
                 <div className={cx({ [styles.border]: !isLastRow })}>

--- a/apps/fishing-map/features/reports/vessels/ReportVesselsTable.tsx
+++ b/apps/fishing-map/features/reports/vessels/ReportVesselsTable.tsx
@@ -2,27 +2,19 @@ import { useSelector } from 'react-redux'
 import { useTranslation } from 'react-i18next'
 import cx from 'classnames'
 import { Fragment } from 'react'
-import { IconButton } from '@globalfishingwatch/ui-components'
-import { DatasetTypes, DataviewInstance } from '@globalfishingwatch/api-types'
 import { EMPTY_FIELD_PLACEHOLDER, formatInfoField } from 'utils/info'
-import { getVesselDataviewInstance, getVesselInWorkspace } from 'features/dataviews/dataviews.utils'
-import { selectActiveTrackDataviews } from 'features/dataviews/dataviews.slice'
 import I18nNumber from 'features/i18n/i18nNumber'
 import { useLocationConnect } from 'routes/routes.hook'
-import { useDataviewInstancesConnect } from 'features/workspace/workspace.hook'
-import {
-  getDatasetsReportNotSupported,
-  getRelatedDatasetsByType,
-} from 'features/datasets/datasets.utils'
+import { getDatasetsReportNotSupported } from 'features/datasets/datasets.utils'
 import ReportVesselsTableFooter from 'features/reports/vessels/ReportVesselsTableFooter'
 import { selectActiveReportDataviews, selectReportCategory } from 'features/app/app.selectors'
 import { ReportCategory } from 'types'
 import { selectUserData } from 'features/user/user.slice'
 import DatasetLabel from 'features/datasets/DatasetLabel'
-import { GLOBAL_VESSELS_DATASET_ID } from 'data/workspaces'
 import { EMPTY_API_VALUES } from 'features/reports/reports.config'
 import VesselLink from 'features/vessel/VesselLink'
-import { ReportVesselWithDatasets, selectReportVesselsPaginated } from '../reports.selectors'
+import VesselPin from 'features/vessel/VesselPin'
+import { selectReportVesselsPaginated } from '../reports.selectors'
 import { ReportActivityUnit } from '../Report'
 import styles from './ReportVesselsTable.module.css'
 
@@ -34,9 +26,7 @@ type ReportVesselTableProps = {
 export default function ReportVesselsTable({ activityUnit, reportName }: ReportVesselTableProps) {
   const { t } = useTranslation()
   const { dispatchQueryParams } = useLocationConnect()
-  const { upsertDataviewInstance, deleteDataviewInstance } = useDataviewInstancesConnect()
   const vessels = useSelector(selectReportVesselsPaginated)
-  const vesselsInWorkspace = useSelector(selectActiveTrackDataviews)
   const reportCategory = useSelector(selectReportCategory)
   const userData = useSelector(selectUserData)
   const dataviews = useSelector(selectActiveReportDataviews)
@@ -44,31 +34,6 @@ export default function ReportVesselsTable({ activityUnit, reportName }: ReportV
     dataviews,
     userData?.permissions || []
   )
-
-  const onVesselClick = async (
-    ev: React.MouseEvent<Element, MouseEvent>,
-    vessel: ReportVesselWithDatasets
-  ) => {
-    const vesselInWorkspace = getVesselInWorkspace(vesselsInWorkspace, vessel.vesselId)
-    if (vesselInWorkspace) {
-      deleteDataviewInstance(vesselInWorkspace.id)
-      return
-    }
-    const vesselEventsDatasets = getRelatedDatasetsByType(vessel.infoDataset, DatasetTypes.Events)
-    const eventsDatasetsId =
-      vesselEventsDatasets && vesselEventsDatasets?.length
-        ? vesselEventsDatasets.map((d) => d.id)
-        : []
-    const vesselDataviewInstance: DataviewInstance = getVesselDataviewInstance(
-      { id: vessel.vesselId },
-      {
-        info: vessel.infoDataset?.id,
-        track: vessel.trackDataset?.id,
-        ...(eventsDatasetsId.length > 0 && { events: eventsDatasetsId }),
-      }
-    )
-    upsertDataviewInstance(vesselDataviewInstance)
-  }
 
   const onFilterClick = (reportVesselFilter: any) => {
     dispatchQueryParams({ reportVesselFilter, reportVesselPage: 0 })
@@ -110,14 +75,6 @@ export default function ReportVesselsTable({ activityUnit, reportName }: ReportV
               : t('common.detection_other', 'detections')}
           </div>
           {vessels?.map((vessel, i) => {
-            const hasDatasets = vessel.infoDataset?.id?.includes(GLOBAL_VESSELS_DATASET_ID)
-              ? vessel.infoDataset !== undefined && vessel.trackDataset !== undefined
-              : vessel.infoDataset !== undefined || vessel.trackDataset !== undefined
-            const vesselInWorkspace = getVesselInWorkspace(
-              vesselsInWorkspace,
-              vessel.vesselId as string
-            )
-            const pinTrackDisabled = !hasDatasets
             const isLastRow = i === vessels.length - 1
             const flag = t(`flags:${vessel.flag as string}` as any, EMPTY_FIELD_PLACEHOLDER)
             const flagInteractionEnabled = !EMPTY_API_VALUES.includes(vessel.flag)
@@ -129,22 +86,11 @@ export default function ReportVesselsTable({ activityUnit, reportName }: ReportV
                   className={cx({ [styles.border]: !isLastRow }, styles.icon)}
                   data-test={`vessel-${vessel.vesselId}`}
                 >
-                  <IconButton
-                    icon={vesselInWorkspace ? 'pin-filled' : 'pin'}
-                    style={{
-                      color: vesselInWorkspace ? vesselInWorkspace.config?.color : '',
+                  <VesselPin
+                    vesselToResolve={{
+                      id: vessel.id || vessel.vesselId,
+                      datasetId: vessel.dataset,
                     }}
-                    disabled={pinTrackDisabled}
-                    tooltip={
-                      pinTrackDisabled
-                        ? ''
-                        : vesselInWorkspace
-                        ? t('search.removeVessel', 'Remove vessel')
-                        : t('search.seeVessel', 'See vessel')
-                    }
-                    onClick={(e) => onVesselClick(e, vessel)}
-                    className="print-hidden"
-                    size="small"
                   />
                 </div>
                 <div className={cx({ [styles.border]: !isLastRow })}>

--- a/apps/fishing-map/features/vessel/VesselLink.tsx
+++ b/apps/fishing-map/features/vessel/VesselLink.tsx
@@ -30,6 +30,7 @@ export type VesselLinkProps = {
   identity?: VesselDataIdentity
   children: any
   onClick?: (e: MouseEvent) => void
+  tooltip?: React.ReactNode
   fitBounds?: boolean
   className?: string
   query?: Partial<Record<keyof QueryParams, string | number>>
@@ -41,6 +42,7 @@ const VesselLink = ({
   identity,
   children,
   onClick,
+  tooltip,
   fitBounds = true,
   className = '',
   query,
@@ -110,7 +112,7 @@ const VesselLink = ({
       }}
       onClick={onLinkClick}
     >
-      <Tooltip content={t('search.seeVessel', 'See vessel')}>
+      <Tooltip maxWidth="none" content={tooltip || t('search.seeVessel', 'See vessel')}>
         <span>{children}</span>
       </Tooltip>
     </Link>

--- a/apps/fishing-map/features/vessel/VesselPin.tsx
+++ b/apps/fishing-map/features/vessel/VesselPin.tsx
@@ -1,0 +1,158 @@
+import { useTranslation } from 'react-i18next'
+import { useSelector } from 'react-redux'
+import { useState } from 'react'
+import { IconButton } from '@globalfishingwatch/ui-components'
+import {
+  Dataset,
+  DatasetTypes,
+  DataviewInstance,
+  IdentityVessel,
+  Resource,
+  ResourceStatus,
+} from '@globalfishingwatch/api-types'
+import { resolveEndpoint, setResource } from '@globalfishingwatch/dataviews-client'
+import { GFWAPI } from '@globalfishingwatch/api-client'
+import { useDataviewInstancesConnect } from 'features/workspace/workspace.hook'
+import {
+  getVesselDataviewInstance,
+  getVesselDataviewInstanceDatasetConfig,
+  getVesselInWorkspace,
+  getVesselInfoDataviewInstanceDatasetConfig,
+} from 'features/dataviews/dataviews.utils'
+import { getRelatedDatasetsByType } from 'features/datasets/datasets.utils'
+import { getEventLabel } from 'utils/analytics'
+import { selectTrackDataviews } from 'features/dataviews/dataviews.slice'
+import { TrackCategory, trackEvent } from 'features/app/analytics.hooks'
+import { useAppDispatch } from 'features/app/app.hooks'
+import { getRelatedIdentityVesselIds, getVesselId } from 'features/vessel/vessel.utils'
+import { fetchDatasetByIdThunk, selectDatasetById } from 'features/datasets/datasets.slice'
+import { DEFAULT_VESSEL_IDENTITY_ID } from 'features/vessel/vessel.config'
+
+export type VesselToResolve = { id: string; name?: string; flag?: string; datasetId?: string }
+
+// Supports both options:
+// 1. When identity vessel already available: <VesselPin vessel={vessel} />
+// 2. When identity vessel is not available and we only have the vesselId, for example reports or encounters:
+//    <VesselPin vesselToResolve={vesselToResolve} /> This will fetch the vessel info and the info dataset
+function VesselPin({
+  vessel,
+  vesselToResolve,
+}: {
+  vessel?: IdentityVessel
+  vesselToResolve?: VesselToResolve
+}) {
+  const [loading, setLoading] = useState(false)
+  const { t } = useTranslation()
+  const dispatch = useAppDispatch()
+  const { upsertDataviewInstance, deleteDataviewInstance } = useDataviewInstancesConnect()
+  const vesselsInWorkspace = useSelector(selectTrackDataviews)
+  const infoDatasetId = vessel?.dataset || vesselToResolve?.datasetId || DEFAULT_VESSEL_IDENTITY_ID
+  const infoDataset = useSelector(selectDatasetById(infoDatasetId))
+  const vesselId = vessel ? getVesselId(vessel) : vesselToResolve!?.id
+  const vesselInWorkspace = getVesselInWorkspace(vesselsInWorkspace, vesselId)
+
+  // This avoid requesting the vessel info again when we alredy requested it for the popup
+  const populateVesselInfoResource = (
+    vessel: IdentityVessel,
+    vesselDataviewInstance: DataviewInstance
+  ) => {
+    const infoDatasetConfig = getVesselDataviewInstanceDatasetConfig(
+      vesselId,
+      vesselDataviewInstance.config || {}
+    )?.find((dc) => dc.datasetId === infoDataset?.id)
+    if (infoDataset && infoDatasetConfig) {
+      const url = resolveEndpoint(infoDataset, infoDatasetConfig)
+      if (url) {
+        const resource: Resource = {
+          url,
+          dataset: infoDataset,
+          datasetConfig: infoDatasetConfig,
+          dataviewId: vesselDataviewInstance.dataviewId as string,
+          data: vessel,
+          status: ResourceStatus.Finished,
+        }
+        dispatch(setResource(resource))
+      }
+    }
+  }
+
+  const onPinClick = async () => {
+    let vesselWithIdentity = vessel ? ({ ...vessel } as IdentityVessel) : undefined
+    let infoDatasetResolved = { ...infoDataset } as Dataset
+    if (!infoDatasetResolved && infoDatasetId) {
+      setLoading(true)
+      // Fetch the info dataset when no available in the store
+      const action = await dispatch(fetchDatasetByIdThunk(infoDatasetId))
+      if (fetchDatasetByIdThunk.fulfilled.match(action)) {
+        infoDatasetResolved = action.payload as Dataset
+      } else {
+        console.warn('Pin vessel is not available without an info dataset')
+      }
+    }
+    if (!vesselWithIdentity && infoDatasetResolved) {
+      // Fetch the vessel identity info no available
+      const datasetConfig = getVesselInfoDataviewInstanceDatasetConfig(vesselId, {
+        info: infoDatasetResolved?.id,
+      })
+      const url = resolveEndpoint(infoDatasetResolved, datasetConfig)
+      if (url) {
+        setLoading(true)
+        vesselWithIdentity = await GFWAPI.fetch<IdentityVessel>(url)
+      }
+    }
+    if (vesselWithIdentity) {
+      if (vesselInWorkspace) {
+        deleteDataviewInstance(vesselInWorkspace.id)
+      } else {
+        const trackDataset = getRelatedDatasetsByType(infoDataset, DatasetTypes.Tracks)?.[0]
+        const vesselEventsDatasets = getRelatedDatasetsByType(infoDataset, DatasetTypes.Events)
+        const eventsDatasetsId =
+          vesselEventsDatasets && vesselEventsDatasets?.length
+            ? vesselEventsDatasets.map((d) => d.id)
+            : []
+        const vesselDataviewInstance = getVesselDataviewInstance(
+          { id: vesselId },
+          {
+            info: infoDataset?.id,
+            track: trackDataset?.id,
+            ...(eventsDatasetsId?.length && { events: eventsDatasetsId }),
+            relatedVesselIds: getRelatedIdentityVesselIds(vesselWithIdentity),
+          }
+        )
+
+        if (vesselDataviewInstance) {
+          upsertDataviewInstance(vesselDataviewInstance)
+          populateVesselInfoResource(vesselWithIdentity, vesselDataviewInstance)
+
+          trackEvent({
+            category: TrackCategory.Tracks,
+            action: 'Click in vessel from grid cell panel',
+            label: getEventLabel([infoDataset?.id || '', vesselId]),
+          })
+        }
+      }
+    } else {
+      console.warn('Vessel to pin not found')
+    }
+    setLoading(false)
+  }
+
+  return (
+    <IconButton
+      icon={vesselInWorkspace ? 'pin-filled' : 'pin'}
+      loading={loading}
+      style={{
+        color: vesselInWorkspace ? vesselInWorkspace.config?.color : '',
+      }}
+      tooltip={
+        vesselInWorkspace
+          ? t('search.vesselAlreadyInWorkspace', 'This vessel is already in your workspace')
+          : t('search.seeVessel', 'See vessel')
+      }
+      onClick={onPinClick}
+      size="small"
+    />
+  )
+}
+
+export default VesselPin

--- a/apps/fishing-map/features/vessel/VesselPin.tsx
+++ b/apps/fishing-map/features/vessel/VesselPin.tsx
@@ -37,9 +37,11 @@ export type VesselToResolve = { id: string; name?: string; flag?: string; datase
 function VesselPin({
   vessel,
   vesselToResolve,
+  tooltip,
 }: {
   vessel?: IdentityVessel
   vesselToResolve?: VesselToResolve
+  tooltip?: React.ReactNode
 }) {
   const [loading, setLoading] = useState(false)
   const { t } = useTranslation()
@@ -147,7 +149,7 @@ function VesselPin({
       tooltip={
         vesselInWorkspace
           ? t('search.vesselAlreadyInWorkspace', 'This vessel is already in your workspace')
-          : t('search.seeVessel', 'See vessel')
+          : tooltip || t('search.seeVessel', 'See vessel')
       }
       onClick={onPinClick}
       size="small"

--- a/apps/fishing-map/features/vessel/related-vessels/RelatedEncounterVessels.tsx
+++ b/apps/fishing-map/features/vessel/related-vessels/RelatedEncounterVessels.tsx
@@ -17,7 +17,7 @@ const VesselTick = ({ y, index }: any) => {
   const vessel = encountersByVessel[index]
   return (
     <foreignObject x={0} y={y - 20} className={styles.vesselContainer}>
-      <RelatedVessel vessel={vessel as any} showTooltip />
+      <RelatedVessel vesselToResolve={vessel} showTooltip />
     </foreignObject>
   )
 }

--- a/apps/fishing-map/features/vessel/related-vessels/RelatedOwnersVessels.tsx
+++ b/apps/fishing-map/features/vessel/related-vessels/RelatedOwnersVessels.tsx
@@ -7,9 +7,9 @@ import { Spinner } from '@globalfishingwatch/ui-components'
 import { VesselRegistryOwner } from '@globalfishingwatch/api-types'
 import { selectVesselDatasetId } from 'features/vessel/vessel.config.selectors'
 import {
-  getCurrentIdentityVessel,
   getVesselProperty,
   filterRegistryInfoByDateAndSSVID,
+  getVesselId,
 } from 'features/vessel/vessel.utils'
 import { formatInfoField } from 'utils/info'
 import { selectVesselInfoData } from 'features/vessel/vessel.slice'
@@ -53,10 +53,9 @@ const OwnerVessels = ({ owner, dataset, ignoreVessel }: OwnerVesselsProps) => {
   return (
     <ul className={styles.ownersList}>
       {vessels?.map((vessel) => {
-        const vesselIdentity = getCurrentIdentityVessel(vessel)
         return (
-          <li key={vesselIdentity.id} className={styles.vessel}>
-            <RelatedVessel vessel={vesselIdentity} showTooltip />
+          <li key={getVesselId(vessel)} className={styles.vessel}>
+            <RelatedVessel vessel={vessel} showTooltip />
           </li>
         )
       })}

--- a/apps/fishing-map/features/vessel/related-vessels/RelatedVessel.tsx
+++ b/apps/fishing-map/features/vessel/related-vessels/RelatedVessel.tsx
@@ -1,7 +1,7 @@
 import { Fragment } from 'react'
 import { useSelector } from 'react-redux'
+import { useTranslation } from 'react-i18next'
 import { Dataset, IdentityVessel } from '@globalfishingwatch/api-types'
-import { Tooltip } from '@globalfishingwatch/ui-components'
 import { selectVesselDataset } from 'features/vessel/vessel.selectors'
 import { formatInfoField } from 'utils/info'
 import VesselLink from 'features/vessel/VesselLink'
@@ -19,6 +19,7 @@ const RelatedVessel = ({
   vesselToResolve?: VesselToResolve
   showTooltip?: boolean
 }) => {
+  const { t } = useTranslation()
   const vesselIdentity = vessel ? getCurrentIdentityVessel(vessel) : vesselToResolve
   const isWorkspaceVesselLocation = useSelector(selectIsWorkspaceVesselLocation)
   const vesselDataset = useSelector(selectVesselDataset) as Dataset
@@ -27,23 +28,20 @@ const RelatedVessel = ({
     'shipname'
   )
   const flagLabel = formatInfoField(vesselIdentity?.flag || '', 'flag')
-  const fullLabel = `${nameLabel} (${flagLabel})`
+  const fullLabel = `${t('common.see', 'See')} ${nameLabel} (${flagLabel})`
 
   return (
     <Fragment>
       {isWorkspaceVesselLocation && <VesselPin vessel={vessel} vesselToResolve={vesselToResolve} />}
-      <Tooltip content={showTooltip && fullLabel.length > 30 && fullLabel}>
-        <span>
-          <VesselLink
-            className={styles.vessel}
-            vesselId={vesselIdentity?.id}
-            datasetId={vesselDataset?.id}
-          >
-            {nameLabel}
-          </VesselLink>{' '}
-          <span className={styles.secondary}>({flagLabel})</span>
-        </span>
-      </Tooltip>
+      <VesselLink
+        className={styles.vessel}
+        vesselId={vesselIdentity?.id}
+        datasetId={vesselDataset?.id}
+        tooltip={showTooltip ? fullLabel : ''}
+      >
+        {nameLabel}
+      </VesselLink>{' '}
+      <span className={styles.secondary}>({flagLabel})</span>
     </Fragment>
   )
 }

--- a/apps/fishing-map/features/vessel/related-vessels/RelatedVessel.tsx
+++ b/apps/fishing-map/features/vessel/related-vessels/RelatedVessel.tsx
@@ -32,7 +32,13 @@ const RelatedVessel = ({
 
   return (
     <Fragment>
-      {isWorkspaceVesselLocation && <VesselPin vessel={vessel} vesselToResolve={vesselToResolve} />}
+      {isWorkspaceVesselLocation && (
+        <VesselPin
+          vessel={vessel}
+          vesselToResolve={vesselToResolve}
+          tooltip={t('vessel.addToWorkspace', 'Add vessel to view')}
+        />
+      )}
       <VesselLink
         className={styles.vessel}
         vesselId={vesselIdentity?.id}

--- a/apps/fishing-map/features/vessel/vessel.slice.ts
+++ b/apps/fishing-map/features/vessel/vessel.slice.ts
@@ -4,7 +4,6 @@ import { GFWAPI, ParsedAPIError, parseAPIError } from '@globalfishingwatch/api-c
 import {
   Dataset,
   DatasetTypes,
-  EndpointId,
   IdentityVessel,
   Resource,
   ResourceStatus,
@@ -15,6 +14,7 @@ import {
 import { resolveEndpoint, setResource } from '@globalfishingwatch/dataviews-client'
 import { VesselIdentitySourceEnum } from '@globalfishingwatch/api-types'
 import { AsyncReducerStatus } from 'utils/async-slice'
+import { selectResources } from 'features/resources/resources.slice'
 import {
   fetchDatasetByIdThunk,
   fetchDatasetsByIdsThunk,
@@ -24,6 +24,7 @@ import { getRelatedDatasetByType, getRelatedDatasetsByType } from 'features/data
 import {
   VesselInstanceDatasets,
   getVesselDataviewInstance,
+  getVesselInfoDataviewInstanceDatasetConfig,
 } from 'features/dataviews/dataviews.utils'
 import { fetchDataviewsByIdsThunk } from 'features/dataviews/dataviews.slice'
 import { PROFILE_DATAVIEW_SLUGS } from 'data/workspaces'
@@ -77,8 +78,11 @@ export const fetchVesselInfoThunk = createAsyncThunk(
   ) => {
     try {
       const state = getState() as any
+      // TODO: skip dataset fetch if already loaded in the
+      // const dataset = selectAllDatasets(state).find((d: Dataset) => d.id === datasetId)
       const action = await dispatch(fetchDatasetByIdThunk(datasetId))
       const guestUser = isGuestUser(state)
+      const resources = selectResources(state)
       if (fetchDatasetByIdThunk.fulfilled.match(action)) {
         const dataset = action.payload as Dataset
         // Datasets and dataview needed to mock follow the structure of the map and resolve the generators
@@ -92,38 +96,23 @@ export const fetchVesselInfoThunk = createAsyncThunk(
         })
         dispatch(fetchDatasetsByIdsThunk({ ids: datasetsToFetch }))
 
-        const datasetConfig = {
-          endpoint: EndpointId.Vessel,
-          datasetId: dataset.id,
-          params: [{ id: 'vesselId', value: vesselId }],
-          query: [
-            {
-              id: 'dataset',
-              value: datasetId,
-            },
-          ],
-        }
-        // Adding the custom query to include the self-reported info but only for the vessel profile
-        // this way we can prepolate the vessel info resouce and avoid requesting the resource again
-        const vesselProfileDatasetConfig = {
-          ...datasetConfig,
-          query: [
-            ...datasetConfig.query,
-            {
-              id: 'includes',
-              value: ['POTENTIAL_RELATED_SELF_REPORTED_INFO'],
-            },
-          ],
-        }
+        const datasetConfig = getVesselInfoDataviewInstanceDatasetConfig(vesselId, {
+          info: dataset.id,
+        })
         if (guestUser) {
           // This changes the order of the query params to avoid the cache
-          vesselProfileDatasetConfig.query.reverse()
+          datasetConfig.query?.reverse()
         }
-        const url = resolveEndpoint(dataset, vesselProfileDatasetConfig)
+        const url = resolveEndpoint(dataset, datasetConfig)
+
         if (!url) {
           return rejectWithValue({ message: 'Error resolving endpoint' })
         }
-        const vessel = await GFWAPI.fetch<IdentityVessel>(url)
+
+        const vessel = resources[url]
+          ? (resources[url].data as IdentityVessel)
+          : await GFWAPI.fetch<IdentityVessel>(url)
+
         const resource: Resource = {
           url: resolveEndpoint(dataset, datasetConfig) as string,
           dataset: dataset,

--- a/apps/fishing-map/features/vessel/vessel.utils.ts
+++ b/apps/fishing-map/features/vessel/vessel.utils.ts
@@ -289,8 +289,9 @@ export function filterRegistryInfoByDateAndSSVID(
 
 export const getOtherVesselNames = (
   vessel: IdentityVessel | IdentityVesselData,
-  currentNShipname: string
+  currentName?: string
 ) => {
+  const currentNShipname = currentName || getSearchIdentityResolved(vessel)?.nShipname
   const uniqIdentitiesByNormalisedName = uniqBy(getVesselIdentities(vessel), 'nShipname')
   const otherIdentities = uniqIdentitiesByNormalisedName.filter(
     (i) => i.nShipname !== currentNShipname

--- a/apps/fishing-map/features/workspace/shared/LayerPanel.module.css
+++ b/apps/fishing-map/features/workspace/shared/LayerPanel.module.css
@@ -280,7 +280,8 @@
   display: none !important;
 }
 
-.faded {
+.faded,
+.secondary {
   color: var(--color-secondary-blue);
 }
 

--- a/apps/fishing-map/features/workspace/vessels/VesselLayerPanel.tsx
+++ b/apps/fishing-map/features/workspace/vessels/VesselLayerPanel.tsx
@@ -41,6 +41,19 @@ export type VesselLayerPanelProps = {
   dataview: UrlDataviewInstance
 }
 
+export const getVesselIdentityTooltipSummary = (vessel: IdentityVessel) => {
+  return vessel?.selfReportedInfo.flatMap((selfReported, index) => {
+    const info = `${formatInfoField(selfReported.shipname, 'name')} - ${formatInfoField(
+      selfReported.flag,
+      'flag'
+    )} (${formatI18nDate(selfReported.transmissionDateFrom)} - ${formatI18nDate(
+      selfReported.transmissionDateTo
+    )})`
+
+    return index < vessel?.selfReportedInfo.length - 1 ? [info, <br />] : [info]
+  })
+}
+
 function VesselLayerPanel({ dataview }: VesselLayerPanelProps): React.ReactElement {
   const { t } = useTranslation()
   const { upsertDataviewInstance } = useDataviewInstancesConnect()
@@ -91,16 +104,7 @@ function VesselLayerPanel({ dataview }: VesselLayerPanelProps): React.ReactEleme
   const vesselData = infoResource?.data
   const vesselLabel = vesselData ? getVesselLabel(vesselData) : ''
   const otherVesselsLabel = vesselData ? getOtherVesselNames(vesselData as IdentityVessel) : ''
-  const identitiesSummary = vesselData?.selfReportedInfo.flatMap((selfReported, index) => {
-    const info = `${formatInfoField(selfReported.shipname, 'name')} - ${formatInfoField(
-      selfReported.flag,
-      'flag'
-    )} (${formatI18nDate(selfReported.transmissionDateFrom)} - ${formatI18nDate(
-      selfReported.transmissionDateTo
-    )})`
-
-    return index < vesselData?.selfReportedInfo.length - 1 ? [info, <br />] : [info]
-  })
+  const identitiesSummary = vesselData ? getVesselIdentityTooltipSummary(vesselData) : ''
 
   const vesselId =
     (infoResource?.datasetConfig?.params?.find(

--- a/apps/fishing-map/features/workspace/vessels/VesselLayerPanel.tsx
+++ b/apps/fishing-map/features/workspace/vessels/VesselLayerPanel.tsx
@@ -29,6 +29,7 @@ import { useLayerPanelDataviewSort } from 'features/workspace/shared/layer-panel
 import GFWOnly from 'features/user/GFWOnly'
 import VesselDownload from 'features/workspace/vessels/VesselDownload'
 import VesselLink from 'features/vessel/VesselLink'
+import { getOtherVesselNames } from 'features/vessel/vessel.utils'
 import Color from '../common/Color'
 import LayerSwitch from '../common/LayerSwitch'
 import Remove from '../common/Remove'
@@ -87,6 +88,9 @@ function VesselLayerPanel({ dataview }: VesselLayerPanelProps): React.ReactEleme
   const trackError = trackResource?.status === ResourceStatus.Error
 
   const vesselLabel = infoResource?.data ? getVesselLabel(infoResource.data) : ''
+  const otherVesselsLabel = infoResource?.data
+    ? getOtherVesselNames(infoResource?.data as IdentityVessel)
+    : ''
   const vesselId =
     (infoResource?.datasetConfig?.params?.find(
       (p: DataviewDatasetConfigParam) => p.id === 'vesselId'
@@ -103,11 +107,19 @@ function VesselLayerPanel({ dataview }: VesselLayerPanelProps): React.ReactEleme
         <Fragment>
           <GFWOnly type="only-icon" />
           {vesselLabel}
+          {otherVesselsLabel && <span className={styles.secondary}>{otherVesselsLabel}</span>}
         </Fragment>
       )
-    if (dataview?.datasetsConfig?.some((d) => isPrivateDataset({ id: d.datasetId })))
-      return `🔒 ${vesselLabel}`
-    return vesselLabel
+    const isPrivateVessel = dataview?.datasetsConfig?.some((d) =>
+      isPrivateDataset({ id: d.datasetId })
+    )
+    return (
+      <Fragment>
+        {isPrivateVessel && '🔒'}
+        {vesselLabel}
+        {otherVesselsLabel && <span className={styles.secondary}>{otherVesselsLabel}</span>}
+      </Fragment>
+    )
   }
 
   const TitleComponentContent = () => (

--- a/apps/fishing-map/public/locales/source/translations.json
+++ b/apps/fishing-map/public/locales/source/translations.json
@@ -174,6 +174,7 @@
     "resetHelpHints": "Show again all help hints",
     "sar": "Radar detections (SAR)",
     "save": "Save",
+    "see": "See",
     "seeDefault": "See default view",
     "share": "Share the current view",
     "sources": "Sources",


### PR DESCRIPTION
To show all the vessel track and events history data, we need to resolve all vessel identities before pinning a vessel to ensure the `relatedVesselIds` are populated into the dataviewInstance.

This is [easily done in the cell interaction](https://github.com/GlobalFishingWatch/frontend/commit/beccc4e1d41f0df4f6e01f72c295c92fe27efa16#diff-315ad2108ff73a49247a0562ce9ba936813e014830808cdbf2d44acb64ff84a3R182) as we already requested the vessel identity to the new API but we only have the `vesselId` in the following cases:
- Encounter layers
- Pinning a vessel from a report
- Related vessels in profile

To keep it as simple and reusable as possible the new <VesselPin /> component will request automatically the vesselIdentity info when passing a `vesselToResolve` prop and include the rest of the `selfReportedInfo` ids into the `relatedVesselIds`

Also, this PR adds the identity summary in the:
- Vessel sidebar
![image](https://github.com/GlobalFishingWatch/frontend/assets/10500650/06805b81-5176-48f2-8cea-7ae9222c38e0)
- Vessel interaction tooltip
![image](https://github.com/GlobalFishingWatch/frontend/assets/10500650/eab3b2d3-5724-4673-879c-067a8263b91f)

