### PR TITLE
add object-fit for map canvas to ensure print doesn't change the ratio

### DIFF
--- a/apps/fishing-map/features/map/Map.module.css
+++ b/apps/fishing-map/features/map/Map.module.css
@@ -12,6 +12,11 @@
   height: 100%;
 }
 
+/* Ensure this id matches the id in the DeckGLWrapper.tsx */
+:global(#map) {
+  object-fit: contain;
+}
+
 :global(.printing) .screenshot {
   display: block !important;
 }

--- a/apps/fishing-map/features/reports/report-area/title/ReportTitle.tsx
+++ b/apps/fishing-map/features/reports/report-area/title/ReportTitle.tsx
@@ -44,7 +44,7 @@ import { selectReportId } from 'routes/routes.selectors'
 import type { BufferOperation, BufferUnit } from 'types'
 import { AsyncReducerStatus } from 'utils/async-slice'
 
-import { useHighlightReportArea } from '../area-reports.hooks'
+import { useFitAreaInViewport, useHighlightReportArea } from '../area-reports.hooks'
 
 import { BufferButtonTooltip } from './BufferButonTooltip'
 
@@ -60,6 +60,7 @@ export default function ReportTitle({ isSticky }: { isSticky?: boolean }) {
   const dispatch = useAppDispatch()
   const loading = useReportFeaturesLoading()
   const highlightArea = useHighlightReportArea()
+  const fitAreaInViewport = useFitAreaInViewport()
   const reportId = useSelector(selectReportId)
   const reportCategory = useSelector(selectReportCategory)
   const areaDataview = useSelector(selectReportAreaDataviews)?.[0]
@@ -112,11 +113,14 @@ export default function ReportTitle({ isSticky }: { isSticky?: boolean }) {
   )
 
   const onPrintClick = () => {
+    fitAreaInViewport()
     trackEvent({
       category: TrackCategory.Analysis,
       action: `Click print/save as pdf`,
     })
-    window.print()
+    setTimeout(() => {
+      window.print()
+    }, 100)
   }
 
   const handleTooltipHide = useCallback(() => {


### PR DESCRIPTION
Hopefully [this](https://stackoverflow.com/questions/54866986/how-does-object-fit-work-with-canvas-element) makes the trick to fix https://github.com/GlobalFishingWatch/frontend/pull/3103

@GeorgiaDesigns, can you please test if it works for you?

The mini globe can be a bit outside of the map... but I think it is better than the current solution
<img width="979" alt="Google Chrome 2025-04-03 18 35 32" src="https://github.com/user-attachments/assets/dbc6034c-edbb-4ce6-aeba-8cb92012152e" />


