### PR TITLE
fix disclaimer when no dataset extend end

### DIFF
--- a/apps/fishing-map/data/config.ts
+++ b/apps/fishing-map/data/config.ts
@@ -50,7 +50,10 @@ export const AUTO_GENERATED_FEEDBACK_WORKSPACE_PREFIX = 'gfw-feedback-auto-saved
 
 export const DEFAULT_DATA_DELAY_DAYS = 3
 // used when no url data and no workspace data
-const LAST_DATA_UPDATE = DateTime.fromObject({ hour: 0, minute: 0, second: 0 }, { zone: 'utc' })
+export const LAST_DATA_UPDATE = DateTime.fromObject(
+  { hour: 0, minute: 0, second: 0 },
+  { zone: 'utc' }
+)
   .minus({ days: DEFAULT_DATA_DELAY_DAYS })
   .toISO() as string
 

--- a/apps/fishing-map/features/workspace/common/OutOfBoundsDisclaimer.tsx
+++ b/apps/fishing-map/features/workspace/common/OutOfBoundsDisclaimer.tsx
@@ -9,6 +9,7 @@ import {
   getActiveDatasetsInActivityDataviews,
   getDatasetsInDataviews,
 } from 'features/datasets/datasets.utils'
+import { LAST_DATA_UPDATE } from 'data/config'
 
 type OutOfTimerangeDisclaimerValidate = 'start' | 'end' | 'both'
 type OutOfTimerangeDisclaimerProps = {
@@ -32,7 +33,7 @@ const OutOfTimerangeDisclaimer = ({
       : getActiveDatasetsInActivityDataviews([dataview])
 
   const activeDatasets = dataview.datasets?.filter((d) => activeDatasetIds.includes(d.id))
-  const { extentStart, extentEnd } = getDatasetsExtent(activeDatasets, {
+  const { extentStart, extentEnd = LAST_DATA_UPDATE } = getDatasetsExtent(activeDatasets, {
     format: 'isoString',
   })
 
@@ -68,7 +69,7 @@ const OutOfTimerangeDisclaimer = ({
     )
   }
 
-  if (!extentStart && !extentEnd) {
+  if (!extentStart || !extentEnd) {
     return null
   }
 


### PR DESCRIPTION
Fixes out of bounds disclaimer when no extendEnd value available
<img width="334" alt="image" src="https://github.com/GlobalFishingWatch/frontend/assets/10500650/16e6bbdc-fe52-4b61-b04a-eace309a9192">
