### PR TITLE
Fishing map/vessel groups updates

### DIFF
--- a/apps/fishing-map/features/dataviews/dataviews.utils.ts
+++ b/apps/fishing-map/features/dataviews/dataviews.utils.ts
@@ -61,10 +61,10 @@ export const getVesselIdFromInstanceId = (dataviewInstanceId: string) => {
 }
 
 export const getIsVesselDataviewInstanceId = (dataviewInstanceId: string) =>
-  dataviewInstanceId.startsWith(VESSEL_DATAVIEW_INSTANCE_PREFIX)
+  dataviewInstanceId?.startsWith(VESSEL_DATAVIEW_INSTANCE_PREFIX)
 
 export const getIsEncounteredVesselDataviewInstanceId = (dataviewInstanceId: string) =>
-  dataviewInstanceId.startsWith(VESSEL_ENCOUNTER_DATAVIEW_INSTANCE_PREFIX)
+  dataviewInstanceId?.startsWith(VESSEL_ENCOUNTER_DATAVIEW_INSTANCE_PREFIX)
 
 export const getVesselDataviewInstanceId = (vesselId: string) =>
   `${VESSEL_DATAVIEW_INSTANCE_PREFIX}${vesselId}`

--- a/apps/fishing-map/features/reports/report-vessel-group/VesselGroupReport.tsx
+++ b/apps/fishing-map/features/reports/report-vessel-group/VesselGroupReport.tsx
@@ -13,7 +13,7 @@ import {
   useReportAreaCenter,
   useVesselGroupBounds,
 } from 'features/reports/report-area/area-reports.hooks'
-import { selectReportCategory } from 'features/reports/reports.selectors'
+import { selectReportCategory, selectReportVesselGraph } from 'features/reports/reports.selectors'
 import ReportVessels from 'features/reports/shared/vessels/ReportVessels'
 import EventsReport from 'features/reports/tabs/events/EventsReport'
 import VesselGroupReportInsights from 'features/reports/tabs/vessel-group-insights/VGRInsights'
