### PR TITLE
Avoid the chance to increment months on years beyond 2024

### DIFF
--- a/libs/timebar/src/components/timerange-selector.js
+++ b/libs/timebar/src/components/timerange-selector.js
@@ -78,16 +78,16 @@ class TimeRangeSelector extends Component {
     const newStart = dayjs
       .utc({
         year: start.year(),
-        month: disabledFields.month ? 0 : start.month() - 1,
-        date: disabledFields.day ? 0 : start.date(),
+        month: disabledFields['MONTH'] ? 0 : start.month() - 1,
+        date: disabledFields['DAY'] ? 0 : start.date(),
       })
       .startOf('day')
       .toISOString()
     const newEnd = dayjs
       .utc({
         year: end.year(),
-        month: disabledFields.month ? 0 : end.month() - 1,
-        date: disabledFields.day ? 0 : end.date(),
+        month: disabledFields['MONTH'] ? 0 : end.month() - 1,
+        date: disabledFields['DAY'] ? 0 : end.date(),
       })
       .startOf('day')
       .toISOString()
@@ -271,11 +271,11 @@ class TimeRangeSelector extends Component {
                       })}
                     />
                   </div>
-                  <Tooltip content={disabledFields.month ? labels.tooLongForMonths : ''}>
+                  <Tooltip content={disabledFields['MONTH'] ? labels.tooLongForMonths : ''}>
                     <div className={styles.selectorGroup}>
                       <label
                         className={classNames(styles.selectorLabel, {
-                          [styles.faded]: disabledFields.month,
+                          [styles.faded]: disabledFields['MONTH'],
                         })}
                       >
                         {labels.month}
@@ -285,7 +285,7 @@ class TimeRangeSelector extends Component {
                         type="number"
                         min="1"
                         max="12"
-                        value={startInputValues.month}
+                        value={disabledFields['MONTH'] ? 1 : startInputValues.month}
                         onChange={(e) => this.onStartChange(e, 'month')}
                         onBlur={(e) => this.onStartBlur(e, 'month')}
                         step={'1'}
@@ -296,11 +296,11 @@ class TimeRangeSelector extends Component {
                       />
                     </div>
                   </Tooltip>
-                  <Tooltip content={disabledFields.day ? labels.tooLongForDays : ''}>
+                  <Tooltip content={disabledFields['DAY'] ? labels.tooLongForDays : ''}>
                     <div className={styles.selectorGroup}>
                       <label
                         className={classNames(styles.selectorLabel, {
-                          [styles.faded]: disabledFields.day,
+                          [styles.faded]: disabledFields['DAY'],
                         })}
                       >
                         {labels.day}
@@ -310,7 +310,7 @@ class TimeRangeSelector extends Component {
                         type="number"
                         min={'1'}
                         max={startDate.daysInMonth()}
-                        value={startInputValues.date}
+                        value={disabledFields['DAY'] ? 1 : startInputValues.date}
                         onChange={(e) => this.onStartChange(e, 'date')}
                         onBlur={(e) => this.onStartBlur(e, 'date')}
                         step={'1'}
@@ -342,11 +342,11 @@ class TimeRangeSelector extends Component {
                       })}
                     />
                   </div>
-                  <Tooltip content={disabledFields.month ? labels.tooLongForMonths : ''}>
+                  <Tooltip content={disabledFields['MONTH'] ? labels.tooLongForMonths : ''}>
                     <div className={styles.selectorGroup}>
                       <label
                         className={classNames(styles.selectorLabel, {
-                          [styles.faded]: disabledFields.month,
+                          [styles.faded]: disabledFields['MONTH'],
                         })}
                       >
                         {labels.month}
@@ -356,7 +356,7 @@ class TimeRangeSelector extends Component {
                         type="number"
                         min="1"
                         max="12"
-                        value={endInputValues.month}
+                        value={disabledFields['MONTH'] ? 1 : endInputValues.month}
                         onChange={(e) => this.onEndChange(e, 'month')}
                         onBlur={(e) => this.onEndBlur(e, 'month')}
                         step={'1'}
@@ -370,11 +370,11 @@ class TimeRangeSelector extends Component {
                       />
                     </div>
                   </Tooltip>
-                  <Tooltip content={disabledFields.day ? labels.tooLongForDays : ''}>
+                  <Tooltip content={disabledFields['DAY'] ? labels.tooLongForDays : ''}>
                     <div className={styles.selectorGroup}>
                       <label
                         className={classNames(styles.selectorLabel, {
-                          [styles.faded]: disabledFields.day,
+                          [styles.faded]: disabledFields['DAY'],
                         })}
                       >
                         {labels.day}
@@ -384,7 +384,7 @@ class TimeRangeSelector extends Component {
                         type="number"
                         min={'1'}
                         max={endDate.daysInMonth()}
-                        value={endInputValues.date}
+                        value={disabledFields['DAY'] ? 1 : endInputValues.date}
                         onChange={(e) => this.onEndChange(e, 'date')}
                         onBlur={(e) => this.onEndBlur(e, 'date')}
                         step={'1'}

--- a/libs/timebar/src/components/timerange-selector.js
+++ b/libs/timebar/src/components/timerange-selector.js
@@ -332,7 +332,7 @@ class TimeRangeSelector extends Component {
                       name="end year"
                       type="number"
                       min={this.bounds.min.slice(0, 4)}
-                      max={(parseInt(this.bounds.max.slice(0, 4)) + 1).toString()}
+                      max={this.bounds.max.slice(0, 4)}
                       value={endInputValues.year}
                       onChange={(e) => this.onEndChange(e, 'year')}
                       onBlur={(e) => this.onEndBlur(e, 'year')}
@@ -360,7 +360,10 @@ class TimeRangeSelector extends Component {
                         onChange={(e) => this.onEndChange(e, 'month')}
                         onBlur={(e) => this.onEndBlur(e, 'month')}
                         step={'1'}
-                        disabled={disabledFields['MONTH']}
+                        disabled={
+                          disabledFields['MONTH'] ||
+                          endInputValues.year > this.bounds.max.slice(0, 4)
+                        }
                         className={classNames(styles.input, {
                           [styles.error]: !endValid || !startBeforeEnd,
                         })}


### PR DESCRIPTION
This PR avoids the situation where the user can increment month values on the timerange-selector when the selected year is higher than 2023 (when changing to month interval sometimes the end date is January the first 2024. With this fix, month input would be disabled so user can not select month 12 on year 2024)