### PR TITLE
login review

### DIFF
--- a/apps/fishing-map/features/user/user-expired.hooks.tsx
+++ b/apps/fishing-map/features/user/user-expired.hooks.tsx
@@ -32,6 +32,9 @@ export const useUserExpiredToast = () => {
         autoClose: false,
         closeButton: true,
       })
+    } else if (toastId.current !== undefined) {
+      toast.dismiss(toastId.current)
+      toastId.current = undefined
     }
   }, [isUserExpired])
 }

--- a/apps/fishing-map/features/user/user.slice.ts
+++ b/apps/fishing-map/features/user/user.slice.ts
@@ -116,6 +116,7 @@ const userSlice = createSlice({
     builder.addCase(fetchUserThunk.fulfilled, (state, action) => {
       state.status = AsyncReducerStatus.Finished
       state.logged = true
+      state.expired = false
       state.data = action.payload
     })
     builder.addCase(fetchUserThunk.rejected, (state) => {

--- a/apps/fishing-map/features/user/user.slice.ts
+++ b/apps/fishing-map/features/user/user.slice.ts
@@ -1,7 +1,7 @@
 import type { PayloadAction } from '@reduxjs/toolkit'
 import { createAsyncThunk, createSlice } from '@reduxjs/toolkit'
 
-import { GFWAPI } from '@globalfishingwatch/api-client'
+import { getIsTimeoutError, GFWAPI } from '@globalfishingwatch/api-client'
 import type { UserData, UserGroupId } from '@globalfishingwatch/api-types'
 import { Locale } from '@globalfishingwatch/api-types'
 import type { FourwingsVisualizationMode } from '@globalfishingwatch/deck-layers'
@@ -61,6 +61,11 @@ export const fetchUserThunk = createAsyncThunk(
 
       return user
     } catch (e: any) {
+      const cause = e?.cause ?? e
+      const isTransient = getIsTimeoutError(cause) || (cause?.status as number) >= 500
+      if (isTransient) {
+        throw e
+      }
       return await GFWAPI.fetchGuestUser()
     }
   },

--- a/apps/fishing-map/middlewares.ts
+++ b/apps/fishing-map/middlewares.ts
@@ -22,8 +22,14 @@ export const logoutUserMiddleware: Middleware =
       const state = getState()
       const isGuestUser = selectIsGuestUser(state)
       const payload = action.payload as AsyncError &
-        UpdateWorkspaceThunkRejectError & { refreshError?: boolean }
-      if (!isGuestUser && payload.refreshError && !payload.isWorkspaceWrongPassword) {
+        UpdateWorkspaceThunkRejectError & {
+          refreshError?: boolean
+          error?: { refreshError?: boolean; isWorkspaceWrongPassword?: boolean }
+        }
+      const refreshError = payload?.refreshError || payload?.error?.refreshError
+      const isWrongPassword =
+        payload?.isWorkspaceWrongPassword || payload?.error?.isWorkspaceWrongPassword
+      if (!isGuestUser && refreshError && !isWrongPassword) {
         dispatch(setLoginExpired(true))
       }
     }

--- a/libs/api-client/src/api-client.spec.ts
+++ b/libs/api-client/src/api-client.spec.ts
@@ -240,6 +240,40 @@ describe('api-client', () => {
         )
       })
 
+      it('should re-read function headers on each attempt (no stale capture across retry)', async () => {
+        const client = createApiClient()
+        const storage = (globalThis as any).localStorage as any
+        storage.setItem('GFW_API_USER_TOKEN', 'token')
+        storage.setItem('GFW_API_USER_REFRESH_TOKEN', 'refresh-A')
+
+        fetchMock
+          // initial request → 401, triggers refresh
+          .mockResolvedValueOnce(
+            new Response(JSON.stringify({ message: 'Unauthorized' }), {
+              status: 401,
+              statusText: 'Unauthorized',
+            })
+          )
+          // /tokens/reload → 200, rotates refresh-A → refresh-B
+          .mockResolvedValueOnce(
+            new Response(JSON.stringify({ token: 'new-token', refreshToken: 'refresh-B' }), {
+              status: 200,
+            })
+          )
+          // retried request → 200
+          .mockResolvedValueOnce(new Response(JSON.stringify({ ok: true }), { status: 200 }))
+
+        await client.fetch('/protected', {
+          headers: () => ({
+            'x-refresh': storage.getItem('GFW_API_USER_REFRESH_TOKEN'),
+          }),
+        })
+
+        // First attempt sends the original token, the retry re-reads the rotated one.
+        expect(fetchMock.mock.calls[0][1].headers['x-refresh']).toBe('refresh-A')
+        expect(fetchMock.mock.calls[2][1].headers['x-refresh']).toBe('refresh-B')
+      })
+
       it('should pass body and method for POST', async () => {
         const client = createApiClient()
         fetchMock.mockResolvedValue(new Response(JSON.stringify({ ok: true }), { status: 200 }))
@@ -1090,6 +1124,45 @@ describe('api-client', () => {
         fetchMock.mockRejectedValue(new Error('Network error'))
 
         await expect(client.logout()).rejects.toThrow('Error on the logout proccess')
+        expect(storage.getItem('GFW_API_USER_TOKEN')).toBeNull()
+        expect(storage.getItem('GFW_API_USER_REFRESH_TOKEN')).toBeNull()
+      })
+
+      it('should not refresh or retry on a 401 (single request) and clear tokens', async () => {
+        const client = createApiClient()
+        const storage = (globalThis as any).localStorage as any
+        storage.setItem('GFW_API_USER_TOKEN', 'token')
+        storage.setItem('GFW_API_USER_REFRESH_TOKEN', 'refresh')
+
+        fetchMock.mockResolvedValue(
+          new Response(JSON.stringify({ message: 'Unauthorized' }), {
+            status: 401,
+            statusText: 'Unauthorized',
+          })
+        )
+
+        await expect(client.logout()).rejects.toThrow('Error on the logout proccess')
+        // skipAuthRefresh: no /tokens/reload call, no retry — exactly one request.
+        expect(fetchMock).toHaveBeenCalledTimes(1)
+        expect(storage.getItem('GFW_API_USER_TOKEN')).toBeNull()
+        expect(storage.getItem('GFW_API_USER_REFRESH_TOKEN')).toBeNull()
+      })
+
+      it('should send the current refresh token (re-read), not a stale one', async () => {
+        const client = createApiClient()
+        const storage = (globalThis as any).localStorage as any
+        storage.setItem('GFW_API_USER_REFRESH_TOKEN', 'refresh-A')
+
+        fetchMock.mockResolvedValue(new Response(null, { status: 200 }))
+
+        await client.logout()
+
+        expect(fetchMock).toHaveBeenCalledWith(
+          expect.stringContaining('logout'),
+          expect.objectContaining({
+            headers: expect.objectContaining({ 'refresh-token': 'refresh-A' }),
+          })
+        )
       })
 
       it('should log when debug is true', async () => {

--- a/libs/api-client/src/api-client.spec.ts
+++ b/libs/api-client/src/api-client.spec.ts
@@ -668,6 +668,162 @@ describe('api-client', () => {
       })
     })
 
+    describe('token refresh resilience', () => {
+      let fetchMock: ReturnType<typeof vi.fn>
+
+      beforeEach(() => {
+        fetchMock = vi.fn()
+        vi.stubGlobal('fetch', fetchMock)
+      })
+
+      afterEach(() => {
+        vi.useRealTimers()
+      })
+
+      it('should retry the reload on a transient 5xx failure', async () => {
+        vi.useFakeTimers()
+        const client = createApiClient()
+        const storage = (globalThis as any).localStorage as any
+        storage.setItem('GFW_API_USER_REFRESH_TOKEN', 'refresh-token')
+
+        fetchMock
+          .mockResolvedValueOnce(
+            new Response(JSON.stringify({ message: 'Server Error' }), {
+              status: 503,
+              statusText: 'Service Unavailable',
+            })
+          )
+          .mockResolvedValueOnce(
+            new Response(JSON.stringify({ token: 'new-token', refreshToken: 'new-refresh' }), {
+              status: 200,
+            })
+          )
+
+        const promise = client.refreshAPIToken()
+        await vi.runAllTimersAsync()
+        const result = await promise
+
+        expect(result).toEqual({ token: 'new-token', refreshToken: 'new-refresh' })
+        expect(fetchMock).toHaveBeenCalledTimes(2)
+      })
+
+      it('should retry the reload on a transient network failure', async () => {
+        vi.useFakeTimers()
+        const client = createApiClient()
+        const storage = (globalThis as any).localStorage as any
+        storage.setItem('GFW_API_USER_REFRESH_TOKEN', 'refresh-token')
+
+        fetchMock.mockRejectedValueOnce(new TypeError('Failed to fetch')).mockResolvedValueOnce(
+          new Response(JSON.stringify({ token: 'new-token', refreshToken: 'new-refresh' }), {
+            status: 200,
+          })
+        )
+
+        const promise = client.refreshAPIToken()
+        await vi.runAllTimersAsync()
+        const result = await promise
+
+        expect(result).toEqual({ token: 'new-token', refreshToken: 'new-refresh' })
+        expect(fetchMock).toHaveBeenCalledTimes(2)
+      })
+
+      it('should give up after maxReloadRetries transient failures', async () => {
+        vi.useFakeTimers()
+        const client = createApiClient()
+        const storage = (globalThis as any).localStorage as any
+        storage.setItem('GFW_API_USER_REFRESH_TOKEN', 'refresh-token')
+
+        fetchMock.mockResolvedValue(
+          new Response(JSON.stringify({ message: 'Server Error' }), {
+            status: 503,
+            statusText: 'Service Unavailable',
+          })
+        )
+
+        const promise = client.refreshAPIToken()
+        const expectation = expect(promise).rejects.toMatchObject({ status: 503 })
+        await vi.runAllTimersAsync()
+        await expectation
+
+        // 1 initial attempt + maxReloadRetries (2) = 3
+        expect(fetchMock).toHaveBeenCalledTimes(client.maxReloadRetries + 1)
+      })
+
+      it('should NOT retry the reload on a 401 (invalid refresh token)', async () => {
+        const client = createApiClient()
+        const storage = (globalThis as any).localStorage as any
+        storage.setItem('GFW_API_USER_REFRESH_TOKEN', 'invalid-refresh')
+
+        fetchMock.mockResolvedValue(
+          new Response(JSON.stringify({ message: 'Invalid' }), {
+            status: 401,
+            statusText: 'Unauthorized',
+          })
+        )
+
+        await expect(client.refreshAPIToken()).rejects.toMatchObject({ status: 401 })
+        expect(fetchMock).toHaveBeenCalledTimes(1)
+      })
+    })
+
+    describe('multi-tab refresh lock', () => {
+      let fetchMock: ReturnType<typeof vi.fn>
+
+      beforeEach(() => {
+        fetchMock = vi.fn()
+        vi.stubGlobal('fetch', fetchMock)
+      })
+
+      afterEach(() => {
+        vi.unstubAllGlobals()
+      })
+
+      it('should run the refresh inside the Web Lock when available', async () => {
+        const requestSpy = vi.fn((_name: string, cb: () => Promise<unknown>) => cb())
+        vi.stubGlobal('navigator', { locks: { request: requestSpy } })
+
+        const client = createApiClient()
+        const storage = (globalThis as any).localStorage as any
+        storage.setItem('GFW_API_USER_REFRESH_TOKEN', 'refresh-token')
+
+        fetchMock.mockResolvedValueOnce(
+          new Response(JSON.stringify({ token: 'new-token', refreshToken: 'new-refresh' }), {
+            status: 200,
+          })
+        )
+
+        await client.refreshAPIToken()
+
+        expect(requestSpy).toHaveBeenCalledWith('gfw-token-refresh', expect.any(Function))
+      })
+
+      it('should skip the network call when another tab already rotated the token', async () => {
+        const storage = (globalThis as any).localStorage as any
+        storage.setItem('GFW_API_USER_TOKEN', 'old-token')
+        storage.setItem('GFW_API_USER_REFRESH_TOKEN', 'old-refresh')
+
+        // Simulate another tab finishing a refresh while we waited for the lock:
+        // the stored tokens are rotated before our callback runs.
+        vi.stubGlobal('navigator', {
+          locks: {
+            request: (_name: string, cb: () => Promise<unknown>) => {
+              storage.setItem('GFW_API_USER_TOKEN', 'rotated-token')
+              storage.setItem('GFW_API_USER_REFRESH_TOKEN', 'rotated-refresh')
+              return cb()
+            },
+          },
+        })
+
+        const client = createApiClient()
+
+        const result = await client.refreshAPIToken()
+
+        expect(result).toEqual({ token: 'rotated-token', refreshToken: 'rotated-refresh' })
+        // The consumed 'old-refresh' is never replayed against the server.
+        expect(fetchMock).not.toHaveBeenCalled()
+      })
+    })
+
     describe('fetchUser', () => {
       let fetchMock: ReturnType<typeof vi.fn>
 

--- a/libs/api-client/src/api-client.ts
+++ b/libs/api-client/src/api-client.ts
@@ -37,12 +37,18 @@ interface LoginParams {
   refreshToken?: string | null
 }
 export type ApiVersion = '' | 'v3'
-export type FetchOptions<T = unknown> = Partial<Omit<RequestInit, 'body'>> & {
+export type FetchOptions<T = unknown> = Partial<Omit<RequestInit, 'body' | 'headers'>> & {
   version?: ApiVersion
   method?: 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE'
   cache?: RequestCache
   responseType?: ResourceResponseType
   requestType?: ResourceRequestType
+  // Pass a function when a header value must be re-read on every attempt (e.g. a
+  // rotating refresh-token), so the auto-retry never replays a stale value.
+  headers?: HeadersInit | (() => HeadersInit)
+  // Skip the 401/403 → refresh → retry machinery (e.g. logout, where a 401 just
+  // means the session is already gone and refreshing would replay a stale token).
+  skipAuthRefresh?: boolean
   body?: T
   local?: boolean
 }
@@ -319,6 +325,7 @@ export class GFW_API_CLASS {
       cache,
       signal,
       local = false,
+      skipAuthRefresh = false,
     } = options
     try {
       if (this.logging && waitLogin) {
@@ -338,7 +345,7 @@ export class GFW_API_CLASS {
           console.log(`GFWAPI: Fetching URL: ${url}`)
         }
         const finalHeaders = {
-          ...headers,
+          ...(typeof headers === 'function' ? headers() : headers),
           ...(requestType === 'json' && { 'Content-Type': 'application/json' }),
           ...(local && {
             'x-gateway-url': API_GATEWAY,
@@ -396,7 +403,7 @@ export class GFW_API_CLASS {
         // 401 + refreshError = true => refresh token failed
         if (refreshRetries <= this.maxRefreshRetries) {
           const authError = isAuthError(e)
-          if (authError) {
+          if (authError && !skipAuthRefresh) {
             if (this.debug) {
               console.log(`GFWAPI: Trying to refresh the token attempt: ${refreshRetries}`)
             }
@@ -418,7 +425,7 @@ export class GFW_API_CLASS {
               throw parseAPIError(e)
             }
           }
-          if (authError || e.status >= 500) {
+          if ((authError && !skipAuthRefresh) || e.status >= 500) {
             return this._internalFetch<T, Body>({
               url,
               options,
@@ -584,13 +591,13 @@ export class GFW_API_CLASS {
       await this._internalFetch<void>({
         url: this.generateUrl(`/${API_VERSION}/${AUTH_PATH}/logout`),
         options: {
-          headers: {
-            'refresh-token': this.refreshToken,
-          },
+          // Re-read the refresh token per attempt and don't refresh on a 401:
+          // a logout 401 means the session is already gone, so refreshing would
+          // only replay a now-stale token against the server.
+          headers: () => ({ 'refresh-token': this.refreshToken }),
+          skipAuthRefresh: true,
         },
       })
-      this.token = ''
-      this.refreshToken = ''
       if (this.debug) {
         console.log(`GFWAPI: Logout invalid session api OK`)
       }
@@ -600,6 +607,11 @@ export class GFW_API_CLASS {
         console.warn(`GFWAPI: Logout invalid session fail`)
       }
       throw new Error('Error on the logout proccess', { cause: e })
+    } finally {
+      // Logout intent is to drop the local session — always clear, even if the
+      // server call failed.
+      this.token = ''
+      this.refreshToken = ''
     }
   }
 }

--- a/libs/api-client/src/api-client.ts
+++ b/libs/api-client/src/api-client.ts
@@ -6,7 +6,12 @@ import type {
   UserPermission,
 } from '@globalfishingwatch/api-types'
 
-import { getIsUnauthorizedError, isAuthError, parseAPIError } from './utils/errors'
+import {
+  getIsTimeoutError,
+  getIsUnauthorizedError,
+  isAuthError,
+  parseAPIError,
+} from './utils/errors'
 import { parseJSON, processStatus } from './utils/parse'
 import { isUrlAbsolute } from './utils/url'
 import {
@@ -61,6 +66,7 @@ export class GFW_API_CLASS {
     refreshToken: string
   }
   maxRefreshRetries = 1
+  maxReloadRetries = 2
   logging: Promise<UserData> | null
   private refreshingToken: Promise<UserTokens> | null = null
   status: RequestStatus = 'idle'
@@ -191,25 +197,49 @@ export class GFW_API_CLASS {
       .then(parseJSON)
   }
 
-  private async reloadAPIToken(refreshToken: string) {
-    const refreshResponse = await this.getTokenWithRefreshToken(refreshToken)
-    const { token, refreshToken: newRefreshToken } = refreshResponse
-    this.token = token
-    this.refreshToken = newRefreshToken
-    return refreshResponse
-  }
-
-  private async reloadAPITokenWithLatestRefreshToken(refreshToken: string) {
+  private async reloadAPIToken(refreshToken: string, reloadRetries = 0): Promise<UserTokens> {
     try {
-      return await this.reloadAPIToken(refreshToken)
+      const refreshResponse = await this.getTokenWithRefreshToken(refreshToken)
+      const { token, refreshToken: newRefreshToken } = refreshResponse
+      this.token = token
+      this.refreshToken = newRefreshToken
+      return refreshResponse
     } catch (e: any) {
-      const latestRefreshToken = this.refreshToken
-      if (latestRefreshToken && latestRefreshToken !== refreshToken) {
-        return await this.reloadAPIToken(latestRefreshToken)
+      const isTransient = !isAuthError(e) && (getIsTimeoutError(e) || !e?.status || e.status >= 500)
+      if (isTransient && reloadRetries < this.maxReloadRetries) {
+        if (this.debug) {
+          console.log(`GFWAPI: Transient reload failure, retry attempt ${reloadRetries + 1}`)
+        }
+        await new Promise((resolve) => setTimeout(resolve, 500 * (reloadRetries + 1)))
+        return this.reloadAPIToken(refreshToken, reloadRetries + 1)
       }
-      e.status = 401
       throw e
     }
+  }
+
+  private async withTokenRefreshLock<T>(run: () => Promise<T>): Promise<T> {
+    if (isClientSide && typeof navigator !== 'undefined' && navigator.locks?.request) {
+      return navigator.locks.request('gfw-token-refresh', run) as Promise<T>
+    }
+    return run()
+  }
+
+  private async reloadAPITokenWithLatestRefreshToken(refreshToken: string): Promise<UserTokens> {
+    return this.withTokenRefreshLock(async () => {
+      const latestRefreshToken = this.refreshToken
+      if (latestRefreshToken && latestRefreshToken !== refreshToken) {
+        return { token: this.token, refreshToken: latestRefreshToken }
+      }
+      try {
+        return await this.reloadAPIToken(refreshToken)
+      } catch (e: any) {
+        const newerRefreshToken = this.refreshToken
+        if (newerRefreshToken && newerRefreshToken !== refreshToken) {
+          return await this.reloadAPIToken(newerRefreshToken)
+        }
+        throw e
+      }
+    })
   }
 
   async refreshAPIToken() {
@@ -379,7 +409,8 @@ export class GFW_API_CLASS {
               if (this.debug) {
                 console.warn(`GFWAPI: Error fetching ${url}`, err)
               }
-              if (isClientSide) {
+              const refreshRejected = getIsUnauthorizedError(err) && !getIsTimeoutError(err)
+              if (isClientSide && refreshRejected) {
                 this.token = ''
                 this.refreshToken = ''
               }

--- a/libs/api-client/src/api-client.ts
+++ b/libs/api-client/src/api-client.ts
@@ -421,7 +421,9 @@ export class GFW_API_CLASS {
                 this.token = ''
                 this.refreshToken = ''
               }
-              e.refreshError = true
+              if (refreshRejected) {
+                e.refreshError = true
+              }
               throw parseAPIError(e)
             }
           }

--- a/libs/api-client/src/utils/errors.ts
+++ b/libs/api-client/src/utils/errors.ts
@@ -47,13 +47,21 @@ export const parseAPIErrorMetadata = (error: ResponseError) => {
   return {} as V2MetadataError
 }
 
-export type ParsedAPIError = { status: number; message: string; metadata?: V2MetadataError }
-export const parseAPIError = (error: ResponseError): ParsedAPIError => {
+export type ParsedAPIError = {
+  status: number
+  message: string
+  metadata?: V2MetadataError
+  refreshError?: boolean
+}
+export const parseAPIError = (
+  error: ResponseError & { refreshError?: boolean }
+): ParsedAPIError => {
   const metadata = parseAPIErrorMetadata(error)
   return {
     status: parseAPIErrorStatus(error),
     message: parseAPIErrorMessage(error),
     ...(metadata && { metadata }),
+    ...(error?.refreshError && { refreshError: true }),
   }
 }
 


### PR DESCRIPTION

potential logout vector | fix 
-- | -- 
Transient refresh wipes tokens | wipe only on real 401, not network/timeout/5xx
app-start blip → guest | reload retries transient (2x backoff); guest-fallback only on non-transient
multi-tab rotation race | Web Lock + rotated-token skip
