### PR TITLE
Fishing map/migration disclaimer

### DIFF
--- a/apps/fishing-map/features/app/App.tsx
+++ b/apps/fishing-map/features/app/App.tsx
@@ -36,7 +36,6 @@ import {
   selectWorkspaceStatus,
 } from 'features/workspace/workspace.selectors'
 import { fetchWorkspaceThunk } from 'features/workspace/workspace.slice'
-import { useMigrateWorkspaceToast } from 'features/workspace/workspace-migration.hooks'
 import { fetchHighlightWorkspacesThunk } from 'features/workspaces-list/workspaces-list.slice'
 import {
   HOME,
@@ -134,7 +133,6 @@ function App() {
   useDatasetDrag()
   useReplaceLoginUrl()
   useBeforeUnload()
-  useMigrateWorkspaceToast()
   const dispatch = useAppDispatch()
   const sidebarOpen = useSelector(selectSidebarOpen)
   const isMapDrawing = useSelector(selectIsMapDrawing)

--- a/apps/fishing-map/features/app/App.tsx
+++ b/apps/fishing-map/features/app/App.tsx
@@ -1,4 +1,4 @@
-import { Fragment,useCallback, useEffect, useLayoutEffect, useState } from 'react'
+import { Fragment, useCallback, useEffect, useLayoutEffect, useState } from 'react'
 import { FpsView } from 'react-fps'
 import { useTranslation } from 'react-i18next'
 import { useSelector } from 'react-redux'
@@ -36,6 +36,7 @@ import {
   selectWorkspaceStatus,
 } from 'features/workspace/workspace.selectors'
 import { fetchWorkspaceThunk } from 'features/workspace/workspace.slice'
+import { useMigrateWorkspaceToast } from 'features/workspace/workspace-migration.hooks'
 import { fetchHighlightWorkspacesThunk } from 'features/workspaces-list/workspaces-list.slice'
 import {
   HOME,
@@ -133,6 +134,7 @@ function App() {
   useDatasetDrag()
   useReplaceLoginUrl()
   useBeforeUnload()
+  useMigrateWorkspaceToast()
   const dispatch = useAppDispatch()
   const sidebarOpen = useSelector(selectSidebarOpen)
   const isMapDrawing = useSelector(selectIsMapDrawing)
@@ -209,6 +211,7 @@ function App() {
         action.abort()
       }
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [userLogged, homeNeedsFetch, locationNeedsFetch, hasWorkspaceIdChanged])
 
   useLayoutEffect(() => {

--- a/apps/fishing-map/features/dataviews/selectors/dataviews.instances.selectors.ts
+++ b/apps/fishing-map/features/dataviews/selectors/dataviews.instances.selectors.ts
@@ -84,7 +84,11 @@ export const selectDataviewInstancesResolvedVisible = createSelector(
     const visibleDataviews = dataviews.filter((dataview) => dataview.config?.visible)
     if (hasDeprecatedDataviewInstances) {
       return visibleDataviews.filter(
-        (d) => d.category === DataviewCategory.Context || d.slug === BASEMAP_DATAVIEW_SLUG
+        (d) =>
+          d.category === DataviewCategory.Context ||
+          d.category === DataviewCategory.User ||
+          d.category === DataviewCategory.Environment ||
+          d.slug === BASEMAP_DATAVIEW_SLUG
       )
     }
     if (isAreaReportLocation) {

--- a/apps/fishing-map/features/reports/areas/AreaReport.tsx
+++ b/apps/fishing-map/features/reports/areas/AreaReport.tsx
@@ -41,6 +41,7 @@ import {
 } from 'features/timebar/timebar.hooks'
 import { selectWorkspaceVesselGroupsStatus } from 'features/vessel-groups/vessel-groups.slice'
 import { selectWorkspaceStatus } from 'features/workspace/workspace.selectors'
+import { useMigrateWorkspaceToast } from 'features/workspace/workspace-migration.hooks'
 import WorkspaceError, { ErrorPlaceHolder } from 'features/workspace/WorkspaceError'
 import { useLocationConnect } from 'routes/routes.hook'
 import { TimebarVisualisations } from 'types'
@@ -49,6 +50,7 @@ import { AsyncReducerStatus } from 'utils/async-slice'
 export type ReportActivityUnit = 'hour' | 'detection'
 
 export default function Report() {
+  useMigrateWorkspaceToast()
   const { t } = useTranslation()
   const dispatch = useAppDispatch()
   const setTimeseries = useSetTimeseries()

--- a/apps/fishing-map/features/reports/ports/PortsReport.tsx
+++ b/apps/fishing-map/features/reports/ports/PortsReport.tsx
@@ -22,6 +22,7 @@ import EventsReportVesselsTableFooter from 'features/reports/shared/events/Event
 import ReportActivityPlaceholder from 'features/reports/shared/placeholders/ReportActivityPlaceholder'
 import ReportTitlePlaceholder from 'features/reports/shared/placeholders/ReportTitlePlaceholder'
 import ReportVesselsPlaceholder from 'features/reports/shared/placeholders/ReportVesselsPlaceholder'
+import { useMigrateWorkspaceToast } from 'features/workspace/workspace-migration.hooks'
 import { selectReportPortId } from 'routes/routes.selectors'
 import { AsyncReducerStatus } from 'utils/async-slice'
 import { formatInfoField } from 'utils/info'
@@ -55,6 +56,7 @@ import styles from './PortsReport.module.css'
 const MAX_VESSELS_REPORT = 500
 
 function PortsReport() {
+  useMigrateWorkspaceToast()
   const dispatchFetchReport = useFetchPortsReport()
   const dispatch = useAppDispatch()
   const { t } = useTranslation()

--- a/apps/fishing-map/features/reports/vessel-groups/VesselGroupReport.tsx
+++ b/apps/fishing-map/features/reports/vessel-groups/VesselGroupReport.tsx
@@ -21,6 +21,7 @@ import {
 import { selectUserData } from 'features/user/selectors/user.selectors'
 import type { VGRSection } from 'features/vessel-groups/vessel-groups.types'
 import { isOutdatedVesselGroup } from 'features/vessel-groups/vessel-groups.utils'
+import { useMigrateWorkspaceToast } from 'features/workspace/workspace-migration.hooks'
 import { useLocationConnect } from 'routes/routes.hook'
 import { selectReportVesselGroupId } from 'routes/routes.selectors'
 import { TimebarVisualisations } from 'types'
@@ -40,6 +41,7 @@ import VesselGroupReportTitle from './VesselGroupReportTitle'
 import styles from './VesselGroupReport.module.css'
 
 function VesselGroupReport() {
+  useMigrateWorkspaceToast()
   const { t } = useTranslation()
   const { dispatchQueryParams } = useLocationConnect()
   const fetchVesselGroupReport = useFetchVesselGroupReport()

--- a/apps/fishing-map/features/sidebar/Sidebar.tsx
+++ b/apps/fishing-map/features/sidebar/Sidebar.tsx
@@ -40,8 +40,8 @@ const PortsReport = dynamic(
 const VesselGroupReport = dynamic(
   () => import(/* webpackChunkName: "Report" */ 'features/reports/vessel-groups/VesselGroupReport')
 )
-const VesselDetailWrapper = dynamic(
-  () => import(/* webpackChunkName: "VesselDetailWrapper" */ 'features/vessel/Vessel')
+const VesselProfile = dynamic(
+  () => import(/* webpackChunkName: "VesselProfile" */ 'features/vessel/Vessel')
 )
 const User = dynamic(() => import(/* webpackChunkName: "User" */ 'features/user/User'))
 const Workspace = dynamic(
@@ -103,7 +103,7 @@ function Sidebar({ onMenuClick }: SidebarProps) {
     }
 
     if (isVesselLocation) {
-      return <VesselDetailWrapper />
+      return <VesselProfile />
     }
 
     if (isWorkspacesListLocation) {

--- a/apps/fishing-map/features/vessel/Vessel.tsx
+++ b/apps/fishing-map/features/vessel/Vessel.tsx
@@ -40,6 +40,7 @@ import { useSetVesselProfileEvents } from 'features/vessel/vessel-events.hooks'
 import VesselHeader from 'features/vessel/VesselHeader'
 import { useDataviewInstancesConnect } from 'features/workspace/workspace.hook'
 import { fetchWorkspaceThunk } from 'features/workspace/workspace.slice'
+import { useMigrateWorkspaceToast } from 'features/workspace/workspace-migration.hooks'
 import { ErrorPlaceHolder, WorkspaceLoginError } from 'features/workspace/WorkspaceError'
 import { useLocationConnect } from 'routes/routes.hook'
 import {
@@ -56,6 +57,7 @@ import type { VesselSection } from './vessel.types'
 import styles from './Vessel.module.css'
 
 const Vessel = () => {
+  useMigrateWorkspaceToast()
   const { t } = useTranslation()
   const dispatch = useAppDispatch()
   const { dispatchQueryParams } = useLocationConnect()

--- a/apps/fishing-map/features/workspace/Workspace.tsx
+++ b/apps/fishing-map/features/workspace/Workspace.tsx
@@ -5,7 +5,7 @@ import { DndContext } from '@dnd-kit/core'
 import { restrictToVerticalAxis } from '@dnd-kit/modifiers'
 import { arrayMove } from '@dnd-kit/sortable'
 
-import { Button, InputText,Modal, Spinner } from '@globalfishingwatch/ui-components'
+import { Button, InputText, Modal, Spinner } from '@globalfishingwatch/ui-components'
 
 import { PUBLIC_SUFIX, ROOT_DOM_ELEMENT, USER_SUFIX } from 'data/config'
 import { WIZARD_TEMPLATE_ID } from 'data/default-workspaces/marine-manager'
@@ -42,13 +42,11 @@ import EnvironmentalSection from './environmental/EnvironmentalSection'
 import EventsSection from './events/EventsSection'
 import VesselGroupSection from './vessel-groups/VesselGroupsSection'
 import VesselsSection from './vessels/VesselsSection'
-import { useMigrateWorkspaceToast } from './workspace-migration.hooks'
 
 import styles from './Workspace.module.css'
 
 function Workspace() {
   useHideLegacyActivityCategoryDataviews()
-  useMigrateWorkspaceToast()
   useUserExpiredToast()
   const { t } = useTranslation()
   const dispatch = useAppDispatch()
@@ -83,7 +81,7 @@ function Workspace() {
     if (workspaceVesselGroupsIds.length) {
       dispatch(fetchWorkspaceVesselGroupsThunk(workspaceVesselGroupsIds))
     }
-     
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [workspaceVesselGroupsIdsHash, dispatch])
 
   const handleDragEnd = useCallback(

--- a/apps/fishing-map/features/workspace/Workspace.tsx
+++ b/apps/fishing-map/features/workspace/Workspace.tsx
@@ -42,12 +42,14 @@ import EnvironmentalSection from './environmental/EnvironmentalSection'
 import EventsSection from './events/EventsSection'
 import VesselGroupSection from './vessel-groups/VesselGroupsSection'
 import VesselsSection from './vessels/VesselsSection'
+import { useMigrateWorkspaceToast } from './workspace-migration.hooks'
 
 import styles from './Workspace.module.css'
 
 function Workspace() {
   useHideLegacyActivityCategoryDataviews()
   useUserExpiredToast()
+  useMigrateWorkspaceToast()
   const { t } = useTranslation()
   const dispatch = useAppDispatch()
   const readOnly = useSelector(selectReadOnly)

--- a/apps/fishing-map/features/workspace/activity/ActivityLayerPanel.tsx
+++ b/apps/fishing-map/features/workspace/activity/ActivityLayerPanel.tsx
@@ -17,6 +17,7 @@ import { useAppDispatch } from 'features/app/app.hooks'
 import { selectBivariateDataviews, selectReadOnly } from 'features/app/selectors/app.selectors'
 import type { SupportedDatasetSchema } from 'features/datasets/datasets.utils'
 import { getDatasetTitleByDataview } from 'features/datasets/datasets.utils'
+import { selectHasDeprecatedDataviewInstances } from 'features/dataviews/selectors/dataviews.instances.selectors'
 import Hint from 'features/help/Hint'
 import { selectHintsDismissed, setHintDismissed } from 'features/help/hints.slice'
 import { useActivityDataviewId } from 'features/map/map-layers.hooks'
@@ -68,6 +69,7 @@ function ActivityLayerPanel({
   const isGFWUser = useSelector(selectIsGFWUser)
   const bivariateDataviews = useSelector(selectBivariateDataviews)
   const hintsDismissed = useSelector(selectHintsDismissed)
+  const hasDeprecatedDataviewInstances = useSelector(selectHasDeprecatedDataviewInstances)
   const readOnly = useSelector(selectReadOnly)
   const layerActive = dataview?.config?.visible ?? true
   const dataviewId = useActivityDataviewId(dataview)
@@ -195,7 +197,8 @@ function ActivityLayerPanel({
           <div className={styles.header}>
             <LayerSwitch
               onToggle={onLayerSwitchToggle}
-              active={layerActive}
+              disabled={hasDeprecatedDataviewInstances}
+              active={layerActive && !hasDeprecatedDataviewInstances}
               className={styles.switch}
               dataview={dataview}
             />
@@ -204,6 +207,7 @@ function ActivityLayerPanel({
               className={styles.name}
               classNameActive={styles.active}
               dataview={dataview}
+              toggleVisibility={!hasDeprecatedDataviewInstances}
               onToggle={onLayerSwitchToggle}
             />
             <div
@@ -256,7 +260,10 @@ function ActivityLayerPanel({
                 showAllDatasets={dataview.dataviewId === SAR_DATAVIEW_SLUG}
               />
               {!readOnly && (
-                <Remove onClick={onRemoveLayerClick} loading={layerActive && !layerLoaded} />
+                <Remove
+                  onClick={onRemoveLayerClick}
+                  loading={!hasDeprecatedDataviewInstances && layerActive && !layerLoaded}
+                />
               )}
               {!readOnly && layerActive && layerError && (
                 <IconButton
@@ -277,7 +284,7 @@ function ActivityLayerPanel({
             <IconButton
               icon={layerError ? 'warning' : layerActive ? 'more' : undefined}
               type={layerError ? 'warning' : 'default'}
-              loading={layerActive && !layerLoaded}
+              loading={!hasDeprecatedDataviewInstances && layerActive && !layerLoaded}
               className={cx('print-hidden', styles.shownUntilHovered)}
               size="small"
             />

--- a/apps/fishing-map/features/workspace/common/Title.module.css
+++ b/apps/fishing-map/features/workspace/common/Title.module.css
@@ -3,3 +3,7 @@
   align-items: center;
   justify-content: flex-start;
 }
+
+.disabled {
+  cursor: not-allowed;
+}

--- a/apps/fishing-map/features/workspace/common/Title.tsx
+++ b/apps/fishing-map/features/workspace/common/Title.tsx
@@ -54,7 +54,10 @@ const Title = (props: TitleProps) => {
   return (
     <Tooltip content={showTooltip && (title as string).length > 20 ? title : ''}>
       <h3
-        className={cx(styles.titleSpan, className, { [classNameActive]: layerActive })}
+        className={cx(styles.titleSpan, className, {
+          [classNameActive]: layerActive,
+          [styles.disabled]: !toggleVisibility,
+        })}
         onClick={onToggleLayerActive}
       >
         {showIcon &&

--- a/apps/fishing-map/features/workspace/vessels/VesselsSection.tsx
+++ b/apps/fishing-map/features/workspace/vessels/VesselsSection.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useRef } from 'react'
-import { Trans,useTranslation } from 'react-i18next'
+import { Trans, useTranslation } from 'react-i18next'
 import { useSelector } from 'react-redux'
 import { SortableContext } from '@dnd-kit/sortable'
 import cx from 'classnames'
@@ -14,7 +14,10 @@ import { useAppDispatch } from 'features/app/app.hooks'
 import { selectReadOnly } from 'features/app/selectors/app.selectors'
 import { VESSEL_DATAVIEW_INSTANCE_PREFIX } from 'features/dataviews/dataviews.utils'
 import { selectActiveVesselsDataviews } from 'features/dataviews/selectors/dataviews.categories.selectors'
-import { selectVesselsDataviews } from 'features/dataviews/selectors/dataviews.instances.selectors'
+import {
+  selectHasDeprecatedDataviewInstances,
+  selectVesselsDataviews,
+} from 'features/dataviews/selectors/dataviews.instances.selectors'
 import { getVesselGroupDataviewInstance } from 'features/reports/vessel-groups/vessel-group-report.dataviews'
 import type { ResourcesState } from 'features/resources/resources.slice'
 import { selectResources } from 'features/resources/resources.slice'
@@ -63,6 +66,7 @@ function VesselsSection(): React.ReactElement<any> {
   const workspace = useSelector(selectWorkspace)
   const guestUser = useSelector(selectIsGuestUser)
   const vesselGroupsStatus = useSelector(selectVesselGroupsStatus)
+  const hasDeprecatedDataviewInstances = useSelector(selectHasDeprecatedDataviewInstances)
   const vesselGroupsInWorkspace = useSelector(selectWorkspaceVessselGroupsIds)
   const { upsertDataviewInstance, deleteDataviewInstance } = useDataviewInstancesConnect()
   const vesselTracksData = useTimebarVesselTracksData()
@@ -175,6 +179,7 @@ function VesselsSection(): React.ReactElement<any> {
           <Switch
             className="print-hidden"
             active={someVesselsVisible}
+            disabled={hasDeprecatedDataviewInstances}
             onClick={onToggleAllVessels}
             tooltip={t('vessel.toggleAllVessels', 'Toggle all vessels visibility')}
             tooltipPlacement="top"
@@ -238,7 +243,7 @@ function VesselsSection(): React.ReactElement<any> {
           type="border"
           size="medium"
           testId="search-vessels-open"
-          disabled={!searchAllowed}
+          disabled={!searchAllowed || hasDeprecatedDataviewInstances}
           className="print-hidden"
           tooltip={
             searchAllowed
@@ -268,7 +273,7 @@ function VesselsSection(): React.ReactElement<any> {
           </div>
         )}
       </SortableContext>
-      {activeDataviews.length > 0 && guestUser && (
+      {activeDataviews.length > 0 && guestUser && !hasDeprecatedDataviewInstances && (
         <p className={cx(styles.disclaimer, 'print-hidden')}>
           {hasVesselsWithNoTrack ? (
             <Trans i18nKey="vessel.trackLogin">
@@ -284,7 +289,7 @@ function VesselsSection(): React.ReactElement<any> {
           )}
         </p>
       )}
-      <VesselEventsLegend dataviews={dataviews} />
+      {!hasDeprecatedDataviewInstances && <VesselEventsLegend dataviews={dataviews} />}
       <VesselsFromPositions />
     </div>
   )

--- a/apps/fishing-map/features/workspace/workspace-migration.hooks.tsx
+++ b/apps/fishing-map/features/workspace/workspace-migration.hooks.tsx
@@ -155,13 +155,13 @@ export const useMigrateWorkspaceToast = () => {
     toast.dismiss(toastId.current)
   }
 
-  const dissmissToast = () => {
-    trackEvent({
-      category: TrackCategory.WorkspaceManagement,
-      action: 'Skip workspace migration',
-    })
-    closeToast()
-  }
+  // const dissmissToast = () => {
+  //   trackEvent({
+  //     category: TrackCategory.WorkspaceManagement,
+  //     action: 'Skip workspace migration',
+  //   })
+  //   closeToast()
+  // }
 
   const updateWorkspace = async () => {
     trackEvent({
@@ -195,9 +195,9 @@ export const useMigrateWorkspaceToast = () => {
         )}
       </p>
       <div className={styles.disclaimerFooter}>
-        <Button onClick={dissmissToast} type="secondary" className={styles.updateBtn}>
+        {/* <Button onClick={dissmissToast} type="secondary" className={styles.updateBtn}>
           {t('workspace.migrationMaintain', 'Skip')}
-        </Button>
+        </Button> */}
         <Button loading={loading} onClick={updateWorkspace} className={styles.updateBtn}>
           {t('workspace.migrationUpdate', 'Update')}
         </Button>
@@ -211,6 +211,10 @@ export const useMigrateWorkspaceToast = () => {
         toastId: 'migrateWorkspace',
         autoClose: false,
       })
+      return () => {
+        closeToast()
+      }
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [hasDeprecatedDataviews])
 }


### PR DESCRIPTION
Stop using deprecated datasets by:
- removing the activity and the vessel layers when containing deprecated datasets
- blocking the UI to toggle or add new layers
- making the migration toast not skippable 