### PR TITLE
hotfix ddp download

### DIFF
--- a/apps/data-download-portal/src/components/table/table.tsx
+++ b/apps/data-download-portal/src/components/table/table.tsx
@@ -216,7 +216,6 @@ function Table({ columns, data, logged }: TableProps) {
 
   const {
     rows,
-    selectedFlatRows,
     flatRows,
     state,
     prepareRow,

--- a/apps/data-download-portal/src/components/table/table.tsx
+++ b/apps/data-download-portal/src/components/table/table.tsx
@@ -216,6 +216,7 @@ function Table({ columns, data, logged }: TableProps) {
 
   const {
     rows,
+    selectedFlatRows,
     flatRows,
     state,
     prepareRow,
@@ -249,14 +250,14 @@ function Table({ columns, data, logged }: TableProps) {
   )
 
   const onDownloadClick = useCallback(() => {
-    const selectedFlatRows = getFlattenedFiles(selectedRows)
-    if (selectedFlatRows.length === 1) {
-      const { path } = selectedFlatRows[0]
+    const selectedFlatRowsCalculated = getFlattenedFiles(selectedRows)
+    if (selectedFlatRowsCalculated.length === 1) {
+      const { path } = selectedFlatRowsCalculated[0]
       if (path) {
         downloadSingleFile(path)
       }
     } else {
-      const files = selectedFlatRows.map((row) => row.path)
+      const files = selectedFlatRowsCalculated.map((row) => row.path)
       setDownloadLoading(true)
       const params = {
         method: 'POST' as const,
@@ -278,7 +279,7 @@ function Table({ columns, data, logged }: TableProps) {
     }
   }, [datasetId, downloadSingleFile, selectedRows])
 
-  const rowSelectedCount = selectedRows.length
+  const rowSelectedCount = getFlattenedFiles(selectedRows).length
 
   return (
     <div>

--- a/apps/data-download-portal/src/pages/dataset/dataset.tsx
+++ b/apps/data-download-portal/src/pages/dataset/dataset.tsx
@@ -4,7 +4,7 @@ import { DateTime } from 'luxon'
 
 import { GFWAPI } from '@globalfishingwatch/api-client'
 import type { Dataset } from '@globalfishingwatch/api-types'
-import { useGFWLogin } from '@globalfishingwatch/react-hooks/use-login'
+import { useGFWLogin } from '@globalfishingwatch/react-hooks'
 import { IconButton } from '@globalfishingwatch/ui-components'
 
 import ApiBanner from '../../components/api-banner/api-banner'

--- a/apps/data-download-portal/src/utils/folderConfig.tsx
+++ b/apps/data-download-portal/src/utils/folderConfig.tsx
@@ -45,25 +45,11 @@ const insertIntoTree = (tree: TableData[], file: DatasetFile) => {
   }
 }
 
-const aggregateSizes = (node: TableData): number => {
-  if (!node.subRows || node.subRows.length === 0) {
-    return Number(node.size ?? 0)
-  }
-
-  const totalSize = node.subRows.reduce((sum, child) => {
-    return sum + aggregateSizes(child)
-  }, 0)
-
-  node.size = totalSize
-  return totalSize
-}
-
 export const buildFileTree = (files: DatasetFile[]): TableData[] => {
   const tree: TableData[] = []
   files.forEach((file) => {
     insertIntoTree(tree, file)
   })
-  // tree.forEach((node) => aggregateSizes(node))
 
   return tree
 }

--- a/apps/data-download-portal/src/utils/folderConfig.tsx
+++ b/apps/data-download-portal/src/utils/folderConfig.tsx
@@ -31,6 +31,7 @@ const insertIntoTree = (tree: TableData[], file: DatasetFile) => {
       const node: TableData = {
         ...file,
         name: part,
+        ...(isFolder && { size: '--' }),
         ...(isFolder ? { subRows: [] } : {}),
       }
 
@@ -62,7 +63,7 @@ export const buildFileTree = (files: DatasetFile[]): TableData[] => {
   files.forEach((file) => {
     insertIntoTree(tree, file)
   })
-  tree.forEach((node) => aggregateSizes(node))
+  // tree.forEach((node) => aggregateSizes(node))
 
   return tree
 }
@@ -98,8 +99,4 @@ export function getFlattenedFiles(selectedFlatRows: Row<TableData>[]) {
 
   selectedFlatRows.forEach(processRow)
   return flattenedFiles
-}
-
-export function countSelectedFiles(selectedFlatRows: Row<TableData>[]) {
-  return getFlattenedFiles(selectedFlatRows).length
 }


### PR DESCRIPTION
DDP TESTING

1 - download collapsed folder 2013-fleet-daily-100-v3 (314 files) -> downloaded 315 files (all in folder + 1 root file possibly in cache)

2 - cleaned cache and download collapsed folder 2012-fleet-daily-100-v3 (366 files) ->
desselect and reselected and clicked download
expanded and clicked download
nothing happened

3 - selected 2 root readme files -> downloaded the 2012-fleet-daily-100-v3 files (366 files)

4 - expanded 2013-fleet-daily-100-v3 folder and selected 5 files then clicked to download -> nothing happened

5 - collapsed folder and selected 1 root readme file -> downloaded all 2013-fleet-daily-100-v3 files (314 files) 


delayed -
- 2012-fleet-daily-100-v3 downloaded (366 files)
- 2 readme files downloaded
- 5 2013 selected files downloaded
- 5 2013 selected files + 1 root readme file downloaded
- 2012-fleet-daily-100-v3 downloaded again (366 files)


CONCLUSION
Seems to be downloading correctly but with slight delay