### PR TITLE
Fix intermittent session loss caused by SSR refresh-token races

### DIFF
--- a/apps/fishing-map/router.tsx
+++ b/apps/fishing-map/router.tsx
@@ -2,8 +2,8 @@ import * as Sentry from '@sentry/tanstackstart-react'
 import { createRouter, Navigate } from '@tanstack/react-router'
 
 import { parseWorkspace, stringifyWorkspace } from '@globalfishingwatch/dataviews-client'
+import { Spinner } from '@globalfishingwatch/ui-components'
 
-// import { Spinner } from '@globalfishingwatch/ui-components'
 import { PATH_BASENAME } from 'data/config'
 import { RouterErrorBoundary } from 'features/app/ErrorBoundaryRouter'
 import { reportRouteError } from 'features/app/sentry'
@@ -42,7 +42,9 @@ export function getCreateRouterOptions() {
     defaultPreload: 'intent' as const,
     trailingSlash: 'never' as const,
     scrollRestoration: true,
-    defaultPendingComponent: () => null,
+    defaultPendingComponent: () => <Spinner />,
+    defaultPendingMs: 0,
+    defaultPendingMinMs: 300,
     defaultErrorComponent: ({ error }: any) => <RouterErrorBoundary error={error} />,
     defaultOnCatch: (error: Error) => {
       reportRouteError(error, 'router-render')

--- a/apps/fishing-map/routes/_app.tsx
+++ b/apps/fishing-map/routes/_app.tsx
@@ -2,7 +2,7 @@ import { Suspense, useEffect, useMemo } from 'react'
 import { Provider } from 'react-redux'
 import { createFileRoute, getRouteApi, useRouter } from '@tanstack/react-router'
 
-import { getGuestUser } from '@globalfishingwatch/api-client'
+import { getGuestUser, GFWAPI } from '@globalfishingwatch/api-client'
 
 import { HINTS } from 'data/config'
 import App from 'features/app/App'
@@ -35,10 +35,31 @@ function AppLayout() {
     const store = getAppRouterStore(router.options.context) ?? makeStore()
     syncInitialLocation(router, store)
     store.dispatch(setUserLanguage(getActiveI18nLanguage() as Locale))
-    store.dispatch(setLoggedUser(user || getGuestUser()))
+    // user === null means SSR left the session pending (expired access token with a live
+    // refresh cookie) — resolved client-side in the effect below.
+    if (user) {
+      store.dispatch(setLoggedUser(user))
+    }
     return store
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [router])
+
+  useEffect(() => {
+    if (user) return
+    let cancelled = false
+    // fetchUser triggers the refresh on 401 through api-client's refreshStrategy, which is
+    // guarded by navigator.locks + in-flight dedup — the single place a refresh may happen.
+    GFWAPI.fetchUser()
+      .then((resolvedUser) => {
+        if (!cancelled) store.dispatch(setLoggedUser(resolvedUser))
+      })
+      .catch(() => {
+        if (!cancelled) store.dispatch(setLoggedUser(getGuestUser()))
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [user, store])
 
   useEffect(() => {
     const unsubscribe = setupRouterSync(router, store)

--- a/apps/fishing-map/server-functions/auth.functions.ts
+++ b/apps/fishing-map/server-functions/auth.functions.ts
@@ -1,6 +1,6 @@
 import { createServerFn } from '@tanstack/react-start'
 
-import { getIsUnauthorizedError, GFWAPI } from '@globalfishingwatch/api-client'
+import { getIsUnauthorizedError, GFWAPI, isTransientError } from '@globalfishingwatch/api-client'
 import type { UserData } from '@globalfishingwatch/api-types'
 
 import { USER_REFRESH_TOKEN_COOKIE_KEY, USER_TOKEN_COOKIE_KEY } from 'features/app/app.config'
@@ -49,6 +49,41 @@ export const loginServerFn = createServerFn({ method: 'POST' })
     }
   })
 
+const MAX_TRANSIENT_RETRIES = 2
+
+// A gateway hiccup (5xx/network) must not surface as an auth failure — downstream that
+// gets classified as a dead session and logs the user out.
+export async function withTransientRetry<T>(run: () => Promise<T>, retries = 0): Promise<T> {
+  try {
+    return await run()
+  } catch (e) {
+    if (
+      isTransientError(e as { status?: number; message?: string }) &&
+      retries < MAX_TRANSIENT_RETRIES
+    ) {
+      await new Promise((resolve) => setTimeout(resolve, 500 * (retries + 1)))
+      return withTransientRetry(run, retries + 1)
+    }
+    throw e
+  }
+}
+
+const REFRESH_GRACE_PERIOD_MS = 30_000
+const sharedRefreshes = new Map<string, { promise: Promise<Tokens>; expires: number }>()
+
+function reloadTokensShared(refreshToken: string): Promise<Tokens> {
+  const now = Date.now()
+  for (const [key, entry] of sharedRefreshes) {
+    if (entry.expires <= now) sharedRefreshes.delete(key)
+  }
+  const shared = sharedRefreshes.get(refreshToken)
+  if (shared) return shared.promise
+  const promise = withTransientRetry(() => GFWAPI.reloadTokens(refreshToken, SSR_HEADERS))
+  sharedRefreshes.set(refreshToken, { promise, expires: now + REFRESH_GRACE_PERIOD_MS })
+  promise.catch(() => sharedRefreshes.delete(refreshToken))
+  return promise
+}
+
 // Reloads tokens from the given refresh token and persists them. Throws a 401 when there
 // is no refresh token. Shared between the refresh RPC and SSR user resolution
 export async function refreshAuthTokens(
@@ -60,7 +95,7 @@ export async function refreshAuthTokens(
     error.status = 401
     throw error
   }
-  const tokens = await GFWAPI.reloadTokens(refreshToken, SSR_HEADERS)
+  const tokens = await reloadTokensShared(refreshToken)
   setAuthCookies(setCookie, tokens)
   return tokens
 }

--- a/apps/fishing-map/server-functions/user.functions.spec.ts
+++ b/apps/fishing-map/server-functions/user.functions.spec.ts
@@ -1,0 +1,76 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { GFWAPI } from '@globalfishingwatch/api-client'
+import type { UserData } from '@globalfishingwatch/api-types'
+
+import { USER_REFRESH_TOKEN_COOKIE_KEY, USER_TOKEN_COOKIE_KEY } from 'features/app/app.config'
+
+// Initializes i18next — the shared vitest.setup.ts calls i18n.changeLanguage in beforeAll
+// and expects app imports to have set it up.
+import 'features/i18n/i18n'
+
+import { resolveUserStateFromCookies } from './user.functions'
+
+// The gateway revokes ALL of a user's tokens when a rotated refresh token is presented
+// again (no grace window), so SSR must NEVER refresh tokens: parallel document requests
+// carrying the same refresh cookie would log the user out everywhere. These tests pin
+// that contract — an expired/missing access token with a live refresh cookie yields a
+// pending session (user: null) for the client to resolve, with no server-side reload.
+
+const USER = { id: 49, type: 'user', permissions: [], groups: [] } as unknown as UserData
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('resolveUserStateFromCookies', () => {
+  it('resolves the user with a valid access token without reloading tokens', async () => {
+    const fetchUser = vi.spyOn(GFWAPI, 'fetchUser').mockResolvedValue(USER)
+    const reloadTokens = vi.spyOn(GFWAPI, 'reloadTokens')
+
+    const { user } = await resolveUserStateFromCookies(
+      `${USER_TOKEN_COOKIE_KEY}=valid-token; ${USER_REFRESH_TOKEN_COOKIE_KEY}=refresh-token`
+    )
+
+    expect(user).toEqual(USER)
+    expect(fetchUser).toHaveBeenCalledWith(expect.objectContaining({ token: 'valid-token' }))
+    expect(reloadTokens).not.toHaveBeenCalled()
+  })
+
+  it('returns a pending session (user: null) when the access token is rejected but a refresh cookie exists — never refreshing server-side', async () => {
+    vi.spyOn(GFWAPI, 'fetchUser').mockRejectedValue(
+      Object.assign(new Error('401'), { status: 401 })
+    )
+    const reloadTokens = vi.spyOn(GFWAPI, 'reloadTokens')
+
+    const { user } = await resolveUserStateFromCookies(
+      `${USER_TOKEN_COOKIE_KEY}=expired-token; ${USER_REFRESH_TOKEN_COOKIE_KEY}=refresh-token`
+    )
+
+    expect(user).toBeNull()
+    // The critical assertion: no token rotation during SSR
+    expect(reloadTokens).not.toHaveBeenCalled()
+  })
+
+  it('returns a pending session when there is no access token but a refresh cookie exists', async () => {
+    const fetchUser = vi.spyOn(GFWAPI, 'fetchUser')
+    const reloadTokens = vi.spyOn(GFWAPI, 'reloadTokens')
+
+    const { user } = await resolveUserStateFromCookies(
+      `${USER_REFRESH_TOKEN_COOKIE_KEY}=refresh-token`
+    )
+
+    expect(user).toBeNull()
+    expect(fetchUser).not.toHaveBeenCalled()
+    expect(reloadTokens).not.toHaveBeenCalled()
+  })
+
+  it('falls back to the guest user when no auth cookies are present', async () => {
+    const reloadTokens = vi.spyOn(GFWAPI, 'reloadTokens')
+
+    const { user } = await resolveUserStateFromCookies('')
+
+    expect(user?.type).toBe('guest')
+    expect(reloadTokens).not.toHaveBeenCalled()
+  })
+})

--- a/apps/fishing-map/server-functions/user.functions.ts
+++ b/apps/fishing-map/server-functions/user.functions.ts
@@ -2,11 +2,18 @@ import { getGuestUser, GFWAPI, readCookieString } from '@globalfishingwatch/api-
 import type { UserData } from '@globalfishingwatch/api-types'
 
 import { USER_REFRESH_TOKEN_COOKIE_KEY, USER_TOKEN_COOKIE_KEY } from 'features/app/app.config'
-import { clearAuthCookies, refreshAuthTokens, SSR_HEADERS } from 'server-functions/auth.functions'
+import { SSR_HEADERS } from 'server-functions/auth.functions'
 
 export async function resolveUserStateFromRequest(): Promise<{ user: UserData | null }> {
-  const { getRequest, setCookie } = await import('@tanstack/react-start/server')
-  const cookieHeader = getRequest().headers.get('cookie') ?? ''
+  const { getRequest } = await import('@tanstack/react-start/server')
+  return resolveUserStateFromCookies(getRequest().headers.get('cookie') ?? '')
+}
+
+// Pure resolution from the cookie header. Deliberately has no way to set or clear cookies
+// and never calls the token-reload endpoint — see the comment below.
+export async function resolveUserStateFromCookies(
+  cookieHeader: string
+): Promise<{ user: UserData | null }> {
   const token = readCookieString(cookieHeader, USER_TOKEN_COOKIE_KEY)
 
   // Try the access token if present.
@@ -18,22 +25,20 @@ export async function resolveUserStateFromRequest(): Promise<{ user: UserData | 
       })
       return { user }
     } catch (e) {
-      // Expired/invalid — fall through to a refresh attempt.
+      // Expired/invalid — fall through to the pending state below.
     }
   }
 
-  // Refresh via the refresh cookie. Falls back to the guest user when there is no refresh
-  // cookie (throws 401) or the refresh is dead.
-  try {
-    const refreshToken = readCookieString(cookieHeader, USER_REFRESH_TOKEN_COOKIE_KEY)
-    const tokens = await refreshAuthTokens(refreshToken ?? undefined, setCookie)
-    const user = await GFWAPI.fetchUser({
-      token: tokens.token,
-      headers: SSR_HEADERS,
-    })
-    return { user }
-  } catch (e) {
-    clearAuthCookies(setCookie)
-    return { user: getGuestUser() }
+  // NEVER refresh during SSR: concurrent document requests (tab restore, multi-tab open)
+  // all carry the same refresh cookie, and the gateway revokes ALL the user's tokens when
+  // a rotated refresh token is presented again — no grace window. With a refresh cookie
+  // present, return a pending session (user: null) and let the hydrated client perform the
+  // single refresh, which api-client serializes via navigator.locks + in-flight dedup.
+  // Don't clear cookies either: an expired access token with a live refresh token is the
+  // normal expiry case, not a broken session.
+  const refreshToken = readCookieString(cookieHeader, USER_REFRESH_TOKEN_COOKIE_KEY)
+  if (refreshToken) {
+    return { user: null }
   }
+  return { user: getGuestUser() }
 }

--- a/apps/fishing-map/server-functions/user.functions.ts
+++ b/apps/fishing-map/server-functions/user.functions.ts
@@ -2,7 +2,7 @@ import { getGuestUser, GFWAPI, readCookieString } from '@globalfishingwatch/api-
 import type { UserData } from '@globalfishingwatch/api-types'
 
 import { USER_REFRESH_TOKEN_COOKIE_KEY, USER_TOKEN_COOKIE_KEY } from 'features/app/app.config'
-import { SSR_HEADERS } from 'server-functions/auth.functions'
+import { SSR_HEADERS, withTransientRetry } from 'server-functions/auth.functions'
 
 export async function resolveUserStateFromRequest(): Promise<{ user: UserData | null }> {
   const { getRequest } = await import('@tanstack/react-start/server')
@@ -16,13 +16,11 @@ export async function resolveUserStateFromCookies(
 ): Promise<{ user: UserData | null }> {
   const token = readCookieString(cookieHeader, USER_TOKEN_COOKIE_KEY)
 
-  // Try the access token if present.
+  // Try the access token if present. Retried on 5xx/network hiccups so a gateway blip
+  // doesn't degrade a valid session to pending.
   if (token) {
     try {
-      const user = await GFWAPI.fetchUser({
-        token,
-        headers: SSR_HEADERS,
-      })
+      const user = await withTransientRetry(() => GFWAPI.fetchUser({ token, headers: SSR_HEADERS }))
       return { user }
     } catch (e) {
       // Expired/invalid — fall through to the pending state below.

--- a/libs/api-client/src/api-client.spec.ts
+++ b/libs/api-client/src/api-client.spec.ts
@@ -1279,7 +1279,9 @@ describe('api-client', () => {
         await client.logout()
 
         expect(logSpy).toHaveBeenCalledWith('GFWAPI: logout — gateway OK')
-        expect(logSpy).toHaveBeenCalledWith('GFWAPI: invalidateClientSession — clearing local session')
+        expect(logSpy).toHaveBeenCalledWith(
+          'GFWAPI: invalidateClientSession — clearing local session'
+        )
         logSpy.mockRestore()
         warnSpy.mockRestore()
       })
@@ -1480,6 +1482,66 @@ describe('api-client', () => {
         await expect(client.fetch('/datasets/1')).rejects.toMatchObject({ status: 401 })
         expect(sessionInvalidateStrategy).toHaveBeenCalledTimes(1)
         expect(storage.getItem('GFW_API_USER_TOKEN')).toBeNull()
+      })
+
+      // Race: an SSR document request (outside this tab's Web Lock) consumes the
+      // single-use refresh token while a strategy refresh replays it. The rejected
+      // refresh must reuse the concurrently rotated session, not invalidate it.
+      it('should reuse a concurrently rotated session when the strategy refresh is rejected', async () => {
+        const client = createApiClient()
+        const storage = (globalThis as any).localStorage as any
+        storage.setItem('GFW_API_USER_TOKEN', 'old-token')
+        const sessionInvalidateStrategy = vi.fn()
+        const refreshStrategy = vi.fn(async () => {
+          storage.setItem('GFW_API_USER_TOKEN', 'rotated-token')
+          const error: any = new Error('Invalid refresh token')
+          error.status = 401
+          throw error
+        })
+        client.configure({ refreshStrategy, sessionInvalidateStrategy })
+
+        fetchMock.mockImplementation((_url, options) => {
+          if (options.headers.Authorization === 'Bearer rotated-token') {
+            return Promise.resolve(new Response(JSON.stringify({ ok: true }), { status: 200 }))
+          }
+          return Promise.resolve(
+            new Response(JSON.stringify({ message: 'Unauthorized' }), {
+              status: 401,
+              statusText: 'Unauthorized',
+            })
+          )
+        })
+
+        const result = await client.fetch('/protected')
+
+        expect(result).toEqual({ ok: true })
+        expect(refreshStrategy).toHaveBeenCalledTimes(1)
+        expect(sessionInvalidateStrategy).not.toHaveBeenCalled()
+        expect(storage.getItem('GFW_API_USER_TOKEN')).toBe('rotated-token')
+      })
+
+      it('should still reject the strategy refresh when the cookies did not rotate', async () => {
+        const client = createApiClient()
+        const storage = (globalThis as any).localStorage as any
+        storage.setItem('GFW_API_USER_TOKEN', 'old-token')
+        const sessionInvalidateStrategy = vi.fn()
+        const refreshStrategy = vi.fn(async () => {
+          const error: any = new Error('Invalid refresh token')
+          error.status = 401
+          throw error
+        })
+        client.configure({ refreshStrategy, sessionInvalidateStrategy })
+
+        fetchMock.mockResolvedValue(
+          new Response(JSON.stringify({ message: 'Unauthorized' }), {
+            status: 401,
+            statusText: 'Unauthorized',
+          })
+        )
+
+        await expect(client.fetch('/protected')).rejects.toMatchObject({ status: 401 })
+        expect(refreshStrategy).toHaveBeenCalledTimes(1)
+        expect(sessionInvalidateStrategy).toHaveBeenCalledTimes(1)
       })
     })
 

--- a/libs/api-client/src/api-client.ts
+++ b/libs/api-client/src/api-client.ts
@@ -340,7 +340,19 @@ export class GFW_API_CLASS {
       this.debugAuthState('refreshAPIToken — via refreshStrategy')
       const strategy = this.refreshStrategy
       this.status = 'refreshingToken'
-      this.refreshingToken = this.withTokenRefreshLock(() => strategy()).finally(() => {
+      this.refreshingToken = this.withTokenRefreshLock(async () => {
+        const tokenBefore = this.token
+        try {
+          return await strategy()
+        } catch (e: any) {
+          const tokenAfter = this.token
+          if (isSessionError(e) && tokenAfter && tokenAfter !== tokenBefore) {
+            this.debugLog('GFWAPI: refreshAPIToken — cookies rotated concurrently, reusing session')
+            return { token: tokenAfter, refreshToken: this.refreshToken }
+          }
+          throw e
+        }
+      }).finally(() => {
         this.status = 'idle'
         this.refreshingToken = null
       })

--- a/libs/api-client/src/utils/errors.ts
+++ b/libs/api-client/src/utils/errors.ts
@@ -85,11 +85,14 @@ const NO_SESSION_MESSAGES = [
 ] as const
 
 // Auth/session rejection — incl. server-fn errors that lose `status` after deserialization.
-export function isSessionError(error?: { status?: number; message?: string } | null) {
+export function isSessionError(
+  error?: { status?: number; message?: string; cause?: unknown } | null
+): boolean {
   if (!error) return false
-  if (isAuthError(error) || getIsUnauthorizedError(error)) return true
+  if (isAuthError(error) || Boolean(getIsUnauthorizedError(error))) return true
   const message = error.message ?? ''
-  return NO_SESSION_MESSAGES.some((m) => message.includes(m))
+  if (NO_SESSION_MESSAGES.some((m) => message.includes(m))) return true
+  return isSessionError(error.cause as { status?: number; message?: string } | null)
 }
 
 export const isTransientError = (error?: ResponseError | { status?: number; message?: string }) =>


### PR DESCRIPTION
https://fishing-map-fishing-map-login-race-fix-2-706952489382.us-central1.run.app/

The gateway rotates the refresh token on every reload, and presenting an
already-used token once revokes **all** the user's tokens (no grace window).
SSR refreshed tokens on every document request with an expired access token,
so common situations produced a stale-token replay and logged the user out
everywhere:

- Several tabs opened/restored at once → parallel SSR refreshes with the same
  refresh cookie (no cross-instance lock possible)
- Cancelled navigation/discarded preload → rotated cookie never stored,
  browser replays the old token on its next request

Reproduced deterministically against dev with a Playwright/raw-fetch probe
(single replay of a consumed token → whole family revoked).

### Fixes
- SSR never refreshes or clears auth cookies. With a valid access token it
  resolves the user; with only a refresh cookie it returns a pending session
  (`user: null`); with no cookies, guest.
- The hydrated client resolves the pending session with one `GFWAPI.fetchUser()`,
  whose 401 triggers the refresh through the existing `refreshTokenServerFn`
  path — serialized by `navigator.locks` + in-flight dedup, now the single
  place a refresh can happen.
- Router shows a `<Spinner />` pending component so the pending-session state
  doesn't flash a blank page.

### Hardening (merged from `fishing-map/login-race-fix`)
- `withTransientRetry`: 5xx/network hiccups on SSR `fetchUser` and server-side
  token reloads are retried instead of being misclassified as a dead session.
- `reloadTokensShared`: 30s per-token dedup/grace on the server refresh path —
  covers a client refresh whose response is lost mid-flight and replayed on
  the same instance.
- `isSessionError` follows the `cause` chain, so wrapped errors keep their
  auth classification.
- api-client: if a refresh fails but another tab rotated the cookies
  concurrently, the rotated session is reused instead of failing.

### Tests
- Unit spec pins the SSR contract: no token reload during SSR resolution,
  pending state when only the refresh cookie is present, guest fallback
  without cookies.
- api-client specs cover the concurrent-rotation recovery path.