### PR TITLE
Fishing map/timeseries perf review

### DIFF
--- a/apps/fishing-map/features/reports/reports-geo.utils.ts
+++ b/apps/fishing-map/features/reports/reports-geo.utils.ts
@@ -34,6 +34,9 @@ export function filterByPolygon({
   mode = 'cell',
 }: FilterByPolygomParams): FilteredPolygons[] {
   const [px1, py1, px2, py2] = bbox(polygon)
+  if (!polygon.bbox) {
+    polygon.bbox = [px1, py1, px2, py2]
+  }
   const filtered = layersCells.map((layerCells) => {
     return layerCells.reduce(
       (acc, cell) => {

--- a/apps/fishing-map/features/reports/tabs/activity/reports-activity-timeseries.utils.ts
+++ b/apps/fishing-map/features/reports/tabs/activity/reports-activity-timeseries.utils.ts
@@ -263,15 +263,21 @@ export const formatEvolutionData = (
       : undefined
 
     if (!Number.isFinite(intervalDiff) || intervalDiff < 0) return []
+
+    const dataByDate = new Map(data.timeseries.map((item) => [item.date, item]))
+    const comparedByDate = comparedData
+      ? new Map(comparedData.timeseries.map((item) => [item.date, item]))
+      : undefined
+
     return Array(intervalDiff)
       .fill(0)
       .map((_, i) => {
         const date = getUTCDateTime(startMillis).plus({ [timeseriesInterval]: i })
-        let dataValue = data.timeseries.find((item) => date.toISO()?.startsWith(item.date))
+        const dateISO = date.toISO()
+        let dataValue = dateISO ? dataByDate.get(dateISO) : undefined
         if (!dataValue && data.interval === 'MONTH' && timeseriesInterval === 'DAY') {
-          dataValue = data.timeseries.find((item) =>
-            date.startOf('month').toISO()?.startsWith(item.date)
-          )
+          const monthISO = date.startOf('month').toISO()
+          dataValue = monthISO ? dataByDate.get(monthISO) : undefined
         }
         if (!dataValue && removeEmptyValues) {
           return {
@@ -294,9 +300,7 @@ export const formatEvolutionData = (
         let avg
 
         if (comparedData) {
-          let comparedDataValue = comparedData?.timeseries.find((item) =>
-            date.toISO()?.startsWith(item.date)
-          )
+          let comparedDataValue = dateISO ? comparedByDate?.get(dateISO) : undefined
           if (isMonthlyComparison) {
             if (comparedDataValue) {
               lastKnownComparedValue = comparedDataValue

--- a/apps/fishing-map/features/reports/tabs/activity/reports-activity-timeseries.utils.ts
+++ b/apps/fishing-map/features/reports/tabs/activity/reports-activity-timeseries.utils.ts
@@ -30,7 +30,6 @@ import type {
   ReportGraphProps,
 } from 'features/reports/reports-timeseries.hooks'
 import type { ReportFourwingsDeckLayer } from 'features/reports/reports-timeseries.utils'
-import type { TimeSeries } from 'features/reports/reports-timeseries-shared.utils'
 import { frameTimeseriesToDateTimeseries } from 'features/reports/reports-timeseries-shared.utils'
 import type { TimeRange } from 'features/timebar/timebar.slice'
 import { getGraphDataFromFourwingsHeatmap } from 'features/timebar/timebar.utils'
@@ -78,7 +77,7 @@ export const fourwingsFeaturesToTimeseries = (
       return featureToTimeseries
     }
 
-    const valuesContainedRaw = getGraphDataFromFourwingsHeatmap(contained as FourwingsFeature[], {
+    const heatmapParams = {
       sublayers,
       interval,
       start,
@@ -88,34 +87,46 @@ export const fourwingsFeaturesToTimeseries = (
       aggregationOperation,
       minVisibleValue,
       maxVisibleValue,
-    })
+    }
+
+    const valuesContainedRaw = getGraphDataFromFourwingsHeatmap(
+      contained as FourwingsFeature[],
+      heatmapParams
+    )
 
     const valuesContained = frameTimeseriesToDateTimeseries(valuesContainedRaw as any)
 
-    const featuresContainedAndOverlapping =
-      overlapping.length > 0 ? [...(contained || []), ...(overlapping || [])] : []
-
-    let valuesContainedAndOverlappingRaw: TimeSeries['values'] = []
-    if (featuresContainedAndOverlapping.length > 0) {
-      valuesContainedAndOverlappingRaw = getGraphDataFromFourwingsHeatmap(
-        featuresContainedAndOverlapping as FourwingsFeature[],
-        {
-          sublayers,
-          interval,
-          start,
-          end,
-          compareStart,
-          compareEnd,
-          aggregationOperation,
-          minVisibleValue,
-          maxVisibleValue,
-        }
-      ) as any
+    let valuesContainedAndOverlapping: typeof valuesContained = []
+    if (overlapping.length > 0) {
+      if (aggregationOperation === 'avg') {
+        // avg is not additive (it divides by the cell count per frame), so the
+        // contained+overlapping union must be accumulated in a single pass.
+        const raw = getGraphDataFromFourwingsHeatmap(
+          [...(contained || []), ...(overlapping || [])] as FourwingsFeature[],
+          heatmapParams
+        ) as any
+        valuesContainedAndOverlapping = frameTimeseriesToDateTimeseries(raw)
+      } else {
+        // sum is additive: accumulate only the (smaller) overlapping set and add it
+        // to the already-computed contained values, skipping a second pass over contained.
+        const overlappingRaw = getGraphDataFromFourwingsHeatmap(
+          overlapping as FourwingsFeature[],
+          heatmapParams
+        ) as any
+        const overlappingValuesByDate = new Map(
+          frameTimeseriesToDateTimeseries(overlappingRaw).map((o) => [o.date, o.values])
+        )
+        valuesContainedAndOverlapping = valuesContained.map(({ date, values }) => {
+          const overlappingValues = overlappingValuesByDate.get(date)
+          return {
+            date,
+            values: overlappingValues
+              ? values.map((v, i) => v + (overlappingValues[i] || 0))
+              : values,
+          }
+        })
+      }
     }
-
-    const valuesContainedAndOverlapping = frameTimeseriesToDateTimeseries(
-      valuesContainedAndOverlappingRaw
-    )
 
     featureToTimeseries.timeseries = valuesContained.map(({ values, date }) => {
       const maxValues = valuesContainedAndOverlapping.find(


### PR DESCRIPTION
synthetic benchmarks (M5 Pro)

function | load | old | new | speedup
-- | -- | -- | -- | --
filterByPolygon https://github.com/GlobalFishingWatch/frontend/pull/4093/commits/b330775a9b6b8edce671517c50d7072a9b5b962a | 40k cells, 2k-vertex polygon, cell mode | 204.7 ms | 67.5 ms | 3.0×
fourwingsFeaturesToTimeseries https://github.com/GlobalFishingWatch/frontend/pull/4093#:~:text=avoid%20double%20pass-,32f8837,-use%20set%20to | 8k cells (6k contained + 2k overlapping), 365 frames, sum | 497.6 ms | 292.0 ms | 1.7×
formatEvolutionData https://github.com/GlobalFishingWatch/frontend/pull/4093#:~:text=avoid%20array.find-,174d60d,-github%2Dactions | 1825 daily frames | 224.3 ms | 3.3 ms | ~68×
