### PR TITLE
Fishing map/retrieve events data for 30min encounters

### DIFF
--- a/apps/fishing-map/features/dataviews/dataviews.utils.ts
+++ b/apps/fishing-map/features/dataviews/dataviews.utils.ts
@@ -27,6 +27,7 @@ import { Area } from 'features/areas/areas.slice'
 
 // used in workspaces with encounter events layers
 export const ENCOUNTER_EVENTS_SOURCE_ID = 'encounter-events'
+export const ENCOUNTER_EVENTS_30MIN_SOURCE_ID = 'proto-global-encounters-events-30min'
 export const FISHING_LAYER_PREFIX = 'fishing-'
 export const BIG_QUERY_PREFIX = 'bq-'
 export const BIG_QUERY_4WINGS_PREFIX = `${BIG_QUERY_PREFIX}4wings-`
@@ -34,6 +35,10 @@ export const BIG_QUERY_EVENTS_PREFIX = `${BIG_QUERY_PREFIX}events-`
 export const VESSEL_LAYER_PREFIX = 'vessel-'
 export const CONTEXT_LAYER_PREFIX = 'context-'
 export const VESSEL_DATAVIEW_INSTANCE_PREFIX = 'vessel-'
+export const ENCOUNTER_EVENTS_SOURCES = [
+  ENCOUNTER_EVENTS_SOURCE_ID,
+  ENCOUNTER_EVENTS_30MIN_SOURCE_ID,
+]
 
 export const getVesselInfoDataviewInstanceDatasetConfig = (
   vesselId: string,

--- a/apps/fishing-map/features/map/map-sources.hooks.ts
+++ b/apps/fishing-map/features/map/map-sources.hooks.ts
@@ -31,6 +31,7 @@ import {
 } from 'features/map/map-sources.utils'
 import {
   BIG_QUERY_EVENTS_PREFIX,
+  ENCOUNTER_EVENTS_30MIN_SOURCE_ID,
   ENCOUNTER_EVENTS_SOURCE_ID,
 } from 'features/dataviews/dataviews.utils'
 
@@ -144,7 +145,11 @@ export const useMapSourceTilesLoaded = (sourcesId: SourcesHookInput) => {
   return sourceInStyle && allSourcesLoaded.every((loaded) => loaded)
 }
 
-const CLUSTERS_SOURCES_IDS = [ENCOUNTER_EVENTS_SOURCE_ID, BIG_QUERY_EVENTS_PREFIX]
+const CLUSTERS_SOURCES_IDS = [
+  ENCOUNTER_EVENTS_SOURCE_ID,
+  BIG_QUERY_EVENTS_PREFIX,
+  ENCOUNTER_EVENTS_30MIN_SOURCE_ID,
+]
 export const useMapClusterTilesLoaded = () => {
   const sourceTilesLoaded = useMapSourceTiles()
   return Object.entries(sourceTilesLoaded)

--- a/apps/fishing-map/features/map/map.hooks.ts
+++ b/apps/fishing-map/features/map/map.hooks.ts
@@ -34,13 +34,15 @@ import { useTimerangeConnect } from 'features/timebar/timebar.hooks'
 import { selectHighlightedEvents, setHighlightedEvents } from 'features/timebar/timebar.slice'
 import { setHintDismissed } from 'features/help/hints.slice'
 import { useMapClusterTilesLoaded, useMapSourceTiles } from 'features/map/map-sources.hooks'
-import { ENCOUNTER_EVENTS_SOURCE_ID } from 'features/dataviews/dataviews.utils'
+import { ENCOUNTER_EVENTS_SOURCES } from 'features/dataviews/dataviews.utils'
 import { useAppDispatch } from 'features/app/app.hooks'
 import {
   selectShowTimeComparison,
   selectTimeComparisonValues,
 } from 'features/reports/reports.selectors'
 import { useMapAnnotation } from 'features/map/annotations/annotations.hooks'
+import { TrackCategory, trackEvent } from 'features/app/analytics.hooks'
+import { getEventLabel } from 'utils/analytics'
 import { selectDefaultMapGeneratorsConfig } from './map.selectors'
 import {
   WORKSPACES_POINTS_TYPE,
@@ -62,8 +64,6 @@ import {
   SliceExtendedFeature,
 } from './map.slice'
 import useViewport from './map-viewport.hooks'
-import { TrackCategory, trackEvent } from 'features/app/analytics.hooks'
-import { getEventLabel } from 'utils/analytics'
 
 export const SUBLAYER_INTERACTION_TYPES_WITH_VESSEL_INTERACTION = ['activity', 'detections']
 
@@ -291,8 +291,12 @@ export const useClickedEventConnect = () => {
     const tileClusterFeature = event.features.find(
       (f) => f.generatorType === GeneratorType.TileCluster
     )
+
     if (tileClusterFeature) {
-      const bqPocQuery = tileClusterFeature.source !== ENCOUNTER_EVENTS_SOURCE_ID
+      const bqPocQuery = !ENCOUNTER_EVENTS_SOURCES.some(
+        (source) => tileClusterFeature.source === source
+      )
+
       const fetchFn = bqPocQuery ? fetchBQEventThunk : fetchEncounterEventThunk
       eventsPromiseRef.current = dispatch(fetchFn(tileClusterFeature))
     }

--- a/apps/fishing-map/features/map/map.hooks.ts
+++ b/apps/fishing-map/features/map/map.hooks.ts
@@ -293,11 +293,11 @@ export const useClickedEventConnect = () => {
     )
 
     if (tileClusterFeature) {
-      const bqPocQuery = !ENCOUNTER_EVENTS_SOURCES.some(
+      const isEncountersCluster = ENCOUNTER_EVENTS_SOURCES.some(
         (source) => tileClusterFeature.source === source
       )
 
-      const fetchFn = bqPocQuery ? fetchBQEventThunk : fetchEncounterEventThunk
+      const fetchFn = isEncountersCluster ? fetchEncounterEventThunk : fetchBQEventThunk
       eventsPromiseRef.current = dispatch(fetchFn(tileClusterFeature))
     }
   }

--- a/apps/fishing-map/features/map/popups/EncounterTooltipRow.tsx
+++ b/apps/fishing-map/features/map/popups/EncounterTooltipRow.tsx
@@ -6,7 +6,7 @@ import { EventVessel } from '@globalfishingwatch/api-types'
 import { TooltipEventFeature } from 'features/map/map.hooks'
 import { AsyncReducerStatus } from 'utils/async-slice'
 import I18nDate from 'features/i18n/i18nDate'
-import { ENCOUNTER_EVENTS_SOURCE_ID } from 'features/dataviews/dataviews.utils'
+import { ENCOUNTER_EVENTS_SOURCES } from 'features/dataviews/dataviews.utils'
 import { formatInfoField } from 'utils/info'
 import { CARRIER_PORTAL_URL } from 'data/config'
 import { useCarrierLatestConnect } from 'features/datasets/datasets.hook'
@@ -195,7 +195,7 @@ function TileClusterTooltipRow({ features, showFeaturesDetails }: UserContextLay
     <Fragment>
       {features.map((feature, index) => {
         const key = `${feature.title}-${index}`
-        if (feature.source === ENCOUNTER_EVENTS_SOURCE_ID) {
+        if (ENCOUNTER_EVENTS_SOURCES.some((source) => feature.source === source)) {
           return (
             <EncounterTooltipRow
               key={key}


### PR DESCRIPTION
This PR allows 30 minutes events cluster to dispatch the same fetch thunk than regular events cluster