### PR TITLE
Fishing map/static heatmaps

### DIFF
--- a/apps/fishing-map/data/default-workspaces/workspace.development.ts
+++ b/apps/fishing-map/data/default-workspaces/workspace.development.ts
@@ -16,10 +16,12 @@ import {
   BASEMAP_LABELS_DATAVIEW_SLUG,
   BASEMAP_DATAVIEW_INSTANCE_ID,
   FIXED_SAR_INFRASTRUCTURE,
+  TEMPLATE_HEATMAP_STATIC_DATAVIEW_SLUG,
 } from 'data/workspaces'
 import { ENCOUNTER_EVENTS_SOURCE_ID } from 'features/dataviews/dataviews.utils'
 import { HIGHLIGHT_DATAVIEW_INSTANCE_ID } from 'features/workspace/highlight-panel/highlight-panel.content'
 import { WorkspaceState } from 'types'
+import { Group } from '../../../../libs/layer-composer/src/types'
 
 const workspace: Workspace<WorkspaceState> = {
   id: DEFAULT_WORKSPACE_ID,
@@ -104,6 +106,28 @@ const workspace: Workspace<WorkspaceState> = {
       config: {
         visible: false,
       },
+    },
+    {
+      id: 'bathymetry-heatmap',
+      dataviewId: TEMPLATE_HEATMAP_STATIC_DATAVIEW_SLUG,
+      config: {
+        color: 'bathymetry',
+        colorRamp: 'bathymetry',
+        group: Group.Bathymetry,
+        maxZoom: 8,
+      },
+      datasetsConfig: [
+        {
+          params: [
+            {
+              id: 'type',
+              value: 'heatmap',
+            },
+          ],
+          endpoint: '4wings-tiles',
+          datasetId: 'public-global-bathymetry',
+        },
+      ],
     },
     {
       id: 'context-layer-graticules',

--- a/apps/fishing-map/data/layer-library/layers-environment.ts
+++ b/apps/fishing-map/data/layer-library/layers-environment.ts
@@ -4,6 +4,7 @@ import { LibraryLayerConfig } from 'data/layer-library/layers.types'
 import {
   TEMPLATE_GFW_ENVIRONMENT_DATAVIEW_SLUG,
   TEMPLATE_HEATMAP_ENVIRONMENT_DATAVIEW_SLUG,
+  TEMPLATE_HEATMAP_STATIC_DATAVIEW_SLUG,
 } from 'data/workspaces'
 
 const heatmapDatasetConfig = {
@@ -37,14 +38,13 @@ export const LAYERS_LIBRARY_ENVIRONMENT: LibraryLayerConfig[] = [
   // },
   {
     id: 'bathymetry',
-    dataviewId: TEMPLATE_HEATMAP_ENVIRONMENT_DATAVIEW_SLUG,
+    dataviewId: TEMPLATE_HEATMAP_STATIC_DATAVIEW_SLUG,
     previewImageUrl: `${PATH_BASENAME}/images/layer-library/bathymetry.jpg`,
     config: {
       color: 'bathymetry',
       colorRamp: 'bathymetry',
-      static: true,
-      maxZoom: 8,
       group: Group.Bathymetry,
+      maxZoom: 8,
     },
     datasetsConfig: [
       {

--- a/apps/fishing-map/data/workspaces.ts
+++ b/apps/fishing-map/data/workspaces.ts
@@ -58,6 +58,7 @@ export const TEMPLATE_POINTS_DATAVIEW_SLUG = 'default-points-layer'
 export const TEMPLATE_ENVIRONMENT_DATAVIEW_SLUG = 'default-environmental-layer'
 export const TEMPLATE_GFW_ENVIRONMENT_DATAVIEW_SLUG = 'gfw-environmental-layer'
 export const TEMPLATE_HEATMAP_ENVIRONMENT_DATAVIEW_SLUG = 'heatmap-environmental-layer'
+export const TEMPLATE_HEATMAP_STATIC_DATAVIEW_SLUG = 'heatmap-static-layer'
 export const TEMPLATE_ACTIVITY_DATAVIEW_SLUG = 'activity-template'
 export const TEMPLATE_CLUSTERS_DATAVIEW_SLUG = 'template-for-bigquery-cluster-events'
 

--- a/apps/fishing-map/features/dataviews/dataviews.mock.ts
+++ b/apps/fishing-map/features/dataviews/dataviews.mock.ts
@@ -1,63 +1,23 @@
 import { Dataview, DataviewCategory } from '@globalfishingwatch/api-types'
+import { GeneratorType, Group } from '@globalfishingwatch/layer-composer'
+import { TEMPLATE_HEATMAP_STATIC_DATAVIEW_SLUG } from 'data/workspaces'
 
 export const dataviews: Dataview[] = [
   {
-    id: 330,
-    name: 'User track',
-    slug: 'user-track',
-    description: 'User track',
+    id: 33333333,
+    name: 'Heatmap static dataview',
+    slug: TEMPLATE_HEATMAP_STATIC_DATAVIEW_SLUG,
+    description: 'Heatmap static dataview',
     app: 'fishing-map',
     config: {
-      type: 'TRACK',
-      color: '#F95E5E',
+      type: GeneratorType.HeatmapStatic,
+      color: 'bathymetry',
+      colorRamp: 'bathymetry',
+      group: Group.Bathymetry,
     },
-    category: DataviewCategory.User,
+    category: DataviewCategory.Environment,
     createdAt: '2023-02-21T20:32:02.152Z',
     updatedAt: '2023-02-21T20:32:02.152Z',
-  },
-  {
-    id: 353,
-    name: 'Default context layer',
-    slug: 'default-context-layer',
-    description: 'Default context layer',
-    app: 'fishing-map',
-    config: {
-      type: 'USER_CONTEXT',
-      color: '#F95E5E',
-    },
-    category: DataviewCategory.User,
-    createdAt: '2023-02-21T20:32:32.709Z',
-    updatedAt: '2023-02-21T20:32:32.709Z',
-  },
-  {
-    id: 339,
-    name: 'Default points layer',
-    slug: 'default-points-layer',
-    description: 'Default points layer',
-    app: 'fishing-map',
-    config: {
-      type: 'USER_POINTS',
-      color: '#00FFBC',
-      colorRamp: 'teal',
-    },
-    category: DataviewCategory.User,
-    createdAt: '2023-02-21T20:32:04.646Z',
-    updatedAt: '2023-02-21T20:32:04.646Z',
-  },
-  {
-    id: 347,
-    name: 'Default environmental layer',
-    slug: 'default-environmental-layer',
-    description: 'Default environmental layer',
-    app: 'fishing-map',
-    config: {
-      type: 'USER_CONTEXT',
-      color: '#00FFBC',
-      colorRamp: 'teal',
-    },
-    category: DataviewCategory.User,
-    createdAt: '2023-02-21T20:32:23.719Z',
-    updatedAt: '2023-02-21T20:32:23.719Z',
   },
 ]
 

--- a/apps/fishing-map/features/map/map-sources.hooks.ts
+++ b/apps/fishing-map/features/map/map-sources.hooks.ts
@@ -194,7 +194,7 @@ function getGeneratorsMetadataChangeKey(
   return Object.keys(generatorsMetadata)
     .flatMap((key) => {
       const metadata = generatorsMetadata[key]
-      if (metadata.sublayers.some((s) => dataviewIds.includes(s.id))) {
+      if (metadata.sublayers?.some((s) => dataviewIds.includes(s.id))) {
         const timeChunks = [
           metadata.timeChunks.activeSourceId,
           (metadata.timeChunks.chunks || [])
@@ -319,7 +319,6 @@ export const useMapDataviewFeatures = (
           : sourceTilesLoaded[sourceId] || ({} as TilesAtomSourceState)
 
         let features: GeoJSONFeature[] = []
-
         if (!chunks && state?.loaded && !state?.error) {
           if (queryMethod === 'render') {
             features = map?.queryRenderedFeatures(undefined, { layers: [sourceId] })

--- a/apps/fishing-map/features/map/map-sources.utils.ts
+++ b/apps/fishing-map/features/map/map-sources.utils.ts
@@ -1,6 +1,7 @@
 import {
   isDetectionsDataview,
   isHeatmapAnimatedDataview,
+  isHeatmapStaticDataview,
   MERGED_ACTIVITY_ANIMATED_HEATMAP_GENERATOR_ID,
   MERGED_DETECTIONS_ANIMATED_HEATMAP_GENERATOR_ID,
   MULTILAYER_SEPARATOR,
@@ -11,6 +12,7 @@ import {
   DEFAULT_POINTS_SOURCE_LAYER,
   ExtendedStyle,
   GeneratorType,
+  getHeatmapStaticSourceId,
   HeatmapLayerMeta,
   TRACK_HIGHLIGHT_SUFFIX,
 } from '@globalfishingwatch/layer-composer'
@@ -42,6 +44,16 @@ export const getSourceMetadata = (style: ExtendedStyle, dataview: UrlDataviewIns
       : MERGED_ACTIVITY_ANIMATED_HEATMAP_GENERATOR_ID
     const metadata = getHeatmapSourceMetadata(style, generatorSourceId)
     return { metadata, generatorSourceId }
+  }
+  const heatmapStaticDataview = isHeatmapStaticDataview(dataview)
+  if (heatmapStaticDataview) {
+    return {
+      metadata: {
+        static: true,
+        sourceLayer: DEFAULT_CONTEXT_SOURCE_LAYER,
+      } as HeatmapLayerMeta,
+      generatorSourceId: getHeatmapStaticSourceId(dataview.id),
+    }
   }
   const environmentMetadata = getHeatmapSourceMetadata(style, dataview.id)
   if (environmentMetadata) {

--- a/apps/fishing-map/features/map/popups/EnvironmentLayers.tsx
+++ b/apps/fishing-map/features/map/popups/EnvironmentLayers.tsx
@@ -1,8 +1,8 @@
 import { Fragment } from 'react'
+import { format } from 'd3-format'
 import { Icon } from '@globalfishingwatch/ui-components'
 import { GeneratorType } from '@globalfishingwatch/layer-composer'
 import { TooltipEventFeature } from 'features/map/map.hooks'
-import { toFixed } from 'utils/shared'
 import styles from './Popup.module.css'
 
 type ContextTooltipRowProps = {
@@ -12,10 +12,10 @@ type ContextTooltipRowProps = {
 
 function parseEnvironmentalValue(value: any) {
   if (typeof value === 'number') {
-    return toFixed(value, 2)
+    return format(',.2~f')(value)
   }
   if (typeof value === 'string') {
-    return toFixed(parseFloat(value), 2)
+    return format(',.2~f')(parseFloat(value))
   }
   return value as number
 }
@@ -27,10 +27,13 @@ function EnvironmentTooltipSection({
   return (
     <Fragment>
       {features.map((feature, index) => {
+        const isHeatmapFeature =
+          feature.type === GeneratorType.HeatmapAnimated ||
+          feature.type === GeneratorType.HeatmapStatic
         return (
           <div key={`${feature.title}-${index}`} className={styles.popupSection}>
             <Icon
-              icon={feature.type === GeneratorType.HeatmapAnimated ? 'heatmap' : 'polygons'}
+              icon={isHeatmapFeature ? 'heatmap' : 'polygons'}
               className={styles.layerIcon}
               style={{ color: feature.color }}
             />
@@ -41,6 +44,7 @@ function EnvironmentTooltipSection({
                   {parseEnvironmentalValue(feature.value)}{' '}
                   {/* TODO will need to not pick from temporalgrid once user polygons support units  */}
                   {feature.temporalgrid?.unit && <span>{feature.temporalgrid?.unit}</span>}
+                  {feature.unit && <span>{feature.unit}</span>}
                 </span>
               </div>
             </div>

--- a/apps/fishing-map/features/map/popups/PopupWrapper.tsx
+++ b/apps/fishing-map/features/map/popups/PopupWrapper.tsx
@@ -136,14 +136,12 @@ function PopupWrapper({
                 const contextEnvironmentalFeatures = features.filter(
                   (feature) =>
                     feature.type === GeneratorType.Context ||
-                    feature.type === GeneratorType.UserContext ||
-                    feature.type === GeneratorType.HeatmapStatic
+                    feature.type === GeneratorType.UserContext
                 )
                 const environmentalFeatures = features.filter(
                   (feature) =>
                     feature.type !== GeneratorType.Context &&
-                    feature.type !== GeneratorType.UserContext &&
-                    feature.type !== GeneratorType.HeatmapStatic
+                    feature.type !== GeneratorType.UserContext
                 )
                 return (
                   <Fragment key={featureCategory}>

--- a/apps/fishing-map/features/map/popups/PopupWrapper.tsx
+++ b/apps/fishing-map/features/map/popups/PopupWrapper.tsx
@@ -136,12 +136,14 @@ function PopupWrapper({
                 const contextEnvironmentalFeatures = features.filter(
                   (feature) =>
                     feature.type === GeneratorType.Context ||
-                    feature.type === GeneratorType.UserContext
+                    feature.type === GeneratorType.UserContext ||
+                    feature.type === GeneratorType.HeatmapStatic
                 )
                 const environmentalFeatures = features.filter(
                   (feature) =>
                     feature.type !== GeneratorType.Context &&
-                    feature.type !== GeneratorType.UserContext
+                    feature.type !== GeneratorType.UserContext &&
+                    feature.type !== GeneratorType.HeatmapStatic
                 )
                 return (
                   <Fragment key={featureCategory}>

--- a/libs/dataviews-client/src/resolve-dataviews-generators.ts
+++ b/libs/dataviews-client/src/resolve-dataviews-generators.ts
@@ -269,6 +269,28 @@ export function getGeneratorConfig(
       }
       return generator
     }
+    case GeneratorType.HeatmapStatic: {
+      const heatmapDataset = dataview.datasets?.find(
+        (dataset) => dataset.type === DatasetTypes.Fourwings
+      )
+
+      generator = {
+        ...generator,
+        maxZoom: dataview.config.maxZoom || 8,
+        breaks: dataview.config.breaks,
+        datasets: [heatmapDataset?.id],
+        metadata: {
+          color: dataview?.config?.color,
+          group: Group.Heatmap,
+          interactive: true,
+          legend: {
+            label: heatmapDataset?.name,
+            unit: heatmapDataset?.unit,
+          },
+        },
+      }
+      return generator
+    }
     case GeneratorType.HeatmapAnimated: {
       const isEnvironmentLayer = dataview.category === DataviewCategory.Environment
       let environmentalConfig: Partial<HeatmapAnimatedGeneratorConfig> = {}
@@ -493,6 +515,10 @@ export function isTrackDataview(dataview: UrlDataviewInstance) {
 
 export function isHeatmapAnimatedDataview(dataview: UrlDataviewInstance) {
   return isActivityDataview(dataview) || isDetectionsDataview(dataview)
+}
+
+export function isHeatmapStaticDataview(dataview: UrlDataviewInstance) {
+  return dataview?.config?.type === GeneratorType.HeatmapStatic
 }
 
 export function getMergedHeatmapAnimatedDataview(

--- a/libs/layer-composer/src/generators/heatmap/heatmap-static.ts
+++ b/libs/layer-composer/src/generators/heatmap/heatmap-static.ts
@@ -97,7 +97,7 @@ class HeatmapStaticGenerator {
         'source-layer': DEFAULT_CONTEXT_SOURCE_LAYER,
         type: 'fill',
         metadata: {
-          group: Group.Bathymetry,
+          group: Group.HeatmapStatic,
           generatorType: GeneratorType.HeatmapStatic,
           generatorId: config.id,
           interactive: true,
@@ -120,7 +120,6 @@ class HeatmapStaticGenerator {
         paint: hoverInteractionPaint,
         metadata: {
           interactive: false,
-          group: Group.Bathymetry,
         } as ExtendedLayerMeta,
       },
     ]
@@ -144,6 +143,7 @@ class HeatmapStaticGenerator {
       layers: this._getStyleLayers(config),
       metadata: {
         legends,
+        group: config.group || Group.HeatmapStatic,
       },
     }
   }

--- a/libs/layer-composer/src/generators/heatmap/heatmap-static.ts
+++ b/libs/layer-composer/src/generators/heatmap/heatmap-static.ts
@@ -1,0 +1,152 @@
+import { AggregationOperation, VALUE_MULTIPLIER } from '@globalfishingwatch/fourwings-aggregate'
+import { FilterSpecification } from '@globalfishingwatch/maplibre-gl'
+import {
+  GeneratorType,
+  MergedGeneratorConfig,
+  HeatmapStaticGeneratorConfig,
+  ColorRampsIds,
+} from '../types'
+import { isUrlAbsolute } from '../../utils'
+import { API_GATEWAY, API_GATEWAY_VERSION } from '../../config'
+import { ExtendedLayerMeta, Group } from '../../types'
+import { addURLSearchParams } from '../utils'
+import { DEFAULT_CONTEXT_SOURCE_LAYER } from '../context/config'
+import { HEATMAP_COLOR_RAMPS } from './colors'
+import { API_ENDPOINTS, HEATMAP_DEFAULT_MAX_ZOOM } from './config'
+import { getLegendsCompare } from './util/get-legends'
+import { hoverInteractionPaint } from './util/get-base-layers'
+
+export type GlobalHeatmapStaticGeneratorConfig = Required<
+  MergedGeneratorConfig<HeatmapStaticGeneratorConfig>
+>
+
+export const getHeatmapStaticSourceId = (id: string): string => {
+  return `heatmap-static-${id}`
+}
+
+export const HEATMAP_STATIC_PROPERTY_ID = 'count'
+
+const getTilesUrl = (config: HeatmapStaticGeneratorConfig): string => {
+  if (config.tilesAPI) {
+    return isUrlAbsolute(config.tilesAPI) ? config.tilesAPI : API_GATEWAY + config.tilesAPI
+  }
+  return `${API_GATEWAY}/${API_GATEWAY_VERSION}/${API_ENDPOINTS.tiles}`
+}
+
+const DEFAULT_CONFIG: Partial<HeatmapStaticGeneratorConfig> = {
+  maxZoom: HEATMAP_DEFAULT_MAX_ZOOM,
+  interactive: true,
+  breaks: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
+  aggregationOperation: AggregationOperation.Sum,
+}
+
+class HeatmapStaticGenerator {
+  type = GeneratorType.HeatmapStatic
+
+  _getStyleSources = (config: GlobalHeatmapStaticGeneratorConfig) => {
+    const tilesUrl = getTilesUrl(config)
+    let url = new URL(tilesUrl.replace(/{{/g, '{').replace(/}}/g, '}'))
+
+    url.searchParams.set('temporal-aggregation', 'true')
+    url.searchParams.set('format', 'MVT')
+    url = addURLSearchParams(url, 'datasets', config.datasets)
+    return [
+      {
+        id: getHeatmapStaticSourceId(config.id),
+        type: 'vector',
+        tiles: [decodeURI(url.toString())],
+      },
+    ]
+  }
+
+  _getStyleLayers = (config: GlobalHeatmapStaticGeneratorConfig) => {
+    const { breaks, colorRamp: colorRampId, visible } = config
+
+    const exprPick: FilterSpecification = ['coalesce', ['get', HEATMAP_STATIC_PROPERTY_ID], 0]
+
+    const useToWhiteRamp = true
+    const finalColorRamp = useToWhiteRamp
+      ? (`${colorRampId}_toWhite` as ColorRampsIds)
+      : colorRampId
+    const colorRamp = HEATMAP_COLOR_RAMPS[finalColorRamp] || HEATMAP_COLOR_RAMPS[colorRampId]
+
+    const exprColorRamp = [
+      'interpolate',
+      ['linear'],
+      // we'll need to minus the offset (TBD: 50 or from dataset) once we are ready for negative values
+      // ['-', ['/', exprPick, VALUE_MULTIPLIER], 50],
+      ['/', exprPick, VALUE_MULTIPLIER],
+      ...colorRamp.flatMap((color, index) => {
+        return breaks
+          ? [
+              breaks[index - 1] !== undefined
+                ? breaks[index - 1]
+                : breaks[index] <= 0
+                  ? breaks[index] - 1
+                  : 0,
+              color,
+            ]
+          : []
+      }),
+    ]
+
+    const layers = [
+      {
+        id: getHeatmapStaticSourceId(config.id),
+        source: getHeatmapStaticSourceId(config.id),
+        'source-layer': DEFAULT_CONTEXT_SOURCE_LAYER,
+        type: 'fill',
+        metadata: {
+          group: Group.Bathymetry,
+          generatorType: GeneratorType.HeatmapStatic,
+          generatorId: config.id,
+          interactive: true,
+          static: true,
+          uniqueFeatureInteraction: true,
+        } as ExtendedLayerMeta,
+        paint: {
+          'fill-color': exprColorRamp,
+          'fill-outline-color': 'transparent',
+        },
+        layout: {
+          visibility: visible,
+        },
+      },
+      {
+        id: getHeatmapStaticSourceId(config.id) + '-hover',
+        source: getHeatmapStaticSourceId(config.id),
+        'source-layer': DEFAULT_CONTEXT_SOURCE_LAYER,
+        type: 'line',
+        paint: hoverInteractionPaint,
+        metadata: {
+          interactive: false,
+          group: Group.Bathymetry,
+        } as ExtendedLayerMeta,
+      },
+    ]
+
+    return layers
+  }
+
+  getStyle = (generatorConfig: GlobalHeatmapStaticGeneratorConfig) => {
+    const config = {
+      ...DEFAULT_CONFIG,
+      ...generatorConfig,
+      breaks: generatorConfig.breaks || DEFAULT_CONFIG.breaks,
+    }
+    const legends = getLegendsCompare(
+      { ...config, sublayers: [config] } as any,
+      [config.breaks] as any
+    )
+    return {
+      id: config.id,
+      sources: this._getStyleSources(config),
+      layers: this._getStyleLayers(config),
+      metadata: {
+        legends,
+      },
+    }
+  }
+}
+
+export default HeatmapStaticGenerator

--- a/libs/layer-composer/src/generators/heatmap/heatmap-static.ts
+++ b/libs/layer-composer/src/generators/heatmap/heatmap-static.ts
@@ -64,7 +64,7 @@ class HeatmapStaticGenerator {
 
     const exprPick: FilterSpecification = ['coalesce', ['get', HEATMAP_STATIC_PROPERTY_ID], 0]
 
-    const useToWhiteRamp = true
+    const useToWhiteRamp = config.totalHeatmapAnimatedGenerators === 1 && visible
     const finalColorRamp = useToWhiteRamp
       ? (`${colorRampId}_toWhite` as ColorRampsIds)
       : colorRampId

--- a/libs/layer-composer/src/generators/heatmap/heatmap-static.ts
+++ b/libs/layer-composer/src/generators/heatmap/heatmap-static.ts
@@ -37,6 +37,7 @@ const DEFAULT_CONFIG: Partial<HeatmapStaticGeneratorConfig> = {
   maxZoom: HEATMAP_DEFAULT_MAX_ZOOM,
   interactive: true,
   breaks: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
+  breaksMultiplier: VALUE_MULTIPLIER,
 }
 
 class HeatmapStaticGenerator {
@@ -132,7 +133,9 @@ class HeatmapStaticGenerator {
     const config = {
       ...DEFAULT_CONFIG,
       ...generatorConfig,
-      breaks: generatorConfig.breaks || DEFAULT_CONFIG.breaks,
+      breaks: (generatorConfig.breaks || DEFAULT_CONFIG.breaks)?.map((b) =>
+        DEFAULT_CONFIG.breaksMultiplier ? b / DEFAULT_CONFIG.breaksMultiplier : b
+      ),
       metadata: generatorConfig.metadata,
     }
     const legends = getLegendsCompare(

--- a/libs/layer-composer/src/generators/heatmap/heatmap-static.ts
+++ b/libs/layer-composer/src/generators/heatmap/heatmap-static.ts
@@ -1,4 +1,4 @@
-import { AggregationOperation, VALUE_MULTIPLIER } from '@globalfishingwatch/fourwings-aggregate'
+import { VALUE_MULTIPLIER } from '@globalfishingwatch/fourwings-aggregate'
 import { FilterSpecification } from '@globalfishingwatch/maplibre-gl'
 import {
   GeneratorType,
@@ -37,7 +37,6 @@ const DEFAULT_CONFIG: Partial<HeatmapStaticGeneratorConfig> = {
   maxZoom: HEATMAP_DEFAULT_MAX_ZOOM,
   interactive: true,
   breaks: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
-  aggregationOperation: AggregationOperation.Sum,
 }
 
 class HeatmapStaticGenerator {
@@ -61,6 +60,7 @@ class HeatmapStaticGenerator {
 
   _getStyleLayers = (config: GlobalHeatmapStaticGeneratorConfig) => {
     const { breaks, colorRamp: colorRampId, visible } = config
+    const sourceId = getHeatmapStaticSourceId(config.id)
 
     const exprPick: FilterSpecification = ['coalesce', ['get', HEATMAP_STATIC_PROPERTY_ID], 0]
 
@@ -92,8 +92,8 @@ class HeatmapStaticGenerator {
 
     const layers = [
       {
-        id: getHeatmapStaticSourceId(config.id),
-        source: getHeatmapStaticSourceId(config.id),
+        id: sourceId,
+        source: sourceId,
         'source-layer': DEFAULT_CONTEXT_SOURCE_LAYER,
         type: 'fill',
         metadata: {
@@ -113,13 +113,14 @@ class HeatmapStaticGenerator {
         },
       },
       {
-        id: getHeatmapStaticSourceId(config.id) + '-hover',
-        source: getHeatmapStaticSourceId(config.id),
+        id: sourceId + '_hover',
+        source: sourceId,
         'source-layer': DEFAULT_CONTEXT_SOURCE_LAYER,
         type: 'line',
         paint: hoverInteractionPaint,
         metadata: {
           interactive: false,
+          group: config.group || Group.Heatmap,
         } as ExtendedLayerMeta,
       },
     ]
@@ -132,6 +133,7 @@ class HeatmapStaticGenerator {
       ...DEFAULT_CONFIG,
       ...generatorConfig,
       breaks: generatorConfig.breaks || DEFAULT_CONFIG.breaks,
+      metadata: generatorConfig.metadata,
     }
     const legends = getLegendsCompare(
       { ...config, sublayers: [config] } as any,

--- a/libs/layer-composer/src/generators/heatmap/util/get-base-layers.ts
+++ b/libs/layer-composer/src/generators/heatmap/util/get-base-layers.ts
@@ -1,3 +1,4 @@
+import { GlobalHeatmapStaticGeneratorConfig } from 'libs/layer-composer/src/generators/heatmap/heatmap-static'
 import {
   SymbolLayerSpecification,
   FillLayerSpecification,
@@ -73,7 +74,7 @@ export const hoverInteractionPaint = {
 } as LineLayerSpecification['paint']
 
 export function getBaseInteractionHoverLayer(
-  config: GlobalHeatmapAnimatedGeneratorConfig,
+  config: GlobalHeatmapAnimatedGeneratorConfig | GlobalHeatmapStaticGeneratorConfig,
   id: string,
   source: string
 ): LineLayerSpecification {

--- a/libs/layer-composer/src/generators/heatmap/util/get-base-layers.ts
+++ b/libs/layer-composer/src/generators/heatmap/util/get-base-layers.ts
@@ -59,6 +59,19 @@ export function getBaseInteractionLayer(
   }
 }
 
+export const hoverInteractionPaint = {
+  'line-color': 'white',
+  'line-width': [
+    'case',
+    ['boolean', ['feature-state', 'hover'], false],
+    4,
+    ['boolean', ['feature-state', 'click'], false],
+    4,
+    0,
+  ],
+  'line-offset': -2,
+} as LineLayerSpecification['paint']
+
 export function getBaseInteractionHoverLayer(
   config: GlobalHeatmapAnimatedGeneratorConfig,
   id: string,
@@ -69,18 +82,7 @@ export function getBaseInteractionHoverLayer(
     source,
     'source-layer': TEMPORALGRID_SOURCE_LAYER_INTERACTIVE,
     type: 'line',
-    paint: {
-      'line-color': 'white',
-      'line-width': [
-        'case',
-        ['boolean', ['feature-state', 'hover'], false],
-        4,
-        ['boolean', ['feature-state', 'click'], false],
-        4,
-        0,
-      ],
-      'line-offset': -2,
-    },
+    paint: hoverInteractionPaint,
     metadata: {
       interactive: false,
       group: config.group || Group.Heatmap,

--- a/libs/layer-composer/src/generators/heatmap/util/get-legends.ts
+++ b/libs/layer-composer/src/generators/heatmap/util/get-legends.ts
@@ -95,7 +95,7 @@ const getGridAreaByZoom = (zoom: number): number => {
   return gridArea
 }
 
-const getLegendsCompare = (config: GlobalHeatmapAnimatedGeneratorConfig, breaks: Breaks) => {
+export const getLegendsCompare = (config: GlobalHeatmapAnimatedGeneratorConfig, breaks: Breaks) => {
   const ramps = getSublayersColorRamps(config)
 
   if (!breaks?.length) {

--- a/libs/layer-composer/src/generators/heatmap/util/get-legends.ts
+++ b/libs/layer-composer/src/generators/heatmap/util/get-legends.ts
@@ -143,7 +143,9 @@ export const getLegendsCompare = (config: GlobalHeatmapAnimatedGeneratorConfig, 
 
     const sublayerLegend: LayerMetadataLegend = {
       id: config.sublayers[sublayerIndex].id,
-      unit: config.sublayers[sublayerIndex].legend?.unit,
+      unit:
+        config.sublayers[sublayerIndex].legend?.unit ||
+        config.sublayers[sublayerIndex].metadata?.legend?.unit,
       type: LegendType.ColorRampDiscrete,
       loading: false,
       ramp: legendRamp,

--- a/libs/layer-composer/src/generators/index.ts
+++ b/libs/layer-composer/src/generators/index.ts
@@ -6,8 +6,9 @@ import BasemapLabelsGenerator from './basemap-labels/basemap-labels'
 import CartoGenerator, { CARTO_FISHING_MAP_API } from './carto-polygons/carto-polygons'
 import ContextGenerator from './context/context'
 import GLStyleGenerator from './gl/gl'
-import HeatmapAnimatedGenerator from './heatmap/heatmap-animated'
 import HeatmapGenerator from './heatmap/heatmap'
+import HeatmapStaticGenerator from './heatmap/heatmap-static'
+import HeatmapAnimatedGenerator from './heatmap/heatmap-animated'
 import PolygonsGenerator from './polygons/polygons'
 import RulersGenerator from './rulers/rulers'
 import TileClusterGenerator from './tile-cluster/tile-cluster'
@@ -25,6 +26,7 @@ export * from './user-points/user-points.utils'
 export * from './rulers/rulers'
 export { TRACK_HIGHLIGHT_SUFFIX } from './track/track'
 export { HEATMAP_COLOR_RAMPS, HEATMAP_COLORS_BY_ID } from './heatmap/colors'
+export { getHeatmapStaticSourceId, HEATMAP_STATIC_PROPERTY_ID } from './heatmap/heatmap-static'
 export { rgbaStringToComponents, hexToComponents, rgbaToString } from './heatmap/util/colors'
 export { DEFAULT_BACKGROUND_COLOR } from './background/config'
 export { DEFAULT_CONTEXT_SOURCE_LAYER } from './context/config'
@@ -47,6 +49,7 @@ export type AnyGeneratorClass =
   | ContextGenerator
   | GLStyleGenerator
   | HeatmapGenerator
+  | HeatmapStaticGenerator
   | HeatmapAnimatedGenerator
   | PolygonsGenerator
   | RulersGenerator
@@ -68,6 +71,7 @@ const GeneratorConfig: GeneratorsRecord = {
   [GeneratorType.Context]: new ContextGenerator(),
   [GeneratorType.GL]: new GLStyleGenerator(),
   [GeneratorType.Heatmap]: new HeatmapGenerator(),
+  [GeneratorType.HeatmapStatic]: new HeatmapStaticGenerator(),
   [GeneratorType.HeatmapAnimated]: new HeatmapAnimatedGenerator(),
   [GeneratorType.Polygons]: new PolygonsGenerator(),
   [GeneratorType.Rulers]: new RulersGenerator(),

--- a/libs/layer-composer/src/generators/types.ts
+++ b/libs/layer-composer/src/generators/types.ts
@@ -477,6 +477,7 @@ export interface HeatmapStaticGeneratorConfig extends GeneratorConfig {
   numBreaks?: number
   breaks?: number[]
   datasets: string[]
+  group?: Group
   filters?: string
   colorRamp?: ColorRampsIds
   interactive?: boolean
@@ -516,6 +517,7 @@ export type AnyGeneratorConfig =
   | CartoPolygonsGeneratorConfig
   | ContextGeneratorConfig
   | GlGeneratorConfig
+  | HeatmapStaticGeneratorConfig
   | HeatmapAnimatedGeneratorConfig
   | HeatmapGeneratorConfig
   | PolygonsGeneratorConfig

--- a/libs/layer-composer/src/generators/types.ts
+++ b/libs/layer-composer/src/generators/types.ts
@@ -20,6 +20,7 @@ export enum GeneratorType {
   Context = 'CONTEXT',
   GL = 'GL',
   Heatmap = 'HEATMAP',
+  HeatmapStatic = 'HEATMAP_STATIC',
   HeatmapAnimated = 'HEATMAP_ANIMATED',
   Polygons = 'POLYGONS',
   Rulers = 'RULERS',
@@ -467,6 +468,19 @@ export interface HeatmapGeneratorConfig extends GeneratorConfig {
   filters?: string
   statsFilter?: string
   colorRamp?: ColorRampsIds
+}
+
+export interface HeatmapStaticGeneratorConfig extends GeneratorConfig {
+  type: GeneratorType.HeatmapStatic
+  tilesAPI?: string
+  maxZoom?: number
+  numBreaks?: number
+  breaks?: number[]
+  datasets: string[]
+  filters?: string
+  colorRamp?: ColorRampsIds
+  interactive?: boolean
+  aggregationOperation?: AggregationOperation
 }
 
 export interface HeatmapAnimatedGeneratorConfig extends GeneratorConfig {

--- a/libs/layer-composer/src/generators/types.ts
+++ b/libs/layer-composer/src/generators/types.ts
@@ -476,6 +476,7 @@ export interface HeatmapStaticGeneratorConfig extends GeneratorConfig {
   maxZoom?: number
   numBreaks?: number
   breaks?: number[]
+  breaksMultiplier?: number
   datasets: string[]
   group?: Group
   filters?: string

--- a/libs/layer-composer/src/generators/types.ts
+++ b/libs/layer-composer/src/generators/types.ts
@@ -614,6 +614,7 @@ export interface HeatmapAnimatedGeneratorSublayer {
   legend?: GeneratorLegend
   interactionType?: HeatmapAnimatedInteractionType
   availableIntervals?: Interval[]
+  metadata?: GeneratorMetadata
 }
 
 // ---- Heatmap Generator color ramps types

--- a/libs/layer-composer/src/layer-composer.ts
+++ b/libs/layer-composer/src/layer-composer.ts
@@ -168,8 +168,9 @@ export class LayerComposer {
     }
     const extendedGlobalGeneratorConfig = {
       ...globalGeneratorConfig,
-      totalHeatmapAnimatedGenerators: layers.filter((l) => l.type === GeneratorType.HeatmapAnimated)
-        ?.length,
+      totalHeatmapAnimatedGenerators: layers.filter(
+        (l) => l.type === GeneratorType.HeatmapAnimated || l.type === GeneratorType.HeatmapStatic
+      )?.length,
     }
     let layersPromises: GeneratorPromise[] = []
     const singleTrackLayersVisible =

--- a/libs/layer-composer/src/transforms/sort/sort.ts
+++ b/libs/layer-composer/src/transforms/sort/sort.ts
@@ -5,6 +5,7 @@ export const GROUP_ORDER = [
   Group.Basemap,
   Group.OutlinePolygonsBackground,
   Group.Bathymetry,
+  Group.HeatmapStatic,
   Group.Heatmap,
   Group.OutlinePolygonsFill,
   Group.Track,

--- a/libs/layer-composer/src/types/index.ts
+++ b/libs/layer-composer/src/types/index.ts
@@ -125,6 +125,7 @@ export interface HeatmapLayerMeta {
   sublayerCombinationMode: SublayerCombinationMode
   sublayers: HeatmapAnimatedGeneratorSublayer[]
   temporalgrid: true
+  static: true
   timeChunks: TimeChunks
   minVisibleValue?: number
   maxVisibleValue?: number

--- a/libs/layer-composer/src/types/index.ts
+++ b/libs/layer-composer/src/types/index.ts
@@ -42,7 +42,8 @@ export enum Group {
   Background = 'background', // Solid bg color
   Basemap = 'basemap', // Satellite tiles
   Bathymetry = 'bathymetry', // 4Wings Bathymetry layer
-  Heatmap = 'heatmap', // Fill/gradient-based heatmaps
+  HeatmapStatic = 'heatmapStatic', // Fill/gradient-based heatmaps
+  Heatmap = 'heatmap', // Fill/gradient-based temporal heatmaps
   OutlinePolygons = 'outlinePolygons', // Context layers with an outlined/hollow style such as RFMOs, MPAs, etc
   OutlinePolygonsFill = 'outlinePolygonsFill', // User context layers with a filled styles, below OutlinePolygons
   BasemapFill = 'basemapFill', // Landmass

--- a/libs/react-hooks/src/use-map-interaction/index.ts
+++ b/libs/react-hooks/src/use-map-interaction/index.ts
@@ -42,6 +42,7 @@ export type ExtendedFeature = {
   temporalgrid?: TemporalGridFeature
   stopPropagation?: boolean
   uniqueFeatureInteraction?: boolean
+  unit?: string
 }
 
 export type InteractionEventCallback = (event: InteractionEvent | null) => void

--- a/libs/react-hooks/src/use-map-interaction/use-map-interaction.ts
+++ b/libs/react-hooks/src/use-map-interaction/use-map-interaction.ts
@@ -9,7 +9,11 @@ import {
   ExtendedLayer,
   Group,
 } from '@globalfishingwatch/layer-composer'
-import { aggregateCell, SublayerCombinationMode } from '@globalfishingwatch/fourwings-aggregate'
+import {
+  aggregateCell,
+  SublayerCombinationMode,
+  VALUE_MULTIPLIER,
+} from '@globalfishingwatch/fourwings-aggregate'
 import type { Map, GeoJSONFeature, MapLayerMouseEvent } from '@globalfishingwatch/maplibre-gl'
 import { ExtendedFeature, InteractionEventCallback, InteractionEvent } from '.'
 
@@ -172,6 +176,15 @@ const getExtendedFeature = (
         }
         return [temporalGridExtendedFeature]
       })
+    case GeneratorType.HeatmapStatic: {
+      return [
+        {
+          ...extendedFeature,
+          value: extendedFeature.value / VALUE_MULTIPLIER,
+          unit: generatorMetadata.legends[0]?.unit,
+        },
+      ]
+    }
     case GeneratorType.Context:
     case GeneratorType.UserPoints:
     case GeneratorType.UserContext: {

--- a/libs/react-hooks/src/use-map-interaction/use-map-interaction.ts
+++ b/libs/react-hooks/src/use-map-interaction/use-map-interaction.ts
@@ -83,7 +83,7 @@ const getExtendedFeature = (
   const uniqueFeatureInteraction = feature.layer?.metadata?.uniqueFeatureInteraction ?? false
   const stopPropagation = feature.layer?.metadata?.stopPropagation ?? false
   const properties = feature.properties || {}
-  let value = properties.value || properties.name || properties.id
+  let value = properties.value || properties.name || properties.id || properties?.count
   if (feature.layer.metadata?.valueProperties?.length) {
     value = feature.layer.metadata.valueProperties
       .flatMap((prop) => properties[prop] || [])
@@ -275,6 +275,7 @@ export const useMapClick = (
   const { updateFeatureState, cleanFeatureState } = useFeatureState(map)
   const onMapClick = useCallback(
     (event: MapLayerMouseEvent) => {
+      console.log(event.features)
       cleanFeatureState('click')
       if (!clickCallback) return
       const interactionEvent: InteractionEvent = {

--- a/libs/react-hooks/src/use-map-legend/use-map-legend.ts
+++ b/libs/react-hooks/src/use-map-legend/use-map-legend.ts
@@ -18,6 +18,7 @@ export const getLegendLayers = (
   hoveredEvent?: InteractionEvent | null
 ) => {
   if (!style) return []
+
   const heatmapLegends = Object.entries(style.metadata?.generatorsMetadata || {}).flatMap(
     ([generatorId, { legends }]) => {
       return legends?.flatMap((legend: LayerMetadataLegend) => {
@@ -26,9 +27,13 @@ export const getLegendLayers = (
         let currentValue
         let currentValues
         const getHoveredFeatureValueForSublayerId = (id: string): number => {
-          const hoveredFeature = hoveredEvent?.features?.find(
-            (f) => f.generatorId === generatorId && f.temporalgrid?.sublayerId === id
-          )
+          const hoveredFeature = hoveredEvent?.features?.find((f) => {
+            const matchesGeneratorId = f.generatorId === generatorId
+            const matchesTemporalGridSublayerId = f.temporalgrid
+              ? f.temporalgrid.sublayerId === id
+              : true
+            return matchesGeneratorId && matchesTemporalGridSublayerId
+          })
           return hoveredFeature?.value
         }
         // Both bivariate sublayers come in the same sublayerLegend (see getLegendsBivariate in LC)


### PR DESCRIPTION
Renders bathymetry layer using the 4wings `mvt` format to simplify it as much as possible.

TODO:
- [x] Ask @rrequero to fix API endpoint to return `avg` in the `count` property
- [ ] Add hover highlight cell interaction
- [x] Fix values multiplier in tooltips and layer icons
- [x] Review dynamic ramp calculation
- [x] Use `toWhite` color ramp when a static layer is the only heatmap visible
- [x] render below dynamic heatmaps
- [x] render unit in legend