### PR TITLE
Avoid full segment selections to create new ones

### DIFF
--- a/apps/track-labeler/src/features/timebar/timebar.hooks.ts
+++ b/apps/track-labeler/src/features/timebar/timebar.hooks.ts
@@ -149,7 +149,7 @@ export const useSegmentsLabeledConnect = () => {
     }
 
     // Case 1: Segment completely contains new segment
-    if (segment.start <= newSegment.start && segment.end >= newSegment.end) {
+    if (segment.start < newSegment.start && segment.end > newSegment.end) {
       const endLatitude = findPreviousPosition(timestamps, positions, newSegment.start, 'latitude')
       const endLongitude = findPreviousPosition(
         timestamps,


### PR DESCRIPTION
There was a bug on segment creation after selection where selecting a full segment to re-label it was creating unnecessary segments and messing with start and end time (removing some points, see the attached video 👇)

https://github.com/user-attachments/assets/11184b34-77e6-4b08-9466-7bdc106790e3

Updated logic avoids splitting previously existing segments and just adds the newly labeled segment 

https://github.com/user-attachments/assets/a0925347-bf47-4bd7-9ec0-a7defd906c17

