### PR TITLE
add neural_vessel_type as filter

### DIFF
--- a/apps/fishing-map/features/datasets/datasets.utils.ts
+++ b/apps/fishing-map/features/datasets/datasets.utils.ts
@@ -59,6 +59,7 @@ export type SupportedActivityDatasetSchema =
   | 'target_species' // between camelCase or snake_case
   | 'license_category'
   | 'vessel-groups'
+  | 'neural_vessel_type'
   | 'visibleValues'
   | 'callsign'
   | 'shipname'

--- a/apps/fishing-map/features/workspace/activity/ActivityLayerPanel.tsx
+++ b/apps/fishing-map/features/workspace/activity/ActivityLayerPanel.tsx
@@ -174,6 +174,7 @@ function ActivityLayerPanel({
       { field: 'license_category', label: t('vessel.license_category', 'License category') },
       { field: 'vessel_type', label: t('vessel.vesselType_other', 'Vessel types') },
       { field: 'vessel-groups', label: t('vesselGroup.vesselGroup', 'Vessel Group') },
+      { field: 'neural_vessel_type', label: t('vessel.neuralVesselType', 'Neural vessel type') },
     ]
     return fields
   }, [t])


### PR DESCRIPTION
This includes the `neural_vessel_type` filter for the SAR dataset simplifying https://github.com/GlobalFishingWatch/frontend/pull/2386 as is using enums now. 