### PR TITLE
Fishing map/vessel profile 3 feedback javi 2

### DIFF
--- a/apps/fishing-map/features/reports/events/VGREventsVesselsTable.tsx
+++ b/apps/fishing-map/features/reports/events/VGREventsVesselsTable.tsx
@@ -6,6 +6,7 @@ import {
   useGetVesselGroupEventsVesselsQuery,
   VesselGroupEventsVesselsParams,
 } from 'queries/vessel-group-events-stats-api'
+import { UrlDataviewInstance } from '@globalfishingwatch/dataviews-client'
 import { EMPTY_FIELD_PLACEHOLDER, formatInfoField } from 'utils/info'
 import { useLocationConnect } from 'routes/routes.hook'
 import VesselLink from 'features/vessel/VesselLink'
@@ -21,9 +22,9 @@ import styles from 'features/reports/vessel-groups/vessels/VesselGroupReportVess
 
 export default function VesselGroupReportEventsVesselsTable() {
   const { t } = useTranslation()
-  const { dispatchQueryParams } = useLocationConnect()
   const params = useSelector(selectFetchVGREventsVesselsParams)
   const workspaceStatus = useSelector(selectWorkspaceStatus)
+  const { dispatchQueryParams } = useLocationConnect()
   const { error, isLoading } = useGetVesselGroupEventsVesselsQuery(
     params as VesselGroupEventsVesselsParams,
     {
@@ -31,9 +32,14 @@ export default function VesselGroupReportEventsVesselsTable() {
     }
   )
   const vessels = useSelector(selectVGREventsVesselsPaginated)
-
-  const onPinClick = () => {
-    dispatchQueryParams({ viewOnlyVesselGroup: false })
+  const onPinClick = ({
+    vesselInWorkspace,
+  }: {
+    vesselInWorkspace?: UrlDataviewInstance | null | undefined
+  }) => {
+    if (!vesselInWorkspace) {
+      dispatchQueryParams({ viewOnlyVesselGroup: false })
+    }
   }
 
   return (

--- a/apps/fishing-map/features/reports/vessel-groups/VesselGroupReport.tsx
+++ b/apps/fishing-map/features/reports/vessel-groups/VesselGroupReport.tsx
@@ -16,6 +16,7 @@ import VGREvents from 'features/reports/events/VGREvents'
 import VGRActivity from 'features/reports/vessel-groups/activity/VGRActivity'
 import { useSetMapCoordinates } from 'features/map/map-viewport.hooks'
 import { selectIsGFWUser } from 'features/user/selectors/user.selectors'
+import { selectTrackDataviews } from 'features/dataviews/selectors/dataviews.instances.selectors'
 import {
   useFitAreaInViewport,
   useReportAreaCenter,
@@ -46,7 +47,7 @@ function VesselGroupReport() {
   const coordinates = useReportAreaCenter(bbox!)
   const setMapCoordinates = useSetMapCoordinates()
   const bboxHash = bbox ? bbox.join(',') : ''
-
+  const vesselsInWorkspace = useSelector(selectTrackDataviews)
   useEffect(() => {
     fetchVesselGroupReport(vesselGroupId)
     if (reportDataview) {
@@ -61,6 +62,11 @@ function VesselGroupReport() {
     vesselGroupId,
   ])
 
+  useEffect(() => {
+    if (vesselsInWorkspace.length) {
+      dispatchQueryParams({ viewOnlyVesselGroup: false })
+    }
+  }, [dispatchQueryParams, vesselsInWorkspace])
   useEffect(() => {
     if (reportSection === 'vessels' && coordinates) {
       setMapCoordinates(coordinates)

--- a/apps/fishing-map/features/reports/vessel-groups/vessels/VesselGroupReportVesselsTable.tsx
+++ b/apps/fishing-map/features/reports/vessel-groups/vessels/VesselGroupReportVesselsTable.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next'
 import cx from 'classnames'
 import { Fragment } from 'react'
 import { IconButton } from '@globalfishingwatch/ui-components'
+import { UrlDataviewInstance } from '@globalfishingwatch/dataviews-client'
 import { EMPTY_FIELD_PLACEHOLDER } from 'utils/info'
 import { useLocationConnect } from 'routes/routes.hook'
 import { getDatasetsReportNotSupported } from 'features/datasets/datasets.utils'
@@ -45,10 +46,6 @@ export default function VesselGroupReportVesselsTable() {
     dispatchQueryParams({ vGRVesselFilter, vGRVesselPage: 0 })
   }
 
-  const onPinClick = () => {
-    dispatchQueryParams({ viewOnlyVesselGroup: false })
-  }
-
   const handleSortClick = (
     property: VGRVesselsOrderProperty,
     direction: VGRVesselsOrderDirection
@@ -57,6 +54,16 @@ export default function VesselGroupReportVesselsTable() {
       vGRVesselsOrderProperty: property,
       vGRVesselsOrderDirection: direction,
     })
+  }
+
+  const onPinClick = ({
+    vesselInWorkspace,
+  }: {
+    vesselInWorkspace?: UrlDataviewInstance | null | undefined
+  }) => {
+    if (!vesselInWorkspace) {
+      dispatchQueryParams({ viewOnlyVesselGroup: false })
+    }
   }
 
   return (

--- a/apps/fishing-map/features/reports/vessel-groups/vessels/VesselGroupReportVesselsTableFooter.tsx
+++ b/apps/fishing-map/features/reports/vessel-groups/vessels/VesselGroupReportVesselsTableFooter.tsx
@@ -32,18 +32,21 @@ export default function VesselGroupReportVesselsTableFooter() {
 
   const onDownloadVesselsClick = () => {
     const vessels = allVessels?.map((vessel) => {
+      const vesselRegistryInfo = !!vessel.identity?.registryInfo?.length
+        ? vessel.identity?.registryInfo[0]
+        : null
       return {
         dataset: vessel.dataset,
-        flag: vessel.flag,
+        flag: vesselRegistryInfo?.flag,
         'flag translated': vessel.flagTranslated,
         'GFW vessel type': vessel.vesselType,
         'GFW gear type': vessel.geartype,
         sources: vessel.source,
         name: vessel.shipName,
-        MMSI: vessel.mmsi,
-        IMO: vessel.imo,
-        'call sign': vessel.callsign,
-        vesselId: vessel.id,
+        MMSI: vesselRegistryInfo?.ssvid,
+        IMO: vesselRegistryInfo?.imo,
+        'call sign': vesselRegistryInfo?.callsign,
+        vesselId: vessel.vesselId,
       }
     })
     if (vessels?.length) {
@@ -54,7 +57,7 @@ export default function VesselGroupReportVesselsTableFooter() {
       //   })
       const csv = unparseCSV(vessels)
       const blob = new Blob([csv], { type: 'text/plain;charset=utf-8' })
-      saveAs(blob, `${formatInfoField(vesselGroup?.name, 'name')}-${start}-${end}.csv`)
+      saveAs(blob, `vessel-group-${formatInfoField(vesselGroup?.name, 'name')}-${start}-${end}.csv`)
     }
   }
 

--- a/apps/fishing-map/features/search/search.slice.ts
+++ b/apps/fishing-map/features/search/search.slice.ts
@@ -99,10 +99,11 @@ export const fetchVesselSearchThunk = createAsyncThunk(
           const filter = (filters as any)[cleanField]
           if (filter && isInFieldsAllowed) {
             let value = filter
-            // Supports searching by multiple values separated by comma
-            if (ADVANCED_SEARCH_FIELDS.includes(field as any) && value?.includes(',')) {
+            // Supports searching by multiple values separated by comma and semicolon
+            const regex = /[,;]/
+            if (ADVANCED_SEARCH_FIELDS.includes(field as any) && regex.test(value)) {
               value = (value as string)
-                .split(',')
+                .split(regex)
                 .map((v) => v.trim())
                 .filter(Boolean)
             }

--- a/apps/fishing-map/features/search/search.slice.ts
+++ b/apps/fishing-map/features/search/search.slice.ts
@@ -146,6 +146,7 @@ export const fetchVesselSearchThunk = createAsyncThunk(
       if (url) {
         const searchResults = await GFWAPI.fetch<APIVesselSearchPagination<IdentityVessel>>(url, {
           signal,
+          cache: 'no-cache',
         })
         // Not removing duplicates for GFWStaff so they can compare other VS fishing vessels
         const uniqSearchResults = gfwUser

--- a/apps/fishing-map/features/vessel-groups/VesselGroupListTooltip.tsx
+++ b/apps/fishing-map/features/vessel-groups/VesselGroupListTooltip.tsx
@@ -45,7 +45,7 @@ function VesselGroupListTooltip(props: VesselGroupListTooltipProps) {
     <Popover
       open={vesselGroupsOpen}
       onOpenChange={toggleVesselGroupsOpen}
-      placement="right"
+      placement="bottom"
       content={
         <ul className={styles.groupOptions}>
           {hasUserGroupsPermissions && (

--- a/apps/fishing-map/features/vessel/VesselPin.tsx
+++ b/apps/fishing-map/features/vessel/VesselPin.tsx
@@ -12,7 +12,7 @@ import {
   Resource,
   ResourceStatus,
 } from '@globalfishingwatch/api-types'
-import { setResource } from '@globalfishingwatch/dataviews-client'
+import { setResource, UrlDataviewInstance } from '@globalfishingwatch/dataviews-client'
 import { resolveEndpoint } from '@globalfishingwatch/datasets-client'
 import { GFWAPI } from '@globalfishingwatch/api-client'
 import { useDataviewInstancesConnect } from 'features/workspace/workspace.hook'
@@ -57,7 +57,11 @@ function VesselPin({
   className?: string
   disabled?: boolean
   size?: IconButtonSize
-  onClick?: () => void
+  onClick?: ({
+    vesselInWorkspace,
+  }: {
+    vesselInWorkspace?: UrlDataviewInstance | null | undefined
+  }) => void
 }) {
   const [loading, setLoading] = useState(false)
   const { t } = useTranslation()
@@ -181,7 +185,7 @@ function VesselPin({
       }
     }
     setLoading(false)
-    onClick?.()
+    onClick?.({ vesselInWorkspace })
   }
 
   return (

--- a/apps/fishing-map/utils/info.ts
+++ b/apps/fishing-map/utils/info.ts
@@ -38,7 +38,7 @@ export const formatInfoField = (
     if (type === 'geartypes') {
       return getVesselGearTypeLabel({ geartypes: fieldValue }, { translationFn })
     }
-    if (type === 'name' || type === 'shipname' || type === 'owner' || type === 'port') {
+    if (type === 'shipname' || type === 'owner' || type === 'port') {
       return fieldValue
         .replace('_', ' ')
         .replace(/\b(?![LXIVCDM]+\b)([A-Z,ÁÉÍÓÚÑÜÀÈÌÒÙÂÊÎÔÛÄËÏÖÜÇÅÆØ,0-9]+)\b/g, upperFirst)


### PR DESCRIPTION
- [x] Allow `;` separated inputs on advanced search
- [x] Vessel group name on group report shows differently 
- [x] vessel list infinite scrolling repeating vessels
- [x] Prepend `vessel-group-` to downloaded vessel group file
- [x] When using the advanced search (e.g. looking for vessels owned by Dongwon" and scrolling the number of vessels is confusing e.g. “Seeing 80 of 77 results” 
- [x] CSV download from end of group profile has a bunch of empty fields, even though the vessel profile accurately reflects e.g. MMSI, IMO etc.
- [x] In vessel profiles, the button to add vessels to vessel groups is blocked in UI
- [x] Vessel tracks not showing automatically on the map when toggled on