### PR TITLE
Avoid history replacement on search link click

### DIFF
--- a/apps/fishing-map/features/sidebar/CategoryTabs.tsx
+++ b/apps/fishing-map/features/sidebar/CategoryTabs.tsx
@@ -42,7 +42,6 @@ function getLinkToSearch(workspace: Workspace) {
       category: workspace?.category || WorkspaceCategory.FishingActivity,
       workspaceId: workspace?.id || DEFAULT_WORKSPACE_ID,
     },
-    replaceQuery: true,
   }
 }
 


### PR DESCRIPTION
This PR avoids the situation in which a pinned vessel is removed from the map when the user performs a new vessel search from the search icon on the sidebar category tabs 👇🏼 
![image](https://github.com/GlobalFishingWatch/frontend/assets/6906348/39a1e421-ca4e-4247-8df4-c2212f741bae)

This does not happens when the search is performed from the vessel sidebar panel