### PR TITLE
api-client/fix memory refresh token

### DIFF
--- a/apps/api-portal/features/user/user.ts
+++ b/apps/api-portal/features/user/user.ts
@@ -35,8 +35,8 @@ const logoutUser = async () => {
 export const useUser = () => {
   const accessToken = typeof window === 'undefined' ? null : getAccessTokenFromUrl()
   const queryResult = useQuery(['user'], () => fetchUser(accessToken), {})
-  const token = GFWAPI.getToken()
-  const refreshToken = GFWAPI.getRefreshToken()
+  const token = GFWAPI.token
+  const refreshToken = GFWAPI.refreshToken
   const { data: user } = queryResult
 
   const authorized = useMemo(() => {

--- a/apps/fishing-map/features/map/map-layers.hooks.ts
+++ b/apps/fishing-map/features/map/map-layers.hooks.ts
@@ -184,7 +184,7 @@ export const useGlobalConfigConnect = () => {
       start,
       end,
       debug,
-      token: GFWAPI.getToken(),
+      token: GFWAPI.token,
       bivariateDataviews,
       activityVisualizationMode,
       detectionsVisualizationMode,

--- a/apps/port-labeler/features/map/Map.tsx
+++ b/apps/port-labeler/features/map/Map.tsx
@@ -31,7 +31,7 @@ const transformRequest: (...args: any[]) => RequestParameters = (
   const response: RequestParameters = { url }
   if (resourceType === 'Tile' && url.includes('globalfishingwatch')) {
     response.headers = {
-      Authorization: 'Bearer ' + GFWAPI.getToken(),
+      Authorization: 'Bearer ' + GFWAPI.token,
     }
   }
   return response

--- a/apps/real-time-prototype/features/map/Map.tsx
+++ b/apps/real-time-prototype/features/map/Map.tsx
@@ -46,10 +46,10 @@ const MapWrapper = ({ lastUpdate, showLatestPositions }): React.ReactElement<any
   const deckRef = useRef<DeckGLRef>(null)
   const basemapLayer = useBasemapLayer()
   const contextLayer = useContextsLayer()
-  const tracksLayer = useTracksLayer({ token: GFWAPI.getToken(), lastUpdate })
+  const tracksLayer = useTracksLayer({ token: GFWAPI.token, lastUpdate })
   const { addTrackSublayer, sublayers } = useTracksSublayers()
   const latestPositionsLayer = useLatestPositionsLayer({
-    token: GFWAPI.getToken(),
+    token: GFWAPI.token,
     lastUpdate,
     vessels: sublayers,
     showLatestPositions,
@@ -70,7 +70,7 @@ const MapWrapper = ({ lastUpdate, showLatestPositions }): React.ReactElement<any
               fetch: {
                 method: 'GET',
                 headers: {
-                  Authorization: `Bearer ${GFWAPI.getToken()}`,
+                  Authorization: `Bearer ${GFWAPI.token}`,
                 },
               },
             },
@@ -101,7 +101,7 @@ const MapWrapper = ({ lastUpdate, showLatestPositions }): React.ReactElement<any
             fetch: {
               method: 'GET',
               headers: {
-                Authorization: `Bearer ${GFWAPI.getToken()}`,
+                Authorization: `Bearer ${GFWAPI.token}`,
               },
             },
           },

--- a/apps/track-labeler/src/features/user/user.slice.ts
+++ b/apps/track-labeler/src/features/user/user.slice.ts
@@ -1,9 +1,9 @@
 import type { PayloadAction } from '@reduxjs/toolkit'
-import { createSelector,createSlice } from '@reduxjs/toolkit'
+import { createSelector, createSlice } from '@reduxjs/toolkit'
 import { jwtDecode } from 'jwt-decode'
 import { redirect } from 'redux-first-router'
 
-import { getAccessTokenFromUrl,GFWAPI } from '@globalfishingwatch/api-client'
+import { getAccessTokenFromUrl, GFWAPI } from '@globalfishingwatch/api-client'
 import type { UserData } from '@globalfishingwatch/api-types'
 
 import { DEFAULT_TOKEN_EXPIRATION } from '../../data/config'
@@ -54,7 +54,7 @@ export const counterSlice = createSlice({
       state.resolved = true
       state.logged = true
       const defaultExpiration = (new Date().getTime() + 1000 * 60 * DEFAULT_TOKEN_EXPIRATION) / 1000
-      const { exp = defaultExpiration } = jwtDecode<UserToken>(GFWAPI.getToken())
+      const { exp = defaultExpiration } = jwtDecode<UserToken>(GFWAPI.token)
       state.tokenExpirationTimestamp = exp * 1000
       state.data = action.payload
     },

--- a/libs/api-client/package.json
+++ b/libs/api-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@globalfishingwatch/api-client",
-  "version": "6.0.5",
+  "version": "7.0.0",
   "description": "",
   "author": "satellitestudio <contact@satellitestud.io>",
   "homepage": "https://github.com/GlobalFishingWatch/frontend#readme",

--- a/libs/dataviews-client/package.json
+++ b/libs/dataviews-client/package.json
@@ -11,7 +11,7 @@
     "url": "git+https://github.com/GlobalFishingWatch/frontend.git"
   },
   "dependencies": {
-    "@globalfishingwatch/api-client": "^6.0.5",
+    "@globalfishingwatch/api-client": "^7.0.0",
     "@globalfishingwatch/api-types": "^8.0.3",
     "@globalfishingwatch/data-transforms": "^3.0.5",
     "@globalfishingwatch/datasets-client": "^3.0.3",

--- a/libs/deck-layer-composer/package.json
+++ b/libs/deck-layer-composer/package.json
@@ -4,7 +4,7 @@
   "main": "./index.cjs",
   "module": "./index.js",
   "dependencies": {
-    "@globalfishingwatch/api-client": "^6.0.5",
+    "@globalfishingwatch/api-client": "^7.0.0",
     "@globalfishingwatch/api-types": "^8.0.3",
     "@globalfishingwatch/deck-layers": "^0.1.7",
     "@globalfishingwatch/dataviews-client": "^16.x",

--- a/libs/deck-layers/package.json
+++ b/libs/deck-layers/package.json
@@ -13,7 +13,7 @@
     "@deck.gl/mesh-layers": "^9.0.35",
     "@deck.gl/react": "^9.0.35",
     "@math.gl/core": "4.x",
-    "@globalfishingwatch/api-client": "^6.0.5",
+    "@globalfishingwatch/api-client": "^7.0.0",
     "@globalfishingwatch/api-types": "^8.0.3",
     "@globalfishingwatch/deck-loaders": "^0.1.3",
     "@globalfishingwatch/dataviews-client": "^16.x",

--- a/libs/deck-layers/src/utils/fetch.ts
+++ b/libs/deck-layers/src/utils/fetch.ts
@@ -4,7 +4,7 @@ export function getFetchLoadOptions(extraOptions = {}) {
   return {
     fetch: {
       headers: {
-        Authorization: `Bearer ${GFWAPI.getToken()}`,
+        Authorization: `Bearer ${GFWAPI.token}`,
       },
       ...extraOptions,
     },

--- a/libs/react-hooks/package.json
+++ b/libs/react-hooks/package.json
@@ -7,7 +7,7 @@
   "main": "./index.cjs",
   "module": "./index.js",
   "dependencies": {
-    "@globalfishingwatch/api-client": "^6.0.5",
+    "@globalfishingwatch/api-client": "^7.0.0",
     "@globalfishingwatch/api-types": "^8.0.3",
     "@globalfishingwatch/dataviews-client": "^16.0.0",
     "@mapbox/tilebelt": "1.x",


### PR DESCRIPTION
This fixes the issue when having multiple tabs open. 
To avoid the expired refreshToken when multiple GFWAPI instances are present, the instance always reads from the localStorage now.