### PR TITLE
fetch only fields needed in report to make the response lighter

### DIFF
--- a/apps/fishing-map/features/reports/report.slice.ts
+++ b/apps/fishing-map/features/reports/report.slice.ts
@@ -56,6 +56,17 @@ type FetchReportVesselsThunkParams = {
   reportBufferOperation?: BufferOperation
 }
 
+const REPORT_FIELDS_TO_INCLUDE = [
+  'mmsi',
+  'dataset',
+  'flag',
+  'geartype',
+  'hours',
+  'shipName',
+  'vesselId',
+  'vesselType',
+]
+
 export const getReportQuery = (params: FetchReportVesselsThunkParams) => {
   const {
     region,
@@ -83,6 +94,7 @@ export const getReportQuery = (params: FetchReportVesselsThunkParams) => {
         getUTCDateTime(dateRange?.end)?.toString(),
       ].join(','),
       'group-by': groupBy,
+      includes: REPORT_FIELDS_TO_INCLUDE.join(','),
       'spatial-resolution': spatialResolution,
       'spatial-aggregation': spatialAggregation,
       format: format,


### PR DESCRIPTION
Testing presence report for New Zealand EEZ in 2020

Before
<img width="289" alt="image" src="https://github.com/GlobalFishingWatch/frontend/assets/10500650/ee672e67-21f4-4756-b16b-5bff786fceb2">

After
<img width="325" alt="image" src="https://github.com/GlobalFishingWatch/frontend/assets/10500650/e9769727-307d-46cf-8374-928b6f6f7487">

