### PR TITLE
support filters without schemas in advanced search

### DIFF
--- a/apps/fishing-map/features/datasets/datasets.utils.ts
+++ b/apps/fishing-map/features/datasets/datasets.utils.ts
@@ -536,8 +536,14 @@ export const datasetHasSchemaFields = (dataset: Dataset, schema: SupportedDatase
     return dataset.fieldsAllowed.some((f) => f.includes(schema))
   }
   const schemaConfig = getDatasetSchemaItem(dataset, schema)
-  const schemaEnum = schemaConfig?.enum || schemaConfig?.items?.enum
-  return schemaEnum !== undefined && schemaEnum.length > 0
+  if (!schemaConfig) {
+    return false
+  }
+  if (schemaConfig.type === 'array') {
+    const schemaEnum = schemaConfig?.enum || schemaConfig?.items?.enum
+    return schemaEnum !== undefined && schemaEnum.length > 0
+  }
+  return schemaConfig.type === 'string'
 }
 
 export const getSupportedSchemaFieldsDatasets = (

--- a/apps/fishing-map/features/search/advanced/SearchAdvancedFilters.tsx
+++ b/apps/fishing-map/features/search/advanced/SearchAdvancedFilters.tsx
@@ -239,13 +239,21 @@ function SearchAdvancedFilters() {
         )}
       {schemaFilters.map((schemaFilter) => {
         if (
-          !showSchemaFilter(schemaFilter) ||
+          (schemaFilter?.type !== 'string' && !showSchemaFilter(schemaFilter)) ||
           isIncompatibleFilterBySelection(schemaFilter, searchFilters)
         ) {
           return null
         }
-        const { id, disabled, options, optionsSelected } = schemaFilter
+        const { id, type, disabled, options, optionsSelected } = schemaFilter
         const translationKey = id === 'shiptypes' ? `gfw_${id}` : id
+        if (type === 'string' && !options?.length) {
+          return (
+            <AdvancedFilterInputField
+              field={id as keyof VesselSearchState}
+              onChange={onInputChange}
+            />
+          )
+        }
         return (
           <MultiSelect
             key={id}

--- a/apps/fishing-map/features/search/advanced/SearchAdvancedFilters.tsx
+++ b/apps/fishing-map/features/search/advanced/SearchAdvancedFilters.tsx
@@ -33,6 +33,7 @@ import {
 import styles from './SearchAdvancedFilters.module.css'
 
 const FILTERS_WITH_SHARED_SELECTION_COMPATIBILITY = ['geartypes', 'shiptypes', 'flag']
+const VMS_FILTERS_WITH_STRING_SEARCH = ['codMarinha', 'nationalId']
 
 type ImcompatibleFilter = { id: keyof VesselSearchState; values: string[] }
 type IncompatibleFilterSelection = {
@@ -238,22 +239,28 @@ function SearchAdvancedFilters() {
           />
         )}
       {schemaFilters.map((schemaFilter) => {
-        if (
-          (schemaFilter?.type !== 'string' && !showSchemaFilter(schemaFilter)) ||
-          isIncompatibleFilterBySelection(schemaFilter, searchFilters)
-        ) {
-          return null
-        }
-        const { id, type, disabled, options, optionsSelected } = schemaFilter
-        const translationKey = id === 'shiptypes' ? `gfw_${id}` : id
-        if (type === 'string' && !options?.length) {
+        if (VMS_FILTERS_WITH_STRING_SEARCH.includes(schemaFilter.id)) {
+          if (
+            schemaFilter.disabled ||
+            isIncompatibleFilterBySelection(schemaFilter, searchFilters)
+          ) {
+            return null
+          }
           return (
             <AdvancedFilterInputField
-              field={id as keyof VesselSearchState}
+              field={schemaFilter.id as keyof VesselSearchState}
               onChange={onInputChange}
             />
           )
         }
+        if (
+          !showSchemaFilter(schemaFilter) ||
+          isIncompatibleFilterBySelection(schemaFilter, searchFilters)
+        ) {
+          return null
+        }
+        const { id, disabled, options, optionsSelected } = schemaFilter
+        const translationKey = id === 'shiptypes' ? `gfw_${id}` : id
         return (
           <MultiSelect
             key={id}

--- a/apps/fishing-map/features/search/advanced/advanced-search.utils.ts
+++ b/apps/fishing-map/features/search/advanced/advanced-search.utils.ts
@@ -12,6 +12,7 @@ export const schemaFilterIds: (keyof VesselSearchState)[] = [
   'geartypes',
   'codMarinha',
   'targetSpecies',
+  'nationalId',
 ]
 
 export const getSearchDataview = (

--- a/apps/fishing-map/features/search/search.config.selectors.ts
+++ b/apps/fishing-map/features/search/search.config.selectors.ts
@@ -24,6 +24,7 @@ export const selectSearchSsvid = selectVesselSearchStateProperty('ssvid')
 export const selectSearchImo = selectVesselSearchStateProperty('imo')
 export const selectSearchCallsign = selectVesselSearchStateProperty('callsign')
 export const selectSearchOwner = selectVesselSearchStateProperty('owner')
+export const selectSearchNationalId = selectVesselSearchStateProperty('nationalId')
 export const selectSearchCodMarinha = selectVesselSearchStateProperty('codMarinha')
 export const selectSearchGeartypes = selectVesselSearchStateProperty('geartypes')
 export const selectSearchShiptypes = selectVesselSearchStateProperty('shiptypes')
@@ -41,6 +42,7 @@ export const selectSearchFilters = createSelector(
     selectSearchImo,
     selectSearchCallsign,
     selectSearchOwner,
+    selectSearchNationalId,
     selectSearchCodMarinha,
     selectSearchGeartypes,
     selectSearchShiptypes,
@@ -58,6 +60,7 @@ export const selectSearchFilters = createSelector(
     imo,
     callsign,
     owner,
+    nationalId,
     codMarinha,
     geartypes,
     shiptypes,
@@ -75,6 +78,7 @@ export const selectSearchFilters = createSelector(
       imo,
       callsign,
       owner,
+      nationalId,
       codMarinha,
       geartypes,
       shiptypes,

--- a/apps/fishing-map/features/search/search.config.ts
+++ b/apps/fishing-map/features/search/search.config.ts
@@ -33,6 +33,7 @@ export const EMPTY_FILTERS = {
   imo: undefined,
   callsign: undefined,
   owner: undefined,
+  nationalId: undefined,
   codMarinha: undefined,
   shiptypes: undefined,
   geartypes: undefined,

--- a/apps/fishing-map/features/search/search.slice.ts
+++ b/apps/fishing-map/features/search/search.slice.ts
@@ -91,6 +91,7 @@ export const fetchVesselSearchThunk = createAsyncThunk(
           'imo',
           'callsign',
           'codMarinha',
+          'nationalId',
           'owner',
         ]
 

--- a/apps/fishing-map/types/index.ts
+++ b/apps/fishing-map/types/index.ts
@@ -118,6 +118,7 @@ export type VesselSearchState = {
   imo?: string
   callsign?: string
   codMarinha?: string
+  nationalId?: string
   flag?: string[]
   geartypes?: GearType[]
   shiptypes?: VesselType[]

--- a/libs/api-client/src/utils/search.ts
+++ b/libs/api-client/src/utils/search.ts
@@ -99,7 +99,8 @@ const FIELDS_PARAMS: Record<AdvancedSearchQueryFieldKey, AdvancedSearchQueryFiel
     operator: '=',
   },
   nationalId: {
-    operator: '=',
+    operator: 'LIKE',
+    transformation: toUpperCaseWithWildcardsAndQuotationMarks,
   },
   targetSpecies: {
     operator: '=',

--- a/libs/api-client/src/utils/search.ts
+++ b/libs/api-client/src/utils/search.ts
@@ -16,6 +16,7 @@ export type AdvancedSearchQueryFieldKey =
   | 'mmsi'
   | 'callsign'
   | 'codMarinha'
+  | 'nationalId'
   | 'flag'
   | 'geartypes'
   | 'shiptypes'
@@ -95,6 +96,9 @@ const FIELDS_PARAMS: Record<AdvancedSearchQueryFieldKey, AdvancedSearchQueryFiel
   },
   // VMS specific
   codMarinha: {
+    operator: '=',
+  },
+  nationalId: {
     operator: '=',
   },
   targetSpecies: {


### PR DESCRIPTION
Add missing `nationalId` for Ecuador VMS source:

- [x] include it as schemaFilter
- [x] support filters without schema
- [x] 🐞 debug why flags looks disabled when only Ecuador VMS source is selected
- [ ] 🐞 malformed api request error

[Preview url](https://fishing-map-fix-advanced-search-missing-filters-jzzp2ui3wq-uc.a.run.app)