### PR TITLE
Avoid month index mess up

### DIFF
--- a/libs/timebar/src/components/timerange-selector.js
+++ b/libs/timebar/src/components/timerange-selector.js
@@ -2,12 +2,7 @@ import React, { Component } from 'react'
 import classNames from 'classnames'
 import { string, func, shape } from 'prop-types'
 import dayjs from 'dayjs'
-import {
-  LIMITS_BY_INTERVAL,
-  getInterval,
-  INTERVAL_ORDER,
-  Interval,
-} from '@globalfishingwatch/layer-composer'
+import { LIMITS_BY_INTERVAL, getInterval, INTERVAL_ORDER } from '@globalfishingwatch/layer-composer'
 import { Select, Tooltip } from '@globalfishingwatch/ui-components'
 import { getTime } from '../utils/internal-utils'
 import { getLastX } from '../utils'
@@ -54,12 +49,12 @@ class TimeRangeSelector extends Component {
       endDate: dayjs.utc(end),
       startInputValues: {
         year: startDate.year(),
-        month: startDate.month() + 1,
+        month: startDate.month(),
         date: startDate.date(),
       },
       endInputValues: {
         year: endDate.year(),
-        month: endDate.month() + 1,
+        month: endDate.month(),
         date: endDate.date(),
       },
       startInputValids: {
@@ -83,7 +78,7 @@ class TimeRangeSelector extends Component {
     const newStart = dayjs
       .utc({
         year: start.year(),
-        month: disabledFields.month ? 0 : start.month() + 1,
+        month: disabledFields.month ? 0 : start.month() - 1,
         date: disabledFields.day ? 0 : start.date(),
       })
       .startOf('day')
@@ -91,7 +86,7 @@ class TimeRangeSelector extends Component {
     const newEnd = dayjs
       .utc({
         year: end.year(),
-        month: disabledFields.month ? 0 : end.month() + 1,
+        month: disabledFields.month ? 0 : end.month() - 1,
         date: disabledFields.day ? 0 : end.date(),
       })
       .startOf('day')

--- a/libs/timebar/src/components/timerange-selector.js
+++ b/libs/timebar/src/components/timerange-selector.js
@@ -49,12 +49,12 @@ class TimeRangeSelector extends Component {
       endDate: dayjs.utc(end),
       startInputValues: {
         year: startDate.year(),
-        month: startDate.month(),
+        month: startDate.month() + 1,
         date: startDate.date(),
       },
       endInputValues: {
         year: endDate.year(),
-        month: endDate.month(),
+        month: endDate.month() + 1,
         date: endDate.date(),
       },
       startInputValids: {
@@ -120,10 +120,7 @@ class TimeRangeSelector extends Component {
   }
 
   onStartChange = (e, property) => {
-    const startDate = dayjs.utc({
-      ...this.state.startInputValues,
-      month: this.state.startInputValues.month,
-    })
+    const startDate = dayjs.utc(this.props.start)
     const currentMonthDays = dayjs
       .utc({
         year: property === 'year' ? e.target.value : startDate.year(),
@@ -160,10 +157,7 @@ class TimeRangeSelector extends Component {
   }
 
   onEndChange = (e, property) => {
-    const endDate = dayjs.utc({
-      ...this.state.endInputValues,
-      month: this.state.endInputValues.month,
-    })
+    const endDate = dayjs.utc(this.props.end)
     const currentMonthDays = dayjs
       .utc({
         year: property === 'year' ? e.target.value : endDate.year(),
@@ -295,7 +289,7 @@ class TimeRangeSelector extends Component {
                         onChange={(e) => this.onStartChange(e, 'month')}
                         onBlur={(e) => this.onStartBlur(e, 'month')}
                         step={'1'}
-                        disabled={disabledFields.month}
+                        disabled={disabledFields['MONTH']}
                         className={classNames(styles.input, {
                           [styles.error]: !startValid || !startBeforeEnd,
                         })}
@@ -320,7 +314,7 @@ class TimeRangeSelector extends Component {
                         onChange={(e) => this.onStartChange(e, 'date')}
                         onBlur={(e) => this.onStartBlur(e, 'date')}
                         step={'1'}
-                        disabled={disabledFields.day}
+                        disabled={disabledFields['DAY']}
                         className={classNames(styles.input, {
                           [styles.error]: !startValid || !startBeforeEnd,
                         })}
@@ -366,7 +360,7 @@ class TimeRangeSelector extends Component {
                         onChange={(e) => this.onEndChange(e, 'month')}
                         onBlur={(e) => this.onEndBlur(e, 'month')}
                         step={'1'}
-                        disabled={disabledFields.month}
+                        disabled={disabledFields['MONTH']}
                         className={classNames(styles.input, {
                           [styles.error]: !endValid || !startBeforeEnd,
                         })}
@@ -391,7 +385,7 @@ class TimeRangeSelector extends Component {
                         onChange={(e) => this.onEndChange(e, 'date')}
                         onBlur={(e) => this.onEndBlur(e, 'date')}
                         step={'1'}
-                        disabled={disabledFields.day}
+                        disabled={disabledFields['DAY']}
                         className={classNames(styles.input, {
                           [styles.error]: !endValid || !startBeforeEnd,
                         })}

--- a/libs/timebar/src/timebar.js
+++ b/libs/timebar/src/timebar.js
@@ -125,9 +125,15 @@ class Timebar extends Component {
 
   onIntervalClick = (interval) => {
     const { start, end, absoluteStart, absoluteEnd, latestAvailableDataDate } = this.props
+    console.log(
+      '🚀 ~ file: timebar.js:128 ~ Timebar ~ latestAvailableDataDate:',
+      latestAvailableDataDate
+    )
     const intervalConfig = CONFIG_BY_INTERVAL[interval]
+    console.log('🚀 ~ start, end:', start, end)
     if (intervalConfig) {
       const intervalLimit = LIMITS_BY_INTERVAL[interval]
+      console.log('🚀 ~ file: timebar.js:136 ~ Timebar ~ intervalLimit:', intervalLimit)
       if (intervalLimit) {
         let newStart
         let newEnd

--- a/libs/timebar/src/timebar.js
+++ b/libs/timebar/src/timebar.js
@@ -125,15 +125,10 @@ class Timebar extends Component {
 
   onIntervalClick = (interval) => {
     const { start, end, absoluteStart, absoluteEnd, latestAvailableDataDate } = this.props
-    console.log(
-      '🚀 ~ file: timebar.js:128 ~ Timebar ~ latestAvailableDataDate:',
-      latestAvailableDataDate
-    )
     const intervalConfig = CONFIG_BY_INTERVAL[interval]
-    console.log('🚀 ~ start, end:', start, end)
     if (intervalConfig) {
       const intervalLimit = LIMITS_BY_INTERVAL[interval]
-      console.log('🚀 ~ file: timebar.js:136 ~ Timebar ~ intervalLimit:', intervalLimit)
+
       if (intervalLimit) {
         let newStart
         let newEnd
@@ -152,7 +147,7 @@ class Timebar extends Component {
           }).startOf(intervalLimit.unit)
           newEnd = newStart.plus({ [intervalLimit.unit]: 1 })
         }
-        this.notifyChange(newStart.toISODate(), newEnd.toISODate(), EVENT_INTERVAL_SOURCE[interval])
+        this.notifyChange(newStart.toISO(), newEnd.toISO(), EVENT_INTERVAL_SOURCE[interval])
       } else {
         this.notifyChange(absoluteStart, absoluteEnd, EVENT_INTERVAL_SOURCE[interval])
       }


### PR DESCRIPTION
PR fixing [this bug reported](https://globalfishingwatch.slack.com/archives/C0296TY92KC/p1699396660179769) 👇🏼 
```
User feedback - 17:25 29T 07 November 2023
Details
Timebar is not updating based on the selected start and end date. It seems to always add a few months to both the start and end date set by the user.
Name - Rollan Geronimo
Role - analyst 
```
`dayjs.utc` method is already normalizing month dates (since January is index `0` on months array). So we were adding a `+1` in some cases that were causing date to move month by one (so January would display February). 
There was another issue when handling input values from the `TimerangeSelector` component, we were using the `event.target.value` so January would be mont `1` hence adding another month (since `index` `1` would be February).
Those two added months were reflected in the UI in all dates.