@@ -51,6 +51,7 @@ function VesselGroupReport() {
   const reportCategory = useSelector(selectReportCategory)
   const reportDataview = useSelector(selectVGRFootprintDataview)
   const timeRange = useSelector(selectReportVesselGroupTimeRange)
+  const reportVesselGraph = useSelector(selectReportVesselGraph)
   const userData = useSelector(selectUserData)
   const { dispatchTimebarVisualisation } = useTimebarVisualisationConnect()
   const { dispatchTimebarSelectedVGId } = useTimebarVesselGroupConnect()
@@ -113,7 +114,13 @@ function VesselGroupReport() {
       {
         id: ReportCategory.VesselGroup,
         title: t('common.vessels'),
-        content: <ReportVessels loading={loading} color={reportDataview?.config?.color} />,
+        content: (
+          <ReportVessels
+            loading={loading}
+            color={reportDataview?.config?.color}
+            activityUnit={reportVesselGraph === 'coverage' ? 'coverage' : undefined}
+          />
+        ),
       },
       {
         id: ReportCategory.VesselGroupInsights,
@@ -131,7 +138,7 @@ function VesselGroupReport() {
         content: <EventsReport />,
       },
     ],
-    [t, reportDataview?.config?.color, loading]
+    [t, loading, reportDataview?.config?.color, reportVesselGraph]
   )
 
   const isOwnedByUser = vesselGroup?.ownerId === userData?.id

--- a/apps/fishing-map/features/reports/report-vessel-group/VesselGroupReportTitle.tsx
+++ b/apps/fishing-map/features/reports/report-vessel-group/VesselGroupReportTitle.tsx
@@ -10,12 +10,12 @@ import { Button, Icon } from '@globalfishingwatch/ui-components'
 import { useAppDispatch } from 'features/app/app.hooks'
 import { formatI18nDate } from 'features/i18n/i18nDate'
 import { formatI18nNumber } from 'features/i18n/i18nNumber'
+import { selectUserIsVesselGroupOwner } from 'features/reports/report-vessel-group/vessel-group-report.selectors'
 import VGRTitlePlaceholder from 'features/reports/shared/placeholders/VGRTitlePlaceholder'
 import {
   selectReportVesselGroupFlags,
   selectReportVesselGroupTimeRange,
 } from 'features/reports/shared/vessels/report-vessels.selectors'
-import { selectUserData } from 'features/user/selectors/user.selectors'
 // import { getEventLabel } from 'utils/analytics'
 // import { TrackCategory, trackEvent } from 'features/app/analytics.hooks'
 import DataTerminology from 'features/vessel/identity/DataTerminology'
@@ -25,6 +25,7 @@ import {
   setVesselGroupModalVessels,
   setVesselGroupsModalOpen,
 } from 'features/vessel-groups/vessel-groups-modal.slice'
+import LoginButtonWrapper from 'routes/LoginButtonWrapper'
 import { AsyncReducerStatus } from 'utils/async-slice'
 
 import { selectVGRData, selectVGRStatus } from './vessel-group-report.slice'
@@ -38,8 +39,7 @@ export default function VesselGroupReportTitle() {
   const reportStatus = useSelector(selectVGRStatus)
   const timeRange = useSelector(selectReportVesselGroupTimeRange)
   const flags = useSelector(selectReportVesselGroupFlags)
-  const userData = useSelector(selectUserData)
-  const userIsVesselGroupOwner = userData?.id === vesselGroup?.ownerId
+  const userIsVesselGroupOwner = useSelector(selectUserIsVesselGroupOwner)
   const loading = reportStatus === AsyncReducerStatus.Loading
 
   const onEditClick = useCallback(() => {
@@ -104,7 +104,7 @@ export default function VesselGroupReportTitle() {
         </a>
 
         <div className={styles.actions}>
-          {userIsVesselGroupOwner && (
+          <LoginButtonWrapper tooltip="">
             <Button
               type="border-secondary"
               size="small"
@@ -113,10 +113,11 @@ export default function VesselGroupReportTitle() {
               disabled={loading}
               tooltip={t('vesselGroup.edit')}
             >
-              <p>{t('common.edit')}</p>
+              {userIsVesselGroupOwner ? <p>{t('common.edit')}</p> : <p>{t('common.save')}</p>}
               <Icon icon="edit" type="default" />
             </Button>
-          )}
+          </LoginButtonWrapper>
+
           {/* <Button
             type="border-secondary"
             size="small"

--- a/apps/fishing-map/features/reports/report-vessel-group/vessel-group-report.selectors.ts
+++ b/apps/fishing-map/features/reports/report-vessel-group/vessel-group-report.selectors.ts
@@ -46,35 +46,59 @@ export const selectFetchVesselGroupReportFlagChangeParams =
   selectFetchVGRParamsByInsight(FLAG_CHANGE_INSIGHT_ID)
 export const selectFetchVesselGroupReportMOUParams = selectFetchVGRParamsByInsight(MOU_INSIGHT_ID)
 
-export const selectVGRInsightDataById = (
-  selector: (state: RootState) => VesselGroupInsightParams
-) => {
+export const selectVGRInsightById = (selector: (state: RootState) => VesselGroupInsightParams) => {
   return createSelector(
     [selectVesselGroupInsightApiSlice, selector],
     (vesselInsightApi, params) => {
-      return selectVesselGroupInsight(params)({ vesselInsightApi })?.data
+      return selectVesselGroupInsight(params)({ vesselInsightApi })
     }
   )
 }
 
-export const selectVGRGapInsightData = selectVGRInsightDataById(
-  selectFetchVesselGroupReportGapParams
-)
-export const selectVGRCoverageInsightData = selectVGRInsightDataById(
+export const selectVGRGapInsight = selectVGRInsightById(selectFetchVesselGroupReportGapParams)
+
+export const selectVGRGapInsightData = createSelector([selectVGRGapInsight], (gapInsight) => {
+  return gapInsight?.data
+})
+
+export const selectVGRCoverageInsight = selectVGRInsightById(
   selectFetchVesselGroupReportCoverageParams
 )
-export const selectVGRFishingInsightData = selectVGRInsightDataById(
+
+export const selectVGRCoverageInsightData = createSelector(
+  [selectVGRCoverageInsight],
+  (coverageInsight) => {
+    return coverageInsight?.data
+  }
+)
+export const selectVGRFishingInsight = selectVGRInsightById(
   selectFetchVesselGroupReportFishingParams
 )
-export const selectVGRIUUInsightData = selectVGRInsightDataById(
-  selectFetchVesselGroupReportIUUParams
+export const selectVGRFishingInsightData = createSelector(
+  [selectVGRFishingInsight],
+  (fishingInsight) => {
+    return fishingInsight?.data
+  }
 )
-export const selectVGRFlagChangeInsightData = selectVGRInsightDataById(
+export const selectVGRIUUInsight = selectVGRInsightById(selectFetchVesselGroupReportFishingParams)
+export const selectVGRIUUInsightData = createSelector([selectVGRIUUInsight], (iuuInsight) => {
+  return iuuInsight?.data
+})
+export const selectVGRFlagChangeInsight = selectVGRInsightById(
   selectFetchVesselGroupReportFlagChangeParams
 )
-export const selectVGRMOUInsightData = selectVGRInsightDataById(
-  selectFetchVesselGroupReportMOUParams
+export const selectVGRFlagChangeInsightData = createSelector(
+  [selectVGRFlagChangeInsight],
+  (flagChangeInsight) => {
+    return flagChangeInsight?.data
+  }
 )
+export const selectVGRMOUInsight = selectVGRInsightById(
+  selectFetchVesselGroupReportFlagChangeParams
+)
+export const selectVGRMOUInsightData = createSelector([selectVGRMOUInsight], (mouInsight) => {
+  return mouInsight?.data
+})
 
 export const selectUserIsVesselGroupOwner = createSelector(
   [selectUserData, selectVGRData],

--- a/apps/fishing-map/features/reports/report-vessel-group/vessel-group-report.selectors.ts
+++ b/apps/fishing-map/features/reports/report-vessel-group/vessel-group-report.selectors.ts
@@ -9,6 +9,8 @@ import type { RootState } from 'reducers'
 import type { InsightType } from '@globalfishingwatch/api-types'
 
 import { selectTimeRange } from 'features/app/selectors/app.timebar.selectors'
+import { selectVGRData } from 'features/reports/report-vessel-group/vessel-group-report.slice'
+import { selectUserData } from 'features/user/selectors/user.selectors'
 import { selectReportVesselGroupId } from 'routes/routes.selectors'
 
 export const COVERAGE_INSIGHT_ID = 'COVERAGE' as InsightType
@@ -72,4 +74,11 @@ export const selectVGRFlagChangeInsightData = selectVGRInsightDataById(
 )
 export const selectVGRMOUInsightData = selectVGRInsightDataById(
   selectFetchVesselGroupReportMOUParams
+)
+
+export const selectUserIsVesselGroupOwner = createSelector(
+  [selectUserData, selectVGRData],
+  (userData, vesselGroup) => {
+    return userData?.id === vesselGroup?.ownerId
+  }
 )

--- a/apps/fishing-map/features/reports/reports.selectors.ts
+++ b/apps/fishing-map/features/reports/reports.selectors.ts
@@ -96,15 +96,18 @@ export const selectReportCategory = createSelector(
 )
 
 export const selectReportUnit = createSelector(
-  [selectReportCategory],
-  (reportCategory): 'hour' | 'detection' | 'event' | '%' | undefined => {
+  [selectReportCategory, selectReportVesselsSubCategory],
+  (reportCategory, reportVesselsSubCategory): 'hour' | 'detection' | 'event' | '%' | undefined => {
     if (reportCategory === ReportCategory.Activity) {
       return 'hour'
     } else if (reportCategory === ReportCategory.Detections) {
       return 'detection'
     } else if (reportCategory === ReportCategory.Events) {
       return 'event'
-    } else if (reportCategory === ReportCategory.VesselGroupInsights) {
+    } else if (
+      (reportCategory === ReportCategory.VesselGroup && reportVesselsSubCategory === 'coverage') ||
+      reportCategory === ReportCategory.VesselGroupInsights
+    ) {
       // Used for VGR insights coverage graph
       return '%'
     }

--- a/apps/fishing-map/features/reports/reports.types.ts
+++ b/apps/fishing-map/features/reports/reports.types.ts
@@ -39,7 +39,7 @@ export type ReportDetectionsSubCategory =
   | `${DatasetSubCategory.Viirs}`
   | `${DatasetSubCategory.Sentinel2}`
 export type ReportEventsSubCategory = EventType
-export type ReportVesselsSubCategory = ReportVesselGraph | 'source'
+export type ReportVesselsSubCategory = ReportVesselGraph | 'source' | 'coverage'
 
 export type AnyReportSubCategory =
   | ReportActivitySubCategory

--- a/apps/fishing-map/features/reports/shared/vessels/ReportVessels.tsx
+++ b/apps/fishing-map/features/reports/shared/vessels/ReportVessels.tsx
@@ -6,6 +6,7 @@ import { selectReportVesselGraph } from 'features/reports/reports.selectors'
 import { type ReportVesselsSubCategory } from 'features/reports/reports.types'
 import ReportVesselsPlaceholder from 'features/reports/shared/placeholders/ReportVesselsPlaceholder'
 import type { ReportActivityUnit } from 'features/reports/tabs/activity/reports-activity.types'
+import VesselGroupReportInsightCoverage from 'features/reports/tabs/vessel-group-insights/VGRInsightCoverage'
 
 import {
   selectReportVesselsGraphAggregatedData,
@@ -48,13 +49,17 @@ function ReportVessels({
         <ReportVesselsPlaceholder showGraphHeader={false} />
       ) : (
         <Fragment>
-          <ReportVesselsGraph
-            data={aggregatedData!}
-            individualData={individualData}
-            aggregatedValueKey={valueKeys}
-            color={color}
-            property={property as ReportVesselsSubCategory}
-          />
+          {property === 'coverage' ? (
+            <VesselGroupReportInsightCoverage />
+          ) : (
+            <ReportVesselsGraph
+              data={aggregatedData!}
+              individualData={individualData}
+              aggregatedValueKey={valueKeys}
+              color={color}
+              property={property as ReportVesselsSubCategory}
+            />
+          )}
           <ReportVesselsFilter filter={filter} />
           <ReportVesselsTable
             activityUnit={activityUnit}

--- a/apps/fishing-map/features/reports/shared/vessels/ReportVessels.tsx
+++ b/apps/fishing-map/features/reports/shared/vessels/ReportVessels.tsx
@@ -34,7 +34,7 @@ function ReportVessels({
 }) {
   const aggregatedData = useSelector(selectReportVesselsGraphAggregatedData)
   const individualData = useSelector(selectReportVesselsGraphIndividualData)
-  const property = useSelector(selectReportVesselGraph)
+  const reportVesselGraph = useSelector(selectReportVesselGraph)
   const filter = useSelector(selectReportVesselFilter)
   const vessels = useSelector(selectReportVesselsPaginated)
   const valueKeys = useSelector(selectReportVesselsGraphDataKeys)
@@ -49,7 +49,7 @@ function ReportVessels({
         <ReportVesselsPlaceholder showGraphHeader={false} />
       ) : (
         <Fragment>
-          {property === 'coverage' ? (
+          {reportVesselGraph === 'coverage' ? (
             <VesselGroupReportInsightCoverage />
           ) : (
             <ReportVesselsGraph
@@ -57,7 +57,7 @@ function ReportVessels({
               individualData={individualData}
               aggregatedValueKey={valueKeys}
               color={color}
-              property={property as ReportVesselsSubCategory}
+              property={reportVesselGraph as ReportVesselsSubCategory}
             />
           )}
           <ReportVesselsFilter filter={filter} />

--- a/apps/fishing-map/features/reports/shared/vessels/ReportVesselsGraph.module.css
+++ b/apps/fishing-map/features/reports/shared/vessels/ReportVesselsGraph.module.css
@@ -51,4 +51,5 @@
   position: absolute;
   top: 6px;
   z-index: 10;
+  color: red;
 }

--- a/apps/fishing-map/features/reports/shared/vessels/ReportVesselsGraph.module.css
+++ b/apps/fishing-map/features/reports/shared/vessels/ReportVesselsGraph.module.css
@@ -51,5 +51,8 @@
   position: absolute;
   top: 6px;
   z-index: 10;
-  color: red;
+}
+
+.experimental {
+  color: var(--color-danger-red);
 }

--- a/apps/fishing-map/features/reports/shared/vessels/ReportVesselsGraph.tsx
+++ b/apps/fishing-map/features/reports/shared/vessels/ReportVesselsGraph.tsx
@@ -53,6 +53,7 @@ const FILTER_PROPERTIES: Record<ReportVesselGraph | ReportVesselsSubCategory, st
   [REPORT_VESSELS_GRAPH_GEARTYPE]: 'gear',
   [REPORT_VESSELS_GRAPH_VESSELTYPE]: 'type',
   source: 'source',
+  coverage: 'coverage',
 }
 
 const ReportBarTooltip = (props: any) => {

--- a/apps/fishing-map/features/reports/shared/vessels/ReportVesselsGraphSelector.tsx
+++ b/apps/fishing-map/features/reports/shared/vessels/ReportVesselsGraphSelector.tsx
@@ -76,6 +76,24 @@ function VesselGroupReportVesselsGraphSelector() {
             ),
             disabled: loading,
           },
+          {
+            id: 'coverage' as ReportVesselsSubCategory,
+            label: (
+              <span>
+                {t('analysis.groupByCoverage')}
+                {selectedOptionId === 'coverage' && (
+                  <DataTerminology
+                    size="tiny"
+                    type="default"
+                    title={t('vessel.insights.coverage')}
+                    terminologyKey="insightsCoverage"
+                    className={styles.dataTerminology}
+                  />
+                )}
+              </span>
+            ),
+            disabled: loading,
+          },
         ]
       : []),
   ]

--- a/apps/fishing-map/features/reports/shared/vessels/ReportVesselsGraphSelector.tsx
+++ b/apps/fishing-map/features/reports/shared/vessels/ReportVesselsGraphSelector.tsx
@@ -85,8 +85,14 @@ function VesselGroupReportVesselsGraphSelector() {
                   <DataTerminology
                     size="tiny"
                     type="default"
-                    title={t('vessel.insights.coverage')}
+                    title={
+                      <span>
+                        {t('vessel.insights.coverage')}
+                        <span className={styles.experimental}>(Experimental)</span>
+                      </span>
+                    }
                     terminologyKey="insightsCoverage"
+                    tooltip={t('common.experimental')}
                     className={styles.dataTerminology}
                   />
                 )}

--- a/apps/fishing-map/features/reports/shared/vessels/ReportVesselsGraphSelector.tsx
+++ b/apps/fishing-map/features/reports/shared/vessels/ReportVesselsGraphSelector.tsx
@@ -1,5 +1,6 @@
 import { useTranslation } from 'react-i18next'
 import { useSelector } from 'react-redux'
+import cx from 'classnames'
 
 import type { ChoiceOption } from '@globalfishingwatch/ui-components'
 import { Choice } from '@globalfishingwatch/ui-components'
@@ -93,7 +94,7 @@ function VesselGroupReportVesselsGraphSelector() {
                     }
                     terminologyKey="insightsCoverage"
                     tooltip={t('common.experimental')}
-                    className={styles.dataTerminology}
+                    className={cx(styles.dataTerminology, styles.experimental)}
                   />
                 )}
               </span>

--- a/apps/fishing-map/features/reports/shared/vessels/ReportVesselsIndividualTooltip.tsx
+++ b/apps/fishing-map/features/reports/shared/vessels/ReportVesselsIndividualTooltip.tsx
@@ -18,7 +18,7 @@ const ReportVesselsIndividualTooltip = ({ data }: { data?: ReportTableVessel }) 
     <div>
       <div className={styles.title}>
         <p className={styles.name}>{data.shipName}</p>
-        {data.value && (
+        {data.value && data.value !== -1 && (
           <p className={styles.value}>
             <I18nNumber number={data.value} />{' '}
             {reportUnit &&

--- a/apps/fishing-map/features/reports/shared/vessels/ReportVesselsTable.tsx
+++ b/apps/fishing-map/features/reports/shared/vessels/ReportVesselsTable.tsx
@@ -4,7 +4,7 @@ import { useSelector } from 'react-redux'
 import cx from 'classnames'
 
 import { VesselIdentitySourceEnum } from '@globalfishingwatch/api-types'
-import { IconButton } from '@globalfishingwatch/ui-components'
+import { IconButton, Spinner } from '@globalfishingwatch/ui-components'
 
 import { GLOBAL_VESSELS_DATASET_ID } from 'data/workspaces'
 import { TrackCategory, trackEvent } from 'features/app/analytics.hooks'
@@ -12,6 +12,7 @@ import DatasetLabel from 'features/datasets/DatasetLabel'
 import { getDatasetsReportNotSupported } from 'features/datasets/datasets.utils'
 import { selectActiveReportDataviews } from 'features/dataviews/selectors/dataviews.selectors'
 import I18nNumber from 'features/i18n/i18nNumber'
+import { selectVGRCoverageInsight } from 'features/reports/report-vessel-group/vessel-group-report.selectors'
 import { EMPTY_API_VALUES } from 'features/reports/reports.config'
 import {
   selectReportVesselsOrderDirection,
@@ -60,6 +61,7 @@ export default function ReportVesselsTable({
   const isAnyAreaReportLocation = useSelector(selectIsAnyAreaReportLocation)
   const reportCategory = useSelector(selectReportCategory)
   const orderDirection = useSelector(selectReportVesselsOrderDirection)
+  const vGRCoverageInsight = useSelector(selectVGRCoverageInsight)
   const datasetsDownloadNotSupported = getDatasetsReportNotSupported(
     dataviews,
     userData?.permissions || []
@@ -249,8 +251,13 @@ export default function ReportVesselsTable({
                 {activityUnit && (
                   <div className={cx({ [styles.border]: !isLastRow }, styles.right)}>
                     {values.length &&
-                      values.map((v) =>
-                        (activityUnit === 'coverage' ? v.value !== -1 : v.value !== undefined) ? (
+                      values.map((v) => {
+                        if (activityUnit === 'coverage' && vGRCoverageInsight?.isLoading) {
+                          return <Spinner key={id} size="tiny" />
+                        }
+                        return (
+                          activityUnit === 'coverage' ? v.value !== -1 : v.value !== undefined
+                        ) ? (
                           <Fragment key={v.value}>
                             {v.color && dataviews?.length > 1 && (
                               <span
@@ -266,7 +273,7 @@ export default function ReportVesselsTable({
                         ) : (
                           EMPTY_FIELD_PLACEHOLDER
                         )
-                      )}
+                      })}
                   </div>
                 )}
               </Fragment>

--- a/apps/fishing-map/features/reports/shared/vessels/ReportVesselsTable.tsx
+++ b/apps/fishing-map/features/reports/shared/vessels/ReportVesselsTable.tsx
@@ -148,7 +148,9 @@ export default function ReportVesselsTable({
                 ? t('common.hour_other')
                 : activityUnit === 'detection'
                   ? t('common.detection_other')
-                  : t('common.event_other')}
+                  : activityUnit === 'coverage'
+                    ? t('vessel.insights.coverage')
+                    : t('common.event_other')}
             </div>
           )}
           {vessels?.map((vessel, i) => {
@@ -246,7 +248,16 @@ export default function ReportVesselsTable({
                 </div>
                 {activityUnit && (
                   <div className={cx({ [styles.border]: !isLastRow }, styles.right)}>
-                    {values.length &&
+                    {activityUnit === 'coverage' ? (
+                      vessel.coverage !== -1 && vessel.coverage !== undefined ? (
+                        <span>
+                          <I18nNumber number={vessel.coverage} />%
+                        </span>
+                      ) : (
+                        EMPTY_FIELD_PLACEHOLDER
+                      )
+                    ) : (
+                      values.length &&
                       values.map((v) =>
                         v.value ? (
                           <Fragment key={v.value}>
@@ -263,7 +274,8 @@ export default function ReportVesselsTable({
                         ) : (
                           EMPTY_FIELD_PLACEHOLDER
                         )
-                      )}
+                      )
+                    )}
                   </div>
                 )}
               </Fragment>

--- a/apps/fishing-map/features/reports/shared/vessels/ReportVesselsTable.tsx
+++ b/apps/fishing-map/features/reports/shared/vessels/ReportVesselsTable.tsx
@@ -248,18 +248,9 @@ export default function ReportVesselsTable({
                 </div>
                 {activityUnit && (
                   <div className={cx({ [styles.border]: !isLastRow }, styles.right)}>
-                    {activityUnit === 'coverage' ? (
-                      vessel.coverage !== -1 && vessel.coverage !== undefined ? (
-                        <span>
-                          <I18nNumber number={vessel.coverage} />%
-                        </span>
-                      ) : (
-                        EMPTY_FIELD_PLACEHOLDER
-                      )
-                    ) : (
-                      values.length &&
+                    {values.length &&
                       values.map((v) =>
-                        v.value ? (
+                        (activityUnit === 'coverage' ? v.value !== -1 : v.value !== undefined) ? (
                           <Fragment key={v.value}>
                             {v.color && dataviews?.length > 1 && (
                               <span
@@ -269,13 +260,13 @@ export default function ReportVesselsTable({
                             )}
                             <span className={styles.value}>
                               <I18nNumber number={v.value} />
+                              {activityUnit === 'coverage' ? '%' : ''}
                             </span>
                           </Fragment>
                         ) : (
                           EMPTY_FIELD_PLACEHOLDER
                         )
-                      )
-                    )}
+                      )}
                   </div>
                 )}
               </Fragment>

--- a/apps/fishing-map/features/reports/shared/vessels/ReportVesselsTableFooter.tsx
+++ b/apps/fishing-map/features/reports/shared/vessels/ReportVesselsTableFooter.tsx
@@ -22,6 +22,7 @@ import {
   selectReportCategory,
   selectReportSubCategory,
   selectReportUnit,
+  selectReportVesselGraph,
 } from 'features/reports/reports.selectors'
 import { ReportCategory } from 'features/reports/reports.types'
 import VesselGroupAddButton from 'features/vessel-groups/VesselGroupAddButton'
@@ -53,6 +54,7 @@ export default function ReportVesselsTableFooter({ activityUnit }: ReportVessels
   const allFilteredVessels = useSelector(selectReportVesselsFiltered)
   const reportVesselFilter = useSelector(selectReportVesselFilter)
   const pagination = useSelector(selectReportVesselsPagination)
+  const reportVesselGraph = useSelector(selectReportVesselGraph)
   const { start, end } = useSelector(selectTimeRange)
 
   const vesselGroupVessels = useMemo(() => {
@@ -82,7 +84,8 @@ export default function ReportVesselsTableFooter({ activityUnit }: ReportVessels
           'GFW vessel type': vessel.vesselType,
           ...(extendedFields && { 'GFW gear type': vessel.geartype }),
           ...(activityUnit && {
-            [`Total ${reportSubCategory} ${reportUnit}s`]: vessel.value,
+            [`Total ${reportSubCategory} ${reportUnit}s`]:
+              reportVesselGraph === 'coverage' && vessel.value !== -1 ? vessel.value : undefined,
           }),
           vesselId: vessel.id,
           dataset: vessel.datasetId,

--- a/apps/fishing-map/features/reports/shared/vessels/report-vessels.selectors.ts
+++ b/apps/fishing-map/features/reports/shared/vessels/report-vessels.selectors.ts
@@ -122,11 +122,10 @@ export const selectReportVessels = createSelector(
         const coverage =
           coverages && coverages.length
             ? weightedMean(
-                coverages.flatMap((d) => d.percentage || []),
-                coverages.flatMap((d) => parseInt(d.blocks) || [])
+                coverages.flatMap((d) => d.percentage ?? []),
+                coverages.flatMap((d) => parseInt(d.blocks) ?? [])
               )
             : -1
-
         const { shipname, ...vesselData } = getSearchIdentityResolved(identity!)
         const source = getVesselSource(identity)
         const vesselType = getVesselShipTypeLabel(vesselData) || EMPTY_FIELD_PLACEHOLDER

--- a/apps/fishing-map/features/reports/shared/vessels/report-vessels.selectors.ts
+++ b/apps/fishing-map/features/reports/shared/vessels/report-vessels.selectors.ts
@@ -142,7 +142,7 @@ export const selectReportVessels = createSelector(
           shipName: formatInfoField(shipname, 'shipname') as string,
           vesselType,
           geartype,
-          coverage,
+          value: coverage,
           coverageBucket: parseCoverageGraphValueBucket(coverage),
           ssvid: getVesselProperty(identity, 'ssvid', {
             identitySource: VesselIdentitySourceEnum.SelfReported,
@@ -277,14 +277,13 @@ export const selectReportVesselsOrdered = createSelector(
     selectReportVesselsFiltered,
     selectReportVesselsOrderProperty,
     selectReportVesselsOrderDirection,
-    selectReportVesselGraph,
   ],
-  (vessels, property, direction, reportVesselGraph) => {
+  (vessels, property, direction) => {
     if (!vessels?.length) return []
     return vessels.toSorted((a, b) => {
       // First compare by value
-      const valueA = reportVesselGraph === 'coverage' ? a.coverage || 0 : a.value || 0
-      const valueB = reportVesselGraph === 'coverage' ? b.coverage || 0 : b.value || 0
+      const valueA = a.value || 0
+      const valueB = b.value || 0
       if (valueA !== valueB) {
         return valueB - valueA
       }

--- a/apps/fishing-map/features/reports/shared/vessels/report-vessels.selectors.ts
+++ b/apps/fishing-map/features/reports/shared/vessels/report-vessels.selectors.ts
@@ -13,6 +13,7 @@ import {
   selectReportDataviewsWithPermissions,
 } from 'features/reports/report-area/area-reports.selectors'
 import { getVesselsFiltered } from 'features/reports/report-area/area-reports.utils'
+import { selectVGRCoverageInsightData } from 'features/reports/report-vessel-group/vessel-group-report.selectors'
 import {
   selectReportVesselFilter,
   selectReportVesselPage,
@@ -28,6 +29,7 @@ import {
 } from 'features/reports/shared/utils/reports.utils'
 import { REPORT_FILTER_PROPERTIES } from 'features/reports/shared/vessels/report-vessels.config'
 import { selectReportVesselsList } from 'features/reports/tabs/activity/vessels/report-activity-vessels.selectors'
+import { parseCoverageGraphValueBucket } from 'features/reports/tabs/vessel-group-insights/vessel-group-report-insights.utils'
 import { getSearchIdentityResolved, getVesselProperty } from 'features/vessel/vessel.utils'
 import { getVesselGroupUniqVessels } from 'features/vessel-groups/vessel-groups.utils'
 import type { VesselGroupVesselIdentity } from 'features/vessel-groups/vessel-groups-modal.slice'
@@ -38,6 +40,7 @@ import {
   getVesselGearTypeLabel,
   getVesselShipTypeLabel,
 } from 'utils/info'
+import { weightedMean } from 'utils/statistics'
 
 import { selectVGRVessels } from '../../report-vessel-group/vessel-group-report.slice'
 import { selectEventsVessels } from '../../tabs/events/events-report.selectors'
@@ -103,8 +106,8 @@ export const selectReportVesselsByCategory = createSelector(
 )
 
 export const selectReportVessels = createSelector(
-  [selectReportVesselsByCategory],
-  (vessels): ReportTableVessel[] | null => {
+  [selectReportVesselsByCategory, selectVGRCoverageInsightData],
+  (vessels, coverageInsightData): ReportTableVessel[] | null => {
     if (!vessels?.length) {
       return null
     }
@@ -113,6 +116,17 @@ export const selectReportVessels = createSelector(
       // Vessels have identity when coming from events or vessel groups
       if (identity) {
         const reportVessel = vessel as VesselGroupVessel
+        const coverages = coverageInsightData?.coverage?.filter(
+          (d) => d.vesselId === reportVessel.vesselId || d.vesselId === reportVessel.relationId
+        )
+        const coverage =
+          coverages && coverages.length
+            ? weightedMean(
+                coverages.flatMap((d) => d.percentage || []),
+                coverages.flatMap((d) => parseInt(d.blocks) || [])
+              )
+            : -1
+
         const { shipname, ...vesselData } = getSearchIdentityResolved(identity!)
         const source = getVesselSource(identity)
         const vesselType = getVesselShipTypeLabel(vesselData) || EMPTY_FIELD_PLACEHOLDER
@@ -129,6 +143,8 @@ export const selectReportVessels = createSelector(
           shipName: formatInfoField(shipname, 'shipname') as string,
           vesselType,
           geartype,
+          coverage,
+          coverageBucket: parseCoverageGraphValueBucket(coverage),
           ssvid: getVesselProperty(identity, 'ssvid', {
             identitySource: VesselIdentitySourceEnum.SelfReported,
           }),

--- a/apps/fishing-map/features/reports/shared/vessels/report-vessels.selectors.ts
+++ b/apps/fishing-map/features/reports/shared/vessels/report-vessels.selectors.ts
@@ -277,14 +277,14 @@ export const selectReportVesselsOrdered = createSelector(
     selectReportVesselsFiltered,
     selectReportVesselsOrderProperty,
     selectReportVesselsOrderDirection,
+    selectReportVesselGraph,
   ],
-  (vessels, property, direction) => {
+  (vessels, property, direction, reportVesselGraph) => {
     if (!vessels?.length) return []
-
     return vessels.toSorted((a, b) => {
       // First compare by value
-      const valueA = a.value || 0
-      const valueB = b.value || 0
+      const valueA = reportVesselGraph === 'coverage' ? a.coverage || 0 : a.value || 0
+      const valueB = reportVesselGraph === 'coverage' ? b.coverage || 0 : b.value || 0
       if (valueA !== valueB) {
         return valueB - valueA
       }

--- a/apps/fishing-map/features/reports/shared/vessels/report-vessels.types.ts
+++ b/apps/fishing-map/features/reports/shared/vessels/report-vessels.types.ts
@@ -28,6 +28,5 @@ export type ReportTableVessel = {
   // so we merge the properties and keep the individual values
   values?: ReportVesselValues
   // Only available for vessels group vessels when tab is coverage insight to avoid overloading the api
-  coverage?: number
   coverageBucket?: string
 }

--- a/apps/fishing-map/features/reports/shared/vessels/report-vessels.types.ts
+++ b/apps/fishing-map/features/reports/shared/vessels/report-vessels.types.ts
@@ -27,4 +27,7 @@ export type ReportTableVessel = {
   // In some cases the vessel can be duplicated,
   // so we merge the properties and keep the individual values
   values?: ReportVesselValues
+  // Only available for vessels group vessels when tab is coverage insight to avoid overloading the api
+  coverage?: number
+  coverageBucket?: string
 }

--- a/apps/fishing-map/features/reports/tabs/activity/reports-activity.types.ts
+++ b/apps/fishing-map/features/reports/tabs/activity/reports-activity.types.ts
@@ -5,4 +5,4 @@ export type ReportTimeComparisonValues = {
   compareEnd: string
 }
 
-export type ReportActivityUnit = 'hour' | 'detection' | 'numEvents'
+export type ReportActivityUnit = 'hour' | 'detection' | 'numEvents' | 'coverage'

--- a/apps/fishing-map/features/reports/tabs/vessel-group-insights/VGRInsightCoverage.tsx
+++ b/apps/fishing-map/features/reports/tabs/vessel-group-insights/VGRInsightCoverage.tsx
@@ -22,12 +22,6 @@ const VesselGroupReportInsightCoverage = ({ skip }: { skip?: boolean }) => {
 
   return (
     <div id="vessel-group-coverage" className={styles.insightContainer}>
-      <div className={styles.insightTitle}>
-        <Tooltip content={t('common.experimentalTooltip')}>
-          <label className="experimental">{t('vessel.insights.coverage')}</label>
-        </Tooltip>
-        <DataTerminology title={t('vessel.insights.coverage')} terminologyKey="insightsCoverage" />
-      </div>
       {skip || isLoading ? (
         <ReportBarGraphPlaceholder numberOfElements={5} />
       ) : error ? (

--- a/apps/fishing-map/features/reports/tabs/vessel-group-insights/VGRInsightCoverage.tsx
+++ b/apps/fishing-map/features/reports/tabs/vessel-group-insights/VGRInsightCoverage.tsx
@@ -1,13 +1,13 @@
+import { Fragment } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useSelector } from 'react-redux'
 import { useGetVesselGroupInsightQuery } from 'queries/vessel-insight-api'
 
 import type { ParsedAPIError } from '@globalfishingwatch/api-client'
-import { Tooltip } from '@globalfishingwatch/ui-components'
+import { Icon } from '@globalfishingwatch/ui-components'
 
 import { ReportBarGraphPlaceholder } from 'features/reports/shared/placeholders/ReportBarGraphPlaceholder'
-import DataTerminology from 'features/vessel/identity/DataTerminology'
-import InsightError from 'features/vessel/insights/InsightErrorMessage'
+import { selectReportVesselsFiltered } from 'features/reports/shared/vessels/report-vessels.selectors'
 
 import { selectFetchVesselGroupReportCoverageParams } from '../../report-vessel-group/vessel-group-report.selectors'
 
@@ -19,15 +19,35 @@ const VesselGroupReportInsightCoverage = ({ skip }: { skip?: boolean }) => {
   const { t } = useTranslation()
   const fetchParams = useSelector(selectFetchVesselGroupReportCoverageParams)
   const { data, error, isLoading } = useGetVesselGroupInsightQuery(fetchParams, { skip })
+  const vessels = useSelector(selectReportVesselsFiltered)
 
   return (
     <div id="vessel-group-coverage" className={styles.insightContainer}>
-      {skip || isLoading ? (
-        <ReportBarGraphPlaceholder numberOfElements={5} />
-      ) : error ? (
-        <InsightError error={error as ParsedAPIError} />
+      {skip || isLoading || error ? (
+        <ReportBarGraphPlaceholder numberOfElements={6} animate={false}>
+          <Fragment>
+            {(error as ParsedAPIError)?.status === 403 && (
+              <Icon
+                icon="private"
+                tooltip={t(
+                  'vessel.insights.errorPermisions',
+                  "You don't have permissions to see this insight"
+                )}
+              />
+            )}
+            {error && t('analysis.error')}
+          </Fragment>
+        </ReportBarGraphPlaceholder>
       ) : data?.coverage && data?.coverage?.length > 0 ? (
-        <VesselGroupReportInsightCoverageGraph data={data.coverage} />
+        <Fragment>
+          {vessels?.length && vessels?.length > 0 ? (
+            <VesselGroupReportInsightCoverageGraph data={vessels} />
+          ) : (
+            <ReportBarGraphPlaceholder numberOfElements={6} animate={false}>
+              {t('analysis.noVesselDataFiltered')}
+            </ReportBarGraphPlaceholder>
+          )}
+        </Fragment>
       ) : null}
     </div>
   )

--- a/apps/fishing-map/features/reports/tabs/vessel-group-insights/VGRInsightCoverageGraph.module.css
+++ b/apps/fishing-map/features/reports/tabs/vessel-group-insights/VGRInsightCoverageGraph.module.css
@@ -40,20 +40,25 @@
 
 .graph :global(.recharts-bar-rectangle):nth-child(1),
 .graph foreignObject > div > div:nth-child(1) ul {
-  opacity: 0.3;
+  opacity: 0.2;
 }
 
 .graph :global(.recharts-bar-rectangle):nth-child(2),
 .graph foreignObject > div > div:nth-child(2) ul {
-  opacity: 0.5;
+  opacity: 0.4;
 }
 
 .graph :global(.recharts-bar-rectangle):nth-child(3),
 .graph foreignObject > div > div:nth-child(3) ul {
-  opacity: 0.7;
+  opacity: 0.5;
 }
 
 .graph :global(.recharts-bar-rectangle):nth-child(4),
 .graph foreignObject > div > div:nth-child(4) ul {
+  opacity: 0.7;
+}
+
+.graph :global(.recharts-bar-rectangle):nth-child(5),
+.graph foreignObject > div > div:nth-child(5) ul {
   opacity: 0.85;
 }

--- a/apps/fishing-map/features/reports/tabs/vessel-group-insights/VGRInsights.tsx
+++ b/apps/fishing-map/features/reports/tabs/vessel-group-insights/VGRInsights.tsx
@@ -2,7 +2,7 @@ import { useTranslation } from 'react-i18next'
 import { useSelector } from 'react-redux'
 import { DateTime } from 'luxon'
 
-import { Icon, Spinner } from '@globalfishingwatch/ui-components'
+import { Icon } from '@globalfishingwatch/ui-components'
 
 import { selectTimeRange } from 'features/app/selectors/app.timebar.selectors'
 import { selectVesselsDatasets } from 'features/datasets/datasets.selectors'
@@ -12,7 +12,6 @@ import { selectVGRVesselDatasetsWithoutEventsRelated } from 'features/reports/sh
 import DataTerminology from 'features/vessel/identity/DataTerminology'
 import { MIN_INSIGHTS_YEAR } from 'features/vessel/insights/insights.config'
 
-import VesselGroupReportInsightCoverage from './VGRInsightCoverage'
 import VesselGroupReportInsightFishing from './VGRInsightFishing'
 import VesselGroupReportInsightFlagChange from './VGRInsightFlagChange'
 import VesselGroupReportInsightGap from './VGRInsightGaps'

--- a/apps/fishing-map/features/reports/tabs/vessel-group-insights/VGRInsights.tsx
+++ b/apps/fishing-map/features/reports/tabs/vessel-group-insights/VGRInsights.tsx
@@ -65,7 +65,6 @@ const VesselGroupReportInsights = () => {
           terminologyKey="insightsVesselGroups"
         />
       </p>
-      <VesselGroupReportInsightCoverage skip={!vesselDatasets.length} />
       <VesselGroupReportInsightGap skip={!vesselDatasets.length} />
       <VesselGroupReportInsightFishing skip={!vesselDatasets.length} />
       <VesselGroupReportInsightIUU skip={!vesselDatasets.length} />

--- a/apps/fishing-map/features/reports/tabs/vessel-group-insights/vessel-group-report-insights.utils.ts
+++ b/apps/fishing-map/features/reports/tabs/vessel-group-insights/vessel-group-report-insights.utils.ts
@@ -1,0 +1,20 @@
+export const COVERAGE_GRAPH_BUCKETS: Record<string, number> = {
+  unknown: -1,
+  '≤20%': 20,
+  '21-40%': 40,
+  '41-60%': 60,
+  '61-80%': 80,
+  '≥81%': 100,
+}
+
+export const CoverageGraphBuckets = Object.keys(COVERAGE_GRAPH_BUCKETS)
+
+export function parseCoverageGraphValueBucket(value: number) {
+  if (value === -1) {
+    return 'unknown'
+  }
+  return (
+    CoverageGraphBuckets.find((key) => value < COVERAGE_GRAPH_BUCKETS[key]) ||
+    CoverageGraphBuckets[CoverageGraphBuckets.length - 1]
+  )
+}

--- a/apps/fishing-map/features/reports/tabs/vessel-group-insights/vessel-group-report-insights.utils.ts
+++ b/apps/fishing-map/features/reports/tabs/vessel-group-insights/vessel-group-report-insights.utils.ts
@@ -1,5 +1,7 @@
+import { EMPTY_FIELD_PLACEHOLDER } from 'utils/info'
+
 export const COVERAGE_GRAPH_BUCKETS: Record<string, number> = {
-  unknown: -1,
+  [EMPTY_FIELD_PLACEHOLDER]: -1,
   '≤20%': 20,
   '21-40%': 40,
   '41-60%': 60,
@@ -11,7 +13,7 @@ export const CoverageGraphBuckets = Object.keys(COVERAGE_GRAPH_BUCKETS)
 
 export function parseCoverageGraphValueBucket(value: number) {
   if (value === -1) {
-    return 'unknown'
+    return EMPTY_FIELD_PLACEHOLDER
   }
   return (
     CoverageGraphBuckets.find((key) => value < COVERAGE_GRAPH_BUCKETS[key]) ||

--- a/apps/fishing-map/features/vessel-groups/VesselGroupModal.module.css
+++ b/apps/fishing-map/features/vessel-groups/VesselGroupModal.module.css
@@ -136,6 +136,14 @@
   border-bottom: var(--border);
 }
 
+.vesselsTable tr.noBorderBottom td {
+  border-bottom: none;
+}
+
+.vesselsTable tr.noBorderTop td {
+  border-top: none;
+}
+
 .vesselsTable tr.border:not(:last-child) td {
   border-bottom: 1px solid var(--color-secondary-blue);
 }

--- a/apps/fishing-map/features/vessel-groups/VesselGroupModal.module.css
+++ b/apps/fishing-map/features/vessel-groups/VesselGroupModal.module.css
@@ -170,3 +170,9 @@
   justify-content: flex-end;
   margin-right: 0;
 }
+
+.searchLinkText {
+  display: flex;
+  align-items: center;
+  gap: var(--space-S);
+}

--- a/apps/fishing-map/features/vessel-groups/VesselGroupModal.tsx
+++ b/apps/fishing-map/features/vessel-groups/VesselGroupModal.tsx
@@ -454,13 +454,10 @@ function VesselGroupModal(): React.ReactElement<any> {
           )}
           {editingVesselGroup && hasVesselGroupsVessels && (
             <p className={styles.searchLink}>
-              {t('vesselGroup.searchLink')}
-              <IconButton
-                size="small"
-                icon="external-link"
-                className={styles.link}
-                onClick={onSearchClick}
-              />
+              <span className={styles.searchLinkText}>
+                {t('vesselGroup.searchLink')}
+                <IconButton size="small" icon="search" type="border" onClick={onSearchClick} />
+              </span>
             </p>
           )}
         </div>

--- a/apps/fishing-map/features/vessel-groups/VesselGroupModal.tsx
+++ b/apps/fishing-map/features/vessel-groups/VesselGroupModal.tsx
@@ -25,6 +25,7 @@ import { selectVesselsDataviews } from 'features/dataviews/selectors/dataviews.i
 import UserGuideLink from 'features/help/UserGuideLink'
 import { getPlaceholderBySelections } from 'features/i18n/utils'
 import { getVesselGroupDataviewInstance } from 'features/reports/report-vessel-group/vessel-group-report.dataviews'
+import { selectUserIsVesselGroupOwner } from 'features/reports/report-vessel-group/vessel-group-report.selectors'
 import {
   fetchVesselGroupReportThunk,
   resetVesselGroupReportData,
@@ -48,10 +49,10 @@ import {
 } from 'features/workspace/workspace.hook'
 import { selectWorkspace } from 'features/workspace/workspace.selectors'
 import { setWorkspaceSuggestSave } from 'features/workspace/workspace.slice'
-import { type ROUTE_TYPES, SEARCH, WORKSPACE_SEARCH } from 'routes/routes'
+import { type ROUTE_TYPES, SEARCH, VESSEL_GROUP_REPORT, WORKSPACE_SEARCH } from 'routes/routes'
 import { updateLocation } from 'routes/routes.actions'
 import { useLocationConnect } from 'routes/routes.hook'
-import { selectIsVesselGroupReportLocation } from 'routes/routes.selectors'
+import { selectIsVesselGroupReportLocation, selectLocationQuery } from 'routes/routes.selectors'
 import { getEventLabel } from 'utils/analytics'
 import { AsyncReducerStatus } from 'utils/async-slice'
 
@@ -101,6 +102,7 @@ function VesselGroupModal(): React.ReactElement<any> {
   const confirmationMode = useSelector(selectVesselGroupConfirmationMode)
   const searchIdField = useSelector(selectVesselGroupModalSearchIdField)
   const editingVesselGroupId = useSelector(selectVesselGroupEditId)
+  const userIsVesselGroupOwner = useSelector(selectUserIsVesselGroupOwner)
   const vesselGroupVesselsToSearch = useSelector(selectVesselGroupsModalSearchIds)
   const editingVesselGroup = useSelector(selectVesselGroupById(editingVesselGroupId as string))
   const searchVesselStatus = useSelector(selectVesselGroupSearchStatus)
@@ -126,6 +128,7 @@ function VesselGroupModal(): React.ReactElement<any> {
   const isVesselGroupReportLocation = useSelector(selectIsVesselGroupReportLocation)
   const hasVesselGroupsVessels = useSelector(selectHasVesselGroupSearchVessels)
   const vesselGroupsInWorkspace = useSelector(selectWorkspaceVessselGroupsIds)
+  const query = useSelector(selectLocationQuery)
   const datasetsWithoutRelatedEvents = useSelector(
     selectVesselGroupModalDatasetsWithoutEventsRelated
   )
@@ -251,7 +254,7 @@ function VesselGroupModal(): React.ReactElement<any> {
       setButtonLoading(navigateToWorkspace ? 'saveAndSeeInWorkspace' : 'save')
       const vessels: VesselGroupVessel[] = getVesselGroupUniqVessels(vesselGroupVessels)
       let dispatchedAction
-      if (editingVesselGroupId) {
+      if (editingVesselGroupId && userIsVesselGroupOwner) {
         const vesselGroup: UpdateVesselGroupThunkParams = {
           id: editingVesselGroupId,
           name: groupName,
@@ -279,7 +282,19 @@ function VesselGroupModal(): React.ReactElement<any> {
         const dataviewInstance = !isVesselGroupInWorkspace
           ? getVesselGroupDataviewInstance(vesselGroupId)
           : undefined
-        if (navigateToWorkspace && dataviewInstance) {
+
+        if (isVesselGroupReportLocation && vesselGroupId !== editingVesselGroupId) {
+          dispatch(
+            updateLocation(VESSEL_GROUP_REPORT, {
+              payload: {
+                category: workspace?.category,
+                workspaceId: workspace?.id,
+                vesselGroupId: vesselGroupId,
+              },
+              query,
+            })
+          )
+        } else if (navigateToWorkspace && dataviewInstance) {
           if (workspaceToNavigate) {
             const { type, ...rest } = workspaceToNavigate
             const { query, payload } = rest
@@ -331,12 +346,16 @@ function VesselGroupModal(): React.ReactElement<any> {
     [
       vesselGroupVessels,
       editingVesselGroupId,
+      userIsVesselGroupOwner,
       groupName,
       dispatch,
       createAsPublic,
       vesselGroupsInWorkspace,
       isVesselGroupReportLocation,
       close,
+      workspace?.category,
+      workspace?.id,
+      query,
       workspaceToNavigate,
       searchQuery,
       upsertDataviewInstance,

--- a/apps/fishing-map/features/vessel-groups/vessel-groups.utils.ts
+++ b/apps/fishing-map/features/vessel-groups/vessel-groups.utils.ts
@@ -1,4 +1,4 @@
-import { uniq, uniqBy } from 'es-toolkit'
+import { groupBy, uniq, uniqBy } from 'es-toolkit'
 
 import type { IdentityVessel, VesselGroup, VesselGroupVessel } from '@globalfishingwatch/api-types'
 import { SelfReportedSource, VesselIdentitySourceEnum } from '@globalfishingwatch/api-types'
@@ -59,6 +59,19 @@ export const getVesselGroupUniqVessels = (
     }),
     (v) => v.vesselId
   )
+}
+
+export const groupVesselGroupVessels = (
+  vessels: VesselGroupVesselIdentity[] | null,
+  { property = 'ssvid' } = {} as { property: 'imo' | 'ssvid' }
+): Record<string, VesselGroupVesselIdentity[]> => {
+  if (!vessels) {
+    return {} as Record<string, VesselGroupVesselIdentity[]>
+  }
+  return groupBy(vessels, (vessel) => {
+    const propertyValue = getVesselProperty(vessel.identity!, property)
+    return propertyValue || vessel.vesselId
+  })
 }
 
 export const mergeVesselGroupVesselIdentities = (

--- a/apps/fishing-map/features/vessel/identity/DataTerminology.module.css
+++ b/apps/fishing-map/features/vessel/identity/DataTerminology.module.css
@@ -78,3 +78,14 @@
 .content > *:nth-last-child(1) {
   padding-bottom: var(--space-XL);
 }
+
+.flex {
+  display: flex;
+  align-items: center;
+  gap: var(--space-XS);
+}
+
+.experimental {
+  color: red;
+  font: var(--font-XS);
+}

--- a/apps/fishing-map/features/vessel/identity/DataTerminology.tsx
+++ b/apps/fishing-map/features/vessel/identity/DataTerminology.tsx
@@ -5,7 +5,7 @@ import cx from 'classnames'
 import htmlParse from 'html-react-parser'
 
 import type { IconButtonSize, IconButtonType } from '@globalfishingwatch/ui-components'
-import { Icon, Modal, Spinner } from '@globalfishingwatch/ui-components'
+import { Icon, Modal, Spinner, Tooltip } from '@globalfishingwatch/ui-components'
 
 import { TrackCategory, trackEvent } from 'features/app/analytics.hooks'
 import { selectDebugOptions } from 'features/debug/debug.slice'
@@ -18,10 +18,11 @@ import styles from './DataTerminology.module.css'
 interface ModalProps {
   containerClassName?: string
   className?: string
-  title?: string
+  title?: string | React.ReactNode
   size?: IconButtonSize
   type?: IconButtonType
   terminologyKey: keyof I18nNamespaces['data-terminology']
+  tooltip?: string
 }
 
 const DataTerminology: React.FC<ModalProps> = ({
@@ -29,6 +30,7 @@ const DataTerminology: React.FC<ModalProps> = ({
   className,
   containerClassName,
   title,
+  tooltip,
 }): React.ReactElement<any> => {
   const { t } = useTranslation(['translations', 'data-terminology'])
   const [showModal, setShowModal] = useState(false)
@@ -51,9 +53,11 @@ const DataTerminology: React.FC<ModalProps> = ({
 
   return (
     <Fragment>
-      <span role="button" onClick={onClick} tabIndex={0}>
-        <Icon icon="info" className={cx(styles.infoButton, className)} />
-      </span>
+      <Tooltip content={tooltip}>
+        <span role="button" onClick={onClick} tabIndex={0}>
+          <Icon icon="info" className={cx(styles.infoButton, className)} />
+        </span>
+      </Tooltip>
       <Modal
         appSelector="__next"
         isOpen={showModal}


### PR DESCRIPTION
[Vessel group updates](https://dev-ui-fishing-map-vessel-groups-updates-706952489382.us-central1.run.app/):
- Allow users to copy other user vessel group 
- Group vessel group edit vessels modal by its ssvid
- Move coverage to the vessels tab
- Other tweaks