### PR TITLE
Track labeler/rc slider update

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -6,6 +6,8 @@ image-labeler:
   - apps/image-labeler/**/*
 port-labeler:
   - apps/port-labeler/**/*
+track-labeler:
+  - apps/track-labeler/**/*
 user-groups-admin:
   - apps/user-groups-admin/**/*
 vessel-history:

--- a/apps/track-labeler/src/features/timebar/Timebar.module.css
+++ b/apps/track-labeler/src/features/timebar/Timebar.module.css
@@ -64,8 +64,6 @@
 }
 
 .speedSelector {
-  writing-mode: bt-lr; /* IE */
-  appearance: slider-vertical; /* WebKit */
   width: 8px;
   height: calc(var(--track-labeler-timebar-size) - 13px);
   padding: 0 5px;
@@ -95,4 +93,19 @@
 
 .vesselEventPlaceholder:hover {
   background-color: rgba(255, 255, 255, 0.5);
+}
+
+.rangeSliderContainer {
+  height: 100%;
+  display: flex;
+}
+
+.rangeSliderValuesContainer {
+  color: white;
+  font-size: 1rem;
+  padding-left: 5px;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  line-height: 10px;
 }

--- a/apps/track-labeler/src/features/timebar/Timebar.tsx
+++ b/apps/track-labeler/src/features/timebar/Timebar.tsx
@@ -1,9 +1,9 @@
-import React, { createRef, Fragment, memo, useContext,useEffect } from 'react'
+import React, { createRef, Fragment, memo, useContext, useEffect } from 'react'
 import { useSelector } from 'react-redux'
 import type { NumberValue } from 'd3-scale'
-import { createSliderWithTooltip, Range as SliderRange } from 'rc-slider'
+import Slider from 'rc-slider'
 
-import { Timebar, TimebarHighlighter,TimelineContext } from '@globalfishingwatch/timebar'
+import { Timebar, TimebarHighlighter, TimelineContext } from '@globalfishingwatch/timebar'
 
 import { Field } from '../../data/models'
 import { useTimebarModeConnect, useTimerangeConnect } from '../../features/timebar/timebar.hooks'
@@ -92,17 +92,17 @@ const TimebarWrapper = () => {
   // const tracksEvents = useSelector(getEventsForTracks)
   const rangeLimits = useSelector(selectRangeFilterLimits)
   //Those three handlers update the filters when we modify the Range
-  const handleSpeedChange = (values: number[]) => {
-    dispatchSpeed(values)
+  const handleSpeedChange = (values: number[] | number) => {
+    dispatchSpeed(values as number[])
   }
-  const handleElevationChange = (values: number[]) => {
-    dispachElevation(values)
+  const handleElevationChange = (values: number[] | number) => {
+    dispachElevation(values as number[])
   }
-  const handleDistanceFromPortChange = (values: number[]) => {
-    dispachDistanceFromPort(values)
+  const handleDistanceFromPortChange = (values: number[] | number) => {
+    dispachDistanceFromPort(values as number[])
   }
-  const handleTimeChange = (values: number[]) => {
-    dispachHours(values)
+  const handleTimeChange = (values: number[] | number) => {
+    dispachHours(values as number[])
   }
 
   // Transform the range slider for filter the timebar to vertical style
@@ -112,8 +112,6 @@ const TimebarWrapper = () => {
       myRef.current.setAttribute('orientation', 'vertical')
     }
   }, [myRef])
-
-  const Range = createSliderWithTooltip(SliderRange) as any
 
   const tooltip = useSelector(selectTooltip)
   const absoluteStart = new Date('2012-01-01')
@@ -189,56 +187,76 @@ const TimebarWrapper = () => {
       </div>
       <div className={styles.filtersContainer}>
         {filterMode === Field.speed && (
-          <Range
-            min={rangeLimits.speed.min}
-            max={rangeLimits.speed.max}
-            step={0.1}
-            vertical
-            onAfterChange={handleSpeedChange}
-            allowCross={false}
-            tipFormatter={(value: any) => `${value} kt`}
-            tipProps={{ placement: 'right' }}
-            defaultValue={[minSpeed, maxSpeed]}
-          />
+          <div className={styles.rangeSliderContainer}>
+            <Slider
+              range
+              min={rangeLimits.speed.min}
+              max={rangeLimits.speed.max}
+              step={0.1}
+              vertical
+              onChangeComplete={handleSpeedChange}
+              allowCross={false}
+              defaultValue={[minSpeed, maxSpeed]}
+            />
+            <div className={styles.rangeSliderValuesContainer}>
+              <p>{`${maxSpeed} kt`}</p>
+              <p>{`${minSpeed} kt`}</p>
+            </div>
+          </div>
         )}
         {filterMode === Field.timestamp && (
-          <Range
-            min={rangeLimits.hours.min}
-            max={rangeLimits.hours.max}
-            step={1}
-            vertical
-            onAfterChange={handleTimeChange}
-            allowCross={false}
-            tipFormatter={(value: any) => `${value} hs`}
-            tipProps={{ placement: 'right' }}
-            defaultValue={[fromHour, toHour]}
-          />
+          <div className={styles.rangeSliderContainer}>
+            <Slider
+              range
+              min={rangeLimits.hours.min}
+              max={rangeLimits.hours.max}
+              step={1}
+              vertical
+              onChangeComplete={handleTimeChange}
+              allowCross={false}
+              defaultValue={[fromHour, toHour]}
+            />
+            <div className={styles.rangeSliderValuesContainer}>
+              <p>{`${toHour} hs`}</p>
+              <p>{`${fromHour} hs`}</p>
+            </div>
+          </div>
         )}
         {filterMode === Field.elevation && (
-          <Range
-            min={rangeLimits.elevation.min}
-            max={rangeLimits.elevation.max}
-            step={1}
-            vertical
-            onAfterChange={handleElevationChange}
-            allowCross={false}
-            tipFormatter={(value: any) => `${value} mt`}
-            tipProps={{ placement: 'right' }}
-            defaultValue={[minElevation, maxElevation]}
-          />
+          <div className={styles.rangeSliderContainer}>
+            <Slider
+              range
+              min={rangeLimits.elevation.min}
+              max={rangeLimits.elevation.max}
+              step={1}
+              vertical
+              onChangeComplete={handleElevationChange}
+              allowCross={false}
+              defaultValue={[minElevation, maxElevation]}
+            />
+            <div className={styles.rangeSliderValuesContainer}>
+              <p>{`${maxElevation} m`}</p>
+              <p>{`${minElevation} m`}</p>
+            </div>
+          </div>
         )}
         {filterMode === Field.distanceFromPort && (
-          <Range
-            min={rangeLimits.distanceFromPort.min}
-            max={rangeLimits.distanceFromPort.max}
-            step={1}
-            vertical
-            onAfterChange={handleDistanceFromPortChange}
-            allowCross={false}
-            tipFormatter={(value: any) => `${value} mt`}
-            tipProps={{ placement: 'right' }}
-            defaultValue={[minDistanceFromPort, maxDistanceFromPort]}
-          />
+          <div className={styles.rangeSliderContainer}>
+            <Slider
+              range
+              min={rangeLimits.distanceFromPort.min}
+              max={rangeLimits.distanceFromPort.max}
+              step={1}
+              vertical
+              onChangeComplete={handleDistanceFromPortChange}
+              allowCross={false}
+              defaultValue={[minDistanceFromPort, maxDistanceFromPort]}
+            />
+            <div className={styles.rangeSliderValuesContainer}>
+              <p>{`${minDistanceFromPort} mt`}</p>
+              <p>{`${maxDistanceFromPort} mt`}</p>
+            </div>
+          </div>
         )}
         <TimebarSelector />
       </div>

--- a/package.json
+++ b/package.json
@@ -122,7 +122,7 @@
     "pbf": "4.0.1",
     "protobufjs": "7.4.0",
     "qs": "6.14.0",
-    "rc-slider": "^9.7.5",
+    "rc-slider": "^11.1.8",
     "react": "19.0.0",
     "react-dom": "19.0.0",
     "react-dropzone": "14.3.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1439,7 +1439,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/runtime@npm:^7.0.0, @babel/runtime@npm:^7.10.1, @babel/runtime@npm:^7.11.1, @babel/runtime@npm:^7.11.2, @babel/runtime@npm:^7.12.0, @babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.18.3, @babel/runtime@npm:^7.22.6, @babel/runtime@npm:^7.23.2, @babel/runtime@npm:^7.23.8, @babel/runtime@npm:^7.24.5, @babel/runtime@npm:^7.25.0, @babel/runtime@npm:^7.25.7, @babel/runtime@npm:^7.26.0, @babel/runtime@npm:^7.5.5, @babel/runtime@npm:^7.6.2, @babel/runtime@npm:^7.7.2, @babel/runtime@npm:^7.8.4, @babel/runtime@npm:^7.8.7, @babel/runtime@npm:^7.9.2":
+"@babel/runtime@npm:^7.0.0, @babel/runtime@npm:^7.10.1, @babel/runtime@npm:^7.11.2, @babel/runtime@npm:^7.12.0, @babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.18.3, @babel/runtime@npm:^7.22.6, @babel/runtime@npm:^7.23.2, @babel/runtime@npm:^7.23.8, @babel/runtime@npm:^7.24.5, @babel/runtime@npm:^7.25.0, @babel/runtime@npm:^7.25.7, @babel/runtime@npm:^7.26.0, @babel/runtime@npm:^7.5.5, @babel/runtime@npm:^7.6.2, @babel/runtime@npm:^7.7.2, @babel/runtime@npm:^7.8.4, @babel/runtime@npm:^7.8.7, @babel/runtime@npm:^7.9.2":
   version: 7.26.0
   resolution: "@babel/runtime@npm:7.26.0"
   dependencies:
@@ -3011,7 +3011,7 @@ __metadata:
     protobufjs: "npm:7.4.0"
     purgecss: "npm:^7.0.2"
     qs: "npm:6.14.0"
-    rc-slider: "npm:^9.7.5"
+    rc-slider: "npm:^11.1.8"
     react: "npm:19.0.0"
     react-dom: "npm:19.0.0"
     react-dropzone: "npm:14.3.5"
@@ -13313,7 +13313,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"classnames@npm:2.5.1, classnames@npm:2.x, classnames@npm:^2.2.1, classnames@npm:^2.2.5, classnames@npm:^2.2.6, classnames@npm:^2.3.1":
+"classnames@npm:2.5.1, classnames@npm:^2.2.5":
   version: 2.5.1
   resolution: "classnames@npm:2.5.1"
   checksum: 10/58eb394e8817021b153bb6e7d782cfb667e4ab390cb2e9dac2fc7c6b979d1cc2b2a733093955fc5c94aa79ef5c8c89f11ab77780894509be6afbb91dddd79d15
@@ -15491,13 +15491,6 @@ __metadata:
   version: 0.6.3
   resolution: "dom-accessibility-api@npm:0.6.3"
   checksum: 10/83d3371f8226487fbad36e160d44f1d9017fb26d46faba6a06fcad15f34633fc827b8c3e99d49f71d5f3253d866e2131826866fd0a3c86626f8eccfc361881ff
-  languageName: node
-  linkType: hard
-
-"dom-align@npm:^1.7.0":
-  version: 1.12.4
-  resolution: "dom-align@npm:1.12.4"
-  checksum: 10/fbfb005fcb1572700dc164bdb0c5ba2a6b438ddf8b7fb1d7250b697f7899922364a671a37fa3f09b16596fc289d9bddeae6406a45f9587b91c24438590c73a2b
   languageName: node
   linkType: hard
 
@@ -26043,83 +26036,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"rc-align@npm:^4.0.0":
-  version: 4.0.15
-  resolution: "rc-align@npm:4.0.15"
-  dependencies:
-    "@babel/runtime": "npm:^7.10.1"
-    classnames: "npm:2.x"
-    dom-align: "npm:^1.7.0"
-    rc-util: "npm:^5.26.0"
-    resize-observer-polyfill: "npm:^1.5.1"
-  peerDependencies:
-    react: ">=16.9.0"
-    react-dom: ">=16.9.0"
-  checksum: 10/de1af4a58a371bc01cf5f327ce82b5e5631960c3e2dbae03532081e63bf86a809cebf9b8a231495db1dc659c28b6dbb35b0b33f2c29579b8b068388c1288c1b1
-  languageName: node
-  linkType: hard
-
-"rc-motion@npm:^2.0.0":
-  version: 2.9.5
-  resolution: "rc-motion@npm:2.9.5"
-  dependencies:
-    "@babel/runtime": "npm:^7.11.1"
-    classnames: "npm:^2.2.1"
-    rc-util: "npm:^5.44.0"
-  peerDependencies:
-    react: ">=16.9.0"
-    react-dom: ">=16.9.0"
-  checksum: 10/81a60e49c2fa78e88654039523ef9043f1476bc26f80f38561604ec48c256c9e5897254cda62ceff3c8e898285ae085568d1cd4fe35e8b018016517e998e3d44
-  languageName: node
-  linkType: hard
-
-"rc-slider@npm:^9.7.5":
-  version: 9.7.5
-  resolution: "rc-slider@npm:9.7.5"
+"rc-slider@npm:^11.1.8":
+  version: 11.1.8
+  resolution: "rc-slider@npm:11.1.8"
   dependencies:
     "@babel/runtime": "npm:^7.10.1"
     classnames: "npm:^2.2.5"
-    rc-tooltip: "npm:^5.0.1"
-    rc-util: "npm:^5.16.1"
-    shallowequal: "npm:^1.1.0"
+    rc-util: "npm:^5.36.0"
   peerDependencies:
     react: ">=16.9.0"
     react-dom: ">=16.9.0"
-  checksum: 10/500649e4d4d87bf3adb8a4318dddf095fffa46e8693a59a6ee7cc6d9c86bb76cedd83e4c4c9222b84419a5d86d69c16078aded06463139f58bfaff5fc6b3d868
+  checksum: 10/3efaefebd1699f9fcdb7008f03f9ecc73eb0c9db69b8a4009fbec1107950ec84b241275503505fa7e77d85fcef62d93934b8a94efb2be44d70d3e889db1070b4
   languageName: node
   linkType: hard
 
-"rc-tooltip@npm:^5.0.1":
-  version: 5.3.1
-  resolution: "rc-tooltip@npm:5.3.1"
-  dependencies:
-    "@babel/runtime": "npm:^7.11.2"
-    classnames: "npm:^2.3.1"
-    rc-trigger: "npm:^5.3.1"
-  peerDependencies:
-    react: ">=16.9.0"
-    react-dom: ">=16.9.0"
-  checksum: 10/c7627fbfae753a0e73548d1f93329a5132d76727f737d4eedc5a142f2950986f429dae11b5d8bc13f39bd72a631a22cb32f3b8aaad83bfdde770c19e220708bf
-  languageName: node
-  linkType: hard
-
-"rc-trigger@npm:^5.3.1":
-  version: 5.3.4
-  resolution: "rc-trigger@npm:5.3.4"
-  dependencies:
-    "@babel/runtime": "npm:^7.18.3"
-    classnames: "npm:^2.2.6"
-    rc-align: "npm:^4.0.0"
-    rc-motion: "npm:^2.0.0"
-    rc-util: "npm:^5.19.2"
-  peerDependencies:
-    react: ">=16.9.0"
-    react-dom: ">=16.9.0"
-  checksum: 10/32e0a3083ecea27b44d47c8638e399fadab658fe48a526b0f072011acd99f5b26871a9b3c07fc7f121ddbec900e41bf3eb9085a7be18aa66007aae7fd311b1f9
-  languageName: node
-  linkType: hard
-
-"rc-util@npm:^5.16.1, rc-util@npm:^5.19.2, rc-util@npm:^5.26.0, rc-util@npm:^5.44.0":
+"rc-util@npm:^5.36.0":
   version: 5.44.3
   resolution: "rc-util@npm:5.44.3"
   dependencies:
@@ -26968,7 +26899,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"resize-observer-polyfill@npm:1.5.1, resize-observer-polyfill@npm:^1.5.1":
+"resize-observer-polyfill@npm:1.5.1":
   version: 1.5.1
   resolution: "resize-observer-polyfill@npm:1.5.1"
   checksum: 10/e10ee50cd6cf558001de5c6fb03fee15debd011c2f694564b71f81742eef03fb30d6c2596d1d5bf946d9991cb692fcef529b7bd2e4057041377ecc9636c753ce
@@ -27891,13 +27822,6 @@ __metadata:
   dependencies:
     kind-of: "npm:^6.0.2"
   checksum: 10/e066bd540cfec5e1b0f78134853e0d892d1c8945fb9a926a579946052e7cb0c70ca4fc34f875a8083aa7910d751805d36ae64af250a6de6f3d28f9fa7be6c21b
-  languageName: node
-  linkType: hard
-
-"shallowequal@npm:^1.1.0":
-  version: 1.1.0
-  resolution: "shallowequal@npm:1.1.0"
-  checksum: 10/f4c1de0837f106d2dbbfd5d0720a5d059d1c66b42b580965c8f06bb1db684be8783538b684092648c981294bf817869f743a066538771dbecb293df78f765e00
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR avoids `rc-slider `to crash the app due to the incompatibility with current (recently updated) `react-dom` version of the project.