### PR TITLE
🚀 Release - Vessel Viewer v1.9.1

### DIFF
--- a/apps/vessel-history/features/map/Map.tsx
+++ b/apps/vessel-history/features/map/Map.tsx
@@ -227,6 +227,19 @@ const MapWrapper: React.FC = (): React.ReactElement => {
       ]
     }).flat()
 
+    const fishingEffortLayersHidden = [
+      'fishing-ais',
+      // Update this dataviewId when a the vms layer dataview id is changed in
+      // https://github.com/GlobalFishingWatch/frontend/blob/develop/apps/fishing-map/features/workspace/highlight-panel/highlight-panel.content.ts#L43
+      'vms-with-png'
+    ].map(layer => {
+      i++
+      return [
+        `dvIn[${i}][id]=${layer}`,
+        `dvIn[${i}][cfg][vis]=false`,
+      ]
+    }).flat()
+
     const urlSegments = [
       `https://globalfishingwatch.org/map/index?`,
       `start=${start}`,
@@ -236,6 +249,7 @@ const MapWrapper: React.FC = (): React.ReactElement => {
       `end=${end}`,
       ...fishingMapVesselDataview,
       ...contextLayersDataviews,
+      ...fishingEffortLayersHidden,
       `timebarVisualisation=vessel`,
     ]
     const url = urlSegments.join('&')

--- a/apps/vessel-history/package.json
+++ b/apps/vessel-history/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@globalfishingwatchapp/vessel-history",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "private": true,
   "homepage": "/",
   "scripts": {

--- a/apps/vessel-history/package.json
+++ b/apps/vessel-history/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@globalfishingwatchapp/vessel-history",
-  "version": "1.8.3",
+  "version": "1.9.0",
   "private": true,
   "homepage": "/",
   "scripts": {


### PR DESCRIPTION
# Vessel Viewer 1.9.1
## What's Changed
 - [#2417](https://github.com/GlobalFishingWatch/frontend/pull/2417): VV-577. VV Link to VV 2.0 in Map with no fishing effort layer enabled
**Full Changelog**: https://github.com/GlobalFishingWatch/frontend/compare/@globalfishingwatchapp/vessel-history@1.9.0...@globalfishingwatchapp/vessel-history@1.9.